### PR TITLE
Fix dpad navigation of vkbd when borders are on

### DIFF
--- a/libretro/nukleargui/app.c
+++ b/libretro/nukleargui/app.c
@@ -45,6 +45,7 @@ static RSDL_Surface *screen_surface;
 
 extern void restore_bgk();
 extern void save_bkg();
+struct nk_vec2 offset = {0, 0};
 
 /* macros */
 

--- a/libretro/nukleargui/gui.i
+++ b/libretro/nukleargui/gui.i
@@ -138,15 +138,15 @@ gui(struct file_browser *browser,struct nk_context *ctx)
 	case GUI_VKBD:
 		if (nk_begin(ctx,"Vice Keyboard", GUIRECT, window_flags)){
 			#include "vkboard.i"
-			struct nk_vec2 pos;
+			/* ensure vkbd is centered regardless of border setting */
 			if (border_disabled) {
-				pos.x = 0;
-				pos.y = 0;
+				offset.x = 0;
+				offset.y = 0;
 			} else {
-				pos.x = GUIRECT.x;
-				pos.y = GUIRECT.y;
+				offset.x = GUIRECT.x;
+				offset.y = GUIRECT.y;
 			}
-			nk_window_set_position(ctx, pos);
+			nk_window_set_position(ctx, offset);
 			nk_end(ctx);
 		}
 		break;

--- a/libretro/nukleargui/retro/nuklear_retro_soft.h
+++ b/libretro/nukleargui/retro/nuklear_retro_soft.h
@@ -55,6 +55,7 @@ NK_API struct nk_retro_event* nk_retro_event_ptr();
 
 extern retro_input_poll_t input_poll_cb;
 extern retro_input_state_t input_state_cb;
+extern struct nk_vec2 offset; /* needed for correct wraparound in vkbd */
 
 struct nk_retro_event {
 
@@ -716,8 +717,6 @@ nk_retro_handle_event(int *evt,int poll)
    		if(revent.JOYPAD_PRESSED > 0) {
    	    	// Joypad wraparound
             // Offset changes depending on whether borders are on or off
-            struct nk_vec2 offset;
-            offset = nk_window_get_position(ctx);
             if(revent.gmx<offset.x+12) 	revent.gmx=offset.x+319-20-12;
             if(revent.gmx>offset.x+319-12) revent.gmx=offset.x+18+12;
             if(revent.gmy<offset.y+4) 	revent.gmy=offset.y+199-12;


### PR DESCRIPTION
When introducing the Border ON/OFF option, the navigation of vkbd with dpad became broken. This fixes that issue.