### PR TITLE
Fix undefined symbol strlcpy_retro__

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -22,6 +22,7 @@ CXXFLAGS += $(CPPFLAGS)
 SOURCES_CC :=
 SOURCES_C  := \
 				 $(CORE_DIR)/libretro/libretro-core.c \
+				 $(CORE_DIR)/libretro-common/compat/compat_strl.c \
 				 $(CORE_DIR)/libretro-common/file/retro_dirent.c \
 				 $(CORE_DIR)/libretro-common/encodings/encoding_utf.c \
 				 $(GUI)/retro/SDL_gfxPrimitives.c \

--- a/libretro-common/compat/compat_strl.c
+++ b/libretro-common/compat/compat_strl.c
@@ -1,0 +1,69 @@
+/* Copyright  (C) 2010-2017 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (compat_strl.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <ctype.h>
+
+#include <compat/strl.h>
+
+/* Implementation of strlcpy()/strlcat() based on OpenBSD. */
+
+#ifndef __MACH__
+
+size_t strlcpy(char *dest, const char *source, size_t size)
+{
+   size_t src_size = 0;
+   size_t        n = size;
+
+   if (n)
+      while (--n && (*dest++ = *source++)) src_size++;
+
+   if (!n)
+   {
+      if (size) *dest = '\0';
+      while (*source++) src_size++;
+   }
+
+   return src_size;
+}
+
+size_t strlcat(char *dest, const char *source, size_t size)
+{
+   size_t len = strlen(dest);
+
+   dest += len;
+
+   if (len > size)
+      size = 0;
+   else
+      size -= len;
+
+   return len + strlcpy(dest, source, size);
+}
+#endif
+
+char *strldup(const char *s, size_t n)
+{
+   char *dst = (char*)malloc(sizeof(char) * (n + 1));
+   strlcpy(dst, s, n);
+   return dst;
+}


### PR DESCRIPTION
On Linux:
$ ldd -r vice_x64_libretro.so
undefined symbol: strlcpy_retro__ (./vice_x64_libretro.so)

Adding `compat_strl.c` from libretro-common fixes this.