### PR TITLE
Remove confusing retrojoy option, properly use controls options

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -72,11 +72,11 @@ int lastH=768;
 
 #include "vkbd.i"
 
-unsigned vice_devices[ 2 ];
+unsigned vice_devices[ 5 ];
 
-extern int RETROJOY,RETROTDE,RETROSTATUS,RETRODRVTYPE,RETROSIDMODL,RETROC64MODL,RETROUSERPORTJOY,RETROEXTPAL;
+extern int RETROTDE,RETROSTATUS,RETRODRVTYPE,RETROSIDMODL,RETROC64MODL,RETROUSERPORTJOY,RETROEXTPAL;
 extern char RETROEXTPALNAME[512];
-extern int retrojoy_init,retro_ui_finalized;
+extern int retro_ui_finalized;
 extern unsigned int cur_port;
 extern void set_drive_type(int drive,int val);
 extern void set_truedrive_emulation(int val);
@@ -370,17 +370,37 @@ int keyId(const char *val)
 void retro_set_environment(retro_environment_t cb)
 {
    static const struct retro_controller_description p1_controllers[] = {
-      { "Vice Joystick", RETRO_DEVICE_VICE_JOYSTICK },
-      { "Vice Keyboard", RETRO_DEVICE_VICE_KEYBOARD },
+      { "Vice Joystick", RETRO_DEVICE_JOYPAD },
+      { "Vice Keyboard", RETRO_DEVICE_KEYBOARD },
+      { "Disconnected", RETRO_DEVICE_NONE },
    };
    static const struct retro_controller_description p2_controllers[] = {
-      { "Vice Joystick", RETRO_DEVICE_VICE_JOYSTICK },
-      { "Vice Keyboard", RETRO_DEVICE_VICE_KEYBOARD },
+      { "Vice Joystick", RETRO_DEVICE_JOYPAD },
+      { "Vice Keyboard", RETRO_DEVICE_KEYBOARD },
+      { "Disconnected", RETRO_DEVICE_NONE },
+   };
+   static const struct retro_controller_description p3_controllers[] = {
+      { "Vice Joystick", RETRO_DEVICE_JOYPAD },
+      { "Vice Keyboard", RETRO_DEVICE_KEYBOARD },
+      { "Disconnected", RETRO_DEVICE_NONE },
+   };
+   static const struct retro_controller_description p4_controllers[] = {
+      { "Vice Joystick", RETRO_DEVICE_JOYPAD },
+      { "Vice Keyboard", RETRO_DEVICE_KEYBOARD },
+      { "Disconnected", RETRO_DEVICE_NONE },
+   };
+   static const struct retro_controller_description p5_controllers[] = {
+      { "Vice Joystick", RETRO_DEVICE_JOYPAD },
+      { "Vice Keyboard", RETRO_DEVICE_KEYBOARD },
+      { "Disconnected", RETRO_DEVICE_NONE },
    };
 
    static const struct retro_controller_info ports[] = {
-      { p1_controllers, 2  }, // port 1
-      { p2_controllers, 2  }, // port 2
+      { p1_controllers, 3 }, // port 1
+      { p2_controllers, 3 }, // port 2
+      { p3_controllers, 3 }, // port 3
+      { p4_controllers, 3 }, // port 4
+      { p5_controllers, 3 }, // port 5
       { NULL, 0 }
    };
 
@@ -435,15 +455,6 @@ void retro_set_environment(retro_environment_t cb)
          "vice_JoyPort",
          "Controller0 port; port_2|port_1",
       },
-      {
-         "vice_RetroJoy",
-         "Retro joy0; enabled|disabled",
-      },
-      {
-         "vice_Controller",
-         "Controller0 type; keyboard|joystick",
-      },
-
       { "vice_mapper_y", buf[0] },
       { "vice_mapper_x", buf[1] },
       { "vice_mapper_b", buf[2] },
