### PR TITLE
Wii U support (buggy)

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -176,6 +176,17 @@ else ifeq ($(platform), wii)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
    COMMONFLAGS += -DGEKKO -mrvl -mcpu=750 -meabi -mhard-float -D__POWERPC__ -D__ppc__ -DWORDS_BIGENDIAN=1
 	STATIC_LINKING = 1
+
+else ifeq ($(platform), wiiu)
+   TARGET := $(TARGET_NAME)_libretro_wiiu.a
+   CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
+   CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
+   AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
+   COMMONFLAGS += -DGEKKO -mwup -mcpu=750 -meabi -mhard-float -D__POWERPC__ -D__ppc__ -DWORDS_BIGENDIAN=1
+   COMMONFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+   COMMONFLAGS += -DHAVE_STRTOUL
+   STATIC_LINKING = 1
+
 else ifeq ($(platform), wincross64)
    AR = x86_64-w64-mingw32-ar
    CC = x86_64-w64-mingw32-gcc

--- a/vice/src/arch/libretro/archdep.c
+++ b/vice/src/arch/libretro/archdep.c
@@ -185,7 +185,7 @@ const char *archdep_home_path(void)
 {
 #if defined(__ANDROID__) || defined(ANDROID)
     return "/mnt/sdcard";
-#elif defined(__WIN32__) 
+#elif defined(__WIN32__) || defined(GEKKO)
 return retro_system_data_directory;
 #else
     char *home;


### PR DESCRIPTION
Minimal "make it compile" support for Wii U. BASIC seems to work fine; though it seems when loading a game it either won't detect the drive or the framerate will drop to near-zero (presumably something about the Wii U's less-than-stellar filesystem drivers). I can't really take this any further; someone who actually knows the internals of the emulator would have to look into it. If the Wii build works okay already let me know so I can change the `|| defined(GEKKO)` I added to `|| defined(HW_RVL)` (through a complicated series of events, the unmodified code would result in a null dereference on Wii U).

Thanks again,
-Ash