### PR TITLE
PRG autostart tuning

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -266,6 +266,10 @@ int pre_main(const char *argv)
 	 Add_Option("-cartB");
 #endif
 
+     if (strlen(RPATH) >= strlen(".prg"))
+       if (!strcasecmp(&RPATH[strlen(RPATH)-strlen(".prg")], ".prg"))
+         RETROTDE=0;
+
      if (strlen(RPATH) >= strlen(".d71"))
        if (!strcasecmp(&RPATH[strlen(RPATH)-strlen(".d71")], ".d71"))
          RETRODRVTYPE=1571;

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -145,6 +145,8 @@ int ui_init_finalize(void)
 
    resources_set_int("CrtcFilter", 0);
    resources_set_int("CrtcStretchVertical", 0);
+   
+   resources_set_int("AutostartPrgMode", 1);
 
    //RETRO CORE OPT
    if(RETROSTATUS==1) {


### PR DESCRIPTION
ui.c:
Autostarting a prg by default is put inside a temporary d64 (created in system/vice) and then loaded. This makes loading a LOT longer if true drive emulation is on.

AutostartPrgMode=1 equals inject mode. Any reason to make this an option instead of forcing it?


libretro-core.c:
This change temporarily disables true drive emulation to also prevent drive sound emulation init with prgs. Better ways to do the same?