@@ -730,34 +741,6 @@ static void update_variables(void)
    {
       if (strcmp(var.value, "port_2") == 0)cur_port=2;
       else if (strcmp(var.value, "port_1") == 0)cur_port=1;
-   }
-
-   var.key = "vice_RetroJoy";
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if(retrojoy_init){
-         if (strcmp(var.value, "enabled") == 0)
-            resources_set_int( "RetroJoy", 1);
-         if (strcmp(var.value, "disabled") == 0)
-            resources_set_int( "RetroJoy", 0);
-      }
-      else {
-         if (strcmp(var.value, "enabled") == 0)RETROJOY=1;
-         if (strcmp(var.value, "disabled") == 0)RETROJOY=0;
-      }
-   }
-
-   var.key = "vice_Controller";
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (strcmp(var.value, "keyboard") == 0)
-         vice_devices[ 0 ] = 259;
-      if (strcmp(var.value, "joystick") == 0)
-         vice_devices[ 0 ] = 513;
    }
 
    var.key = "vice_mapper_y";
@@ -1129,10 +1112,9 @@ unsigned retro_api_version(void)
 
 void retro_set_controller_port_device( unsigned port, unsigned device )
 {
-   if ( port < 2 )
+   if ( port < 5 )
    {
-      vice_devices[ port ] = device;
-
+      vice_devices[port] = device;
       log_cb(RETRO_LOG_INFO, "[retro_set_controller_port_device] (%d)=%d \n",port,device);
    }
 }

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -11,12 +11,6 @@
 
 #define MATRIX(a,b) (((a) << 3) | (b))
 
-// DEVICE VICE
-#define RETRO_DEVICE_VICE_KEYBOARD RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_KEYBOARD, 0)
-#define RETRO_DEVICE_VICE_JOYSTICK RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 1)
-
-extern unsigned vice_devices[ 2 ];
-
 //LOG
 #if  defined(__ANDROID__) || defined(ANDROID)
 #include <android/log.h>

--- a/libretro/nukleargui/c64menu.i
+++ b/libretro/nukleargui/c64menu.i
@@ -6,7 +6,6 @@
 	    //joystick options
 	    static int joy1on = nk_false;
     	    static int joy2on = nk_false;
-    	    static int retrojoyon = nk_false;
 
 	    if(cur_port==1){
 		joy1on = nk_true;
@@ -16,11 +15,6 @@
 		joy2on = nk_true;
 		joy1on = nk_false;
 	    }
-	    if(retrojoy_init)resources_get_int("RetroJoy",&tmpval);
-	    else tmpval=0;
-
-	    if(tmpval)retrojoyon=nk_true;
-	    else retrojoyon =nk_false;
 
 	    //misc options
 	    static int showled = nk_false;
@@ -132,7 +126,6 @@
             nk_layout_row_dynamic(ctx, DEFHSZ, 3);
             nk_checkbox_label(ctx, "Joy1 on", &joy1on);
             nk_checkbox_label(ctx, "Joy2 on", &joy2on);
-            nk_checkbox_label(ctx, "RetroJoy on", &retrojoyon);
 
 	    if(joy1on && cur_port!=1){
 		cur_port=1;
@@ -142,16 +135,6 @@
 	    	cur_port=2;
 		joy1on=false;
    	    }
-
-	    if(retrojoy_init)resources_get_int("RetroJoy",&tmpval);
-	    else tmpval=0;
-		
-	    if(retrojoyon){
-		if(!tmpval)
-		    resources_set_int( "RetroJoy", 1);
-	    }
-	    else if(tmpval)
-		resources_set_int("RetroJoy", 0);
 
 	    //misc options
             nk_layout_row_dynamic(ctx, DEFHSZ, 1);

--- a/libretro/nukleargui/gui.i
+++ b/libretro/nukleargui/gui.i
@@ -76,7 +76,6 @@ extern int NPAGE,SHIFTON;
 extern int vkey_pressed;
 extern int vice_statusbar;
 extern unsigned int cur_port;
-extern int retrojoy_init;
 
 extern char DISKA_NAME[512];
 extern char DISKB_NAME[512];

--- a/vice/src/arch/libretro/joy.c
+++ b/vice/src/arch/libretro/joy.c
@@ -37,24 +37,6 @@
 #include "translate.h"
 #include "types.h"
 
