### PR TITLE
Fix aspect ratio and vkbd when borders are off

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1415,7 +1415,22 @@ void update_geometry()
    struct retro_system_av_info system_av_info;
    system_av_info.geometry.base_width = retroW;
    system_av_info.geometry.base_height = retroH;
-   system_av_info.geometry.aspect_ratio = (float)4.0/3.0;
+   /* aspect ratio without borders is retroW/retroH, otherwise 4/3 */
+   /* this code is needed because changing borders on/off causes a reset */
+   int border_disabled = 0; 
+   if(retro_ui_finalized)
+#if defined(__VIC20__)
+        resources_get_int("VICBorderMode", &border_disabled);
+#elif defined(__PLUS4__)
+        resources_get_int("TEDBorderMode", &border_disabled);
+#else 
+        resources_get_int("VICIIBorderMode", &border_disabled);
+#endif
+      else border_disabled = RETROBORDERS;
+   if (border_disabled)
+     system_av_info.geometry.aspect_ratio = (float)retroW/retroH;
+   else
+     system_av_info.geometry.aspect_ratio = (float)4.0/3.0;
    environ_cb(RETRO_ENVIRONMENT_SET_GEOMETRY, &system_av_info);
 }
 

--- a/libretro/nukleargui/retro/nuklear_retro_soft.h
+++ b/libretro/nukleargui/retro/nuklear_retro_soft.h
@@ -715,10 +715,13 @@ nk_retro_handle_event(int *evt,int poll)
    		
    		if(revent.JOYPAD_PRESSED > 0) {
    	    	// Joypad wraparound
-   	    	if(revent.gmx<32+12) 	revent.gmx=32+319-20-12;
-       		if(revent.gmx>32+319-12) revent.gmx=32+18+12;
-       		if(revent.gmy<35+4) 	revent.gmy=35+199-12;
-       		if(revent.gmy>35+199-4) revent.gmy=35+20;
+            // Offset changes depending on whether borders are on or off
+            struct nk_vec2 offset;
+            offset = nk_window_get_position(ctx);
+            if(revent.gmx<offset.x+12) 	revent.gmx=offset.x+319-20-12;
+            if(revent.gmx>offset.x+319-12) revent.gmx=offset.x+18+12;
+            if(revent.gmy<offset.y+4) 	revent.gmy=offset.y+199-12;
+            if(revent.gmy>offset.y+199-4) revent.gmy=offset.y+20;
    		} else {
        		// Mouse corners
        		if(revent.gmx<0)		revent.gmx=0;


### PR DESCRIPTION
This PR
- fixes the wrong aspect ratio when borders are disabled
- corrects the position and navigation on virtual keyboard when borders are disabled (the window was out of the screen before)

![C64_a](https://user-images.githubusercontent.com/13071547/62002629-658c7980-b0cd-11e9-8aea-af200d895972.jpg)
![C64_b](https://user-images.githubusercontent.com/13071547/62002630-658c7980-b0cd-11e9-9744-6f4a6cfed9bf.jpg)
![C64_c](https://user-images.githubusercontent.com/13071547/62002632-658c7980-b0cd-11e9-8215-a6e2a4286f9e.jpg)
![C64_d](https://user-images.githubusercontent.com/13071547/62002633-658c7980-b0cd-11e9-8f64-0f8b66db372f.jpg)