### PR TITLE
Less confusing log messages regarding keyboard

### DIFF
--- a/vice/src/arch/libretro/defaultkey.inc
+++ b/vice/src/arch/libretro/defaultkey.inc
@@ -170,9 +170,9 @@ keyboard_parse_set_pos_row(274, 0, 7,8);               /*         Down -> CRSR D
 keyboard_parse_set_pos_row(277, 6 ,0,8);               /*          Ins -> Pound        */
 keyboard_parse_set_pos_row(127, 6, 6,8);               /*          Del -> Up Arrow     */
 #endif
+
 //# Restore key mappings
 keyboard_parse_set_neg_row(280, -3, 0);
-keyboard_parse_set_neg_row(0 ,-3, 1);
 
 //# Joyport attached keypad key mappings
 keyboard_parse_set_neg_row(300, -5, 0);               /*      NumLock -> keypad x0    */

--- a/vice/src/keyboard.c
+++ b/vice/src/keyboard.c
@@ -1370,7 +1370,7 @@ int keyboard_set_keymap_index(int val, void *param)
     if (val < 2) {
         if (switch_keymap_file(&val, &mapping, &type) < 0) {
             DBG(("<keyboard_set_keymap_index switch_keymap_file ERROR\n"));
-            log_error(keyboard_log, "Default keymap not found, this should be fixed. Going on anyway...");
+            /*log_error(keyboard_log, "Default keymap not found, this should be fixed. Going on anyway...");*/
             /* return -1; */
             return 0; /* HACK: allow to start up when default keymap is missing */
         }
@@ -1399,7 +1399,7 @@ int keyboard_set_keyboard_type(int val, void *param)
     DBG((">keyboard_set_keyboard_type(idx:%d mapping:%d type:%d)\n", idx, mapping, val));
     if (idx < 2) {
         if (switch_keymap_file(&idx, &mapping, &val) < 0) {
-            log_error(keyboard_log, "Default keymap not found, this should be fixed. Going on anyway...");
+            /*log_error(keyboard_log, "Default keymap not found, this should be fixed. Going on anyway...");*/
             /* return -1; */
             return 0; /* HACK: allow to start up when default keymap is missing */
         }
@@ -1434,11 +1434,11 @@ int keyboard_set_keyboard_mapping(int val, void *param)
 
     if (idx < 2) {
         if (switch_keymap_file(&idx, &val, &type) < 0) {
-            log_error(keyboard_log, "Default keymap not found, this should be fixed. Going on anyway...");
+            /*log_error(keyboard_log, "Default keymap not found, this should be fixed. Going on anyway...");*/
             /* return -1; */
 #ifdef __LIBRETRO__
-log_error(keyboard_log, "Default keymap embedded libretro...");
-	retro_defaultkeyboard();
+            log_message(keyboard_log, "Default keymap embedded libretro...");
+            retro_defaultkeyboard();
 #endif
             return 0; /* HACK: allow to start up when default keymap is missing */
         }


### PR DESCRIPTION
One restore key is enough & removed useless error messages on keyboard init