-
-int retrojoy_enabled;
-int retrojoy_init=0;
-
-static int set_retrojoy(int val, void *param)
-{
-    retrojoy_enabled = val ? 1 : 0;
-
-    return 0;
-}
-
-static const resource_int_t retrojoy_resources_int[] = {
-    { "RetroJoy", 1, RES_EVENT_NO, NULL,
-      &retrojoy_enabled, set_retrojoy, NULL },
-    RESOURCE_INT_LIST_END
-};
-
-
 static const resource_int_t resources_int[] = {
     { NULL }
 };
@@ -63,23 +45,14 @@ static const resource_int_t resources_int[] = {
 
 int joystick_arch_init_resources(void)
 {
-
-	if(resources_register_int(retrojoy_resources_int)<0)return -1;
-
-	retrojoy_init=1;
-
-    return resources_register_int(resources_int);
+    return 0;
 }
 
 int joy_arch_resources_init(void)
 {
-	if(resources_register_int(retrojoy_resources_int)<0)return -1;
-
-	retrojoy_init=1;
-
-    return resources_register_int(resources_int);
-   // return 0;
+    return 0;
 }
+
 int joy_arch_cmdline_options_init(void)
 {
     return 0;

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -44,7 +44,7 @@
 #include <string.h>
 #include <stdarg.h>
 
-int RETROJOY=0,RETROTDE=0,RETROSTATUS=0,RETRODRVTYPE=1542,RETROSIDMODL=0,RETROC64MODL=0,RETROUSERPORTJOY=-1,RETROEXTPAL=-1;
+int RETROTDE=0,RETROSTATUS=0,RETRODRVTYPE=1542,RETROSIDMODL=0,RETROC64MODL=0,RETROUSERPORTJOY=-1,RETROEXTPAL=-1;
 char RETROEXTPALNAME[512]="pepto-pal";
 int retro_ui_finalized = 0;
 extern int vice_statusbar;
@@ -146,9 +146,6 @@ int ui_init_finalize(void)
       resources_set_int("UserportJoy", 1);
       resources_set_int("UserportJoyType", RETROUSERPORTJOY);
    }
-
-   if(RETROJOY==1)resources_set_int( "RetroJoy", 1);
-   else if(RETROJOY==0)resources_set_int( "RetroJoy", 0);
 
    if(RETROTDE==1){
 	resources_set_int("DriveTrueEmulation", 1);

--- a/vice/src/arch/libretro/vsyncarch.c
+++ b/vice/src/arch/libretro/vsyncarch.c
@@ -41,7 +41,7 @@
 #include <psp2/kernel/threadmgr.h>
 #endif
 
-extern void retro_poll_event(int joyon);
+extern void retro_poll_event();
 extern void app_vkb_handle();
 
 extern struct video_canvas_s *RCANVAS;
@@ -90,12 +90,8 @@ void vsyncarch_sleep(signed long delay)
 
 void vsyncarch_presync(void)
 {
-	int v;
-	resources_get_int("RetroJoy",&v);
-
-        kbdbuf_flush();
-	
-	retro_poll_event(v);
+    kbdbuf_flush();
+    retro_poll_event();
 
 #if defined(__VIC20__)
         RCANVAS->videoconfig->rendermode = VIDEO_RENDER_RGB_1X1;


### PR DESCRIPTION
Closes #8
Closes #10
Closes #15
Closes #49

The quickmenu->controls options have been providing the
functionality to turn joypad input on/off or switch it to keyboard
for a long time. The retrojoy core option was a leftover when
this functionality didn't exist. Similar the Vice_Controller
core option is now uneccessary.

This commit brings this core on-par with how other cores that
support physical keyboard input work.

To enable a full physical keyboard on desktop machines, when you 
have keyboard bindings to Retropad 0 (cursor keys, A/Z etc.), 
simply change quickmenu->controls port 0 to "Vice Keyboard," 
or "Disconnected". This prevents interplay between the Retropad 
port 0 hotkeys (used for vkbd etc.) and physical keyboard input 
bindings to Retropad 0 that usually exist on desktop machines.

Since this is only an issue when Retropad port 0 inputs are bound
to keys A,Z etc. like on desktop machines, by default, all ports
are mapped to Vice Joystick. This default, together with the
default mapper_y etc. options, now allows full control over
the emulator using gamepads only, by default.