### PR TITLE
Fix debug build under Linux

### DIFF
--- a/libretro/include/config.h
+++ b/libretro/include/config.h
@@ -22,6 +22,8 @@
 #endif
 
 #ifdef __linux__ //android falls under this too
+#define HAVE_HTONS 1
+#define HAVE_HTONL 1
 #define HAVE_NETDB_H 1
 #define HAVE_NETINET_IN_H 1
 #define HAVE_NETWORK 1


### PR DESCRIPTION
~~~
vice/src/socket.c:147:21: error: static declaration of ‘htonl’ follows non-static declaration
 static unsigned int htonl(unsigned int ip)
                     ^~~~~
In file included from ./vice/src/arch/libretro/../unix/socketimpl.h:66:0,
                 from ./vice/src/arch/libretro/socketimpl.h:43,
                 from vice/src/socket.c:50:
/usr/include/netinet/in.h:377:17: note: previous declaration of ‘htonl’ was here
 extern uint32_t htonl (uint32_t __hostlong)
                 ^~~~~
vice/src/socket.c:176:23: error: static declaration of ‘htons’ follows non-static declaration
 static unsigned short htons(unsigned short ip)
                       ^~~~~
In file included from ./vice/src/arch/libretro/../unix/socketimpl.h:66:0,
                 from ./vice/src/arch/libretro/socketimpl.h:43,
                 from vice/src/socket.c:50:
/usr/include/netinet/in.h:379:17: note: previous declaration of ‘htons’ was here
 extern uint16_t htons (uint16_t __hostshort)
                 ^~~~~
~~~