### PR TITLE
Joyport force, issue #65

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -289,11 +289,11 @@ int pre_main(const char *argv)
          RETRODRVTYPE=1581;
 
      if (strlen(RPATH) >= strlen("j1"))
-       if (strstr(strlwr(RPATH), "j1") != NULL)
+       if (strstr(strlwr(RPATH), "_j1.") != NULL || strstr(strlwr(RPATH), "(j1)."))
          cur_port=1;
 
      if (strlen(RPATH) >= strlen("j2"))
-       if (strstr(strlwr(RPATH), "j2") != NULL)
+       if (strstr(strlwr(RPATH), "_j2.") != NULL || strstr(strlwr(RPATH), "(j2)."))
          cur_port=2;
 
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -270,7 +270,11 @@ int pre_main(const char *argv)
 
      if (strlen(RPATH) >= strlen(".prg"))
        if (!strcasecmp(&RPATH[strlen(RPATH)-strlen(".prg")], ".prg"))
-         RETROTDE=0;
+         RETRODSE=0;
+
+     if (strlen(RPATH) >= strlen(".crt"))
+       if (!strcasecmp(&RPATH[strlen(RPATH)-strlen(".crt")], ".crt"))
+         RETRODSE=0;
 
      if (strlen(RPATH) >= strlen(".d71"))
        if (!strcasecmp(&RPATH[strlen(RPATH)-strlen(".d71")], ".d71"))

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -289,11 +289,11 @@ int pre_main(const char *argv)
          RETRODRVTYPE=1581;
 
      if (strlen(RPATH) >= strlen("j1"))
-       if (strstr(strlwr(RPATH), "_j1.") != NULL || strstr(strlwr(RPATH), "(j1)."))
+       if (strstr(strlwr(RPATH), "_j1.") || strstr(strlwr(RPATH), "(j1)."))
          cur_port=1;
 
      if (strlen(RPATH) >= strlen("j2"))
-       if (strstr(strlwr(RPATH), "_j2.") != NULL || strstr(strlwr(RPATH), "(j2)."))
+       if (strstr(strlwr(RPATH), "_j2.") || strstr(strlwr(RPATH), "(j2)."))
          cur_port=2;
 
 
@@ -303,11 +303,11 @@ int pre_main(const char *argv)
    { // Pass all cmdline args
       for(i = 0; i < ARGUC; i++) {
          Skip_Option=0;
-         if(strstr(ARGUV[i], "-j1") != NULL) {
+         if(strstr(ARGUV[i], "-j1")) {
             Skip_Option=1;
             cur_port=1;
          }
-         if(strstr(ARGUV[i], "-j2") != NULL) {
+         if(strstr(ARGUV[i], "-j2")) {
             Skip_Option=1;
             cur_port=2;
          }

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -9,6 +9,8 @@
 #include "snapshot.h"
 #include "autostart.h"
 
+
+
 //CORE VAR
 #ifdef _WIN32
 char slash = '\\';
@@ -89,6 +91,7 @@ extern int RETROUSERPORTJOY;
 extern int RETROEXTPAL;
 extern int RETROAUTOSTARTWARP;
 extern int RETROBORDERS;
+extern int RETROTHEME;
 extern char RETROEXTPALNAME[512];
 extern int retro_ui_finalized;
 extern unsigned int cur_port;
@@ -545,6 +548,10 @@ void retro_set_environment(retro_environment_t cb)
          "External palette; none|pepto-pal|pepto-palold|pepto-ntsc-sony|pepto-ntsc|colodore|vice|c64hq|c64s|ccs64|frodo|godot|pc64|rgb|deekay|ptoing|community-colors",
       },
 #endif
+      {
+         "vice_theme",
+         "Virtual keyboard theme; C64|C64C",
+      },
       {
          "vice_reset",
          "Reset type; autostart|soft|hard",
@@ -1085,6 +1092,17 @@ static void update_variables(void)
          RETRORESET=1;
       if (strcmp(var.value, "hard") == 0)
          RETRORESET=2;
+   }
+
+   var.key = "vice_theme";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "C64") == 0)
+         RETROTHEME=0;
+      else if (strcmp(var.value, "C64C") == 0)
+         RETROTHEME=1;
    }
 
    var.key = "vice_mapper_select";

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -217,6 +217,7 @@ int pre_main(const char *argv)
 {
    int i=0;
    bool Only1Arg;
+   bool Skip_Option=0;
 
    if (strlen(argv) > strlen("cmd"))
    {
@@ -284,13 +285,33 @@ int pre_main(const char *argv)
        if (!strcasecmp(&RPATH[strlen(RPATH)-strlen(".d81")], ".d81"))
          RETRODRVTYPE=1581;
 
+     if (strlen(RPATH) >= strlen("j1"))
+       if (strstr(strlwr(RPATH), "j1") != NULL)
+         cur_port=1;
+
+     if (strlen(RPATH) >= strlen("j2"))
+       if (strstr(strlwr(RPATH), "j2") != NULL)
+         cur_port=2;
+
 
      Add_Option(RPATH/*ARGUV[0]*/);
    }
    else
    { // Pass all cmdline args
-      for(i = 0; i < ARGUC; i++)
-         Add_Option(ARGUV[i]);
+      for(i = 0; i < ARGUC; i++) {
+         Skip_Option=0;
+         if(strstr(ARGUV[i], "-j1") != NULL) {
+            Skip_Option=1;
+            cur_port=1;
+         }
+         if(strstr(ARGUV[i], "-j2") != NULL) {
+            Skip_Option=1;
+            cur_port=2;
+         }
+         
+         if(!Skip_Option)
+            Add_Option(ARGUV[i]);
+      }
    }
 
    for (i = 0; i < PARAMCOUNT; i++)

--- a/libretro/nukleargui/app.c
+++ b/libretro/nukleargui/app.c
@@ -83,7 +83,7 @@ int app_init()
     ctx = nk_retro_init(RSDL_font,screen_surface,retrow,retroh);
 
     /* style.c */
-    /* THEME_BLACK, THEME_WHITE, THEME_RED, THEME_BLUE, THEME_DARK */
+    /* THEME_BLACK, THEME_WHITE, THEME_RED, THEME_BLUE, THEME_DARK, THEME_C64, THEME_C64C */
     set_style(ctx, THEME_C64);
 
     memset(core_key_state,0,512);

--- a/libretro/nukleargui/app.c
+++ b/libretro/nukleargui/app.c
@@ -21,6 +21,7 @@ extern char core_old_key_state[512];
 extern char RPATH[512];
 extern int SHOWKEY;
 extern int want_quit;
+extern int RETROTHEME;
 
 char LCONTENT[512];
 int LOADCONTENT=-1;
@@ -84,7 +85,10 @@ int app_init()
 
     /* style.c */
     /* THEME_BLACK, THEME_WHITE, THEME_RED, THEME_BLUE, THEME_DARK, THEME_C64, THEME_C64C */
-    set_style(ctx, THEME_C64);
+    if(RETROTHEME==1) 
+      set_style(ctx, THEME_C64C);
+    else 
+      set_style(ctx, THEME_C64);
 
     memset(core_key_state,0,512);
     memset(core_old_key_state ,0, sizeof(core_old_key_state));

--- a/libretro/nukleargui/gui.i
+++ b/libretro/nukleargui/gui.i
@@ -19,6 +19,7 @@ int GUISTATE = GUI_NONE;
 extern int SHIFTON;
 extern int vkey_pressed;
 extern int RETROBORDERS;
+extern int RETROTHEME;
 extern int retro_ui_finalized;
 
 extern void emu_reset(void);
@@ -72,6 +73,12 @@ gui(struct nk_context *ctx)
     {
         case GUI_VKBD:
             if (nk_begin(ctx,"Vice Keyboard", GUIRECT, window_flags)) {
+
+                if(RETROTHEME==1)
+                  set_style(ctx, THEME_C64C);
+                else
+                  set_style(ctx, THEME_C64);
+                
                 #include "vkboard.i"
                 /* ensure vkbd is centered regardless of border setting */
                 if (border_disabled) {

--- a/libretro/nukleargui/nuklear/style.c
+++ b/libretro/nukleargui/nuklear/style.c
@@ -1,4 +1,4 @@
-enum theme {THEME_BLACK, THEME_WHITE, THEME_RED, THEME_BLUE, THEME_DARK, THEME_C64};
+enum theme {THEME_BLACK, THEME_WHITE, THEME_RED, THEME_BLUE, THEME_DARK, THEME_C64, THEME_C64C};
 
 void
 set_style(struct nk_context *ctx, enum theme theme)
@@ -127,9 +127,9 @@ set_style(struct nk_context *ctx, enum theme theme)
     } else if (theme == THEME_C64) {
         table[NK_COLOR_TEXT] = nk_rgba(254, 254, 254, 255);
         table[NK_COLOR_WINDOW] = nk_rgba(0, 0, 0, 128);
-        table[NK_COLOR_HEADER] = nk_rgba(165, 163, 160, 220);
+        table[NK_COLOR_HEADER] = nk_rgba(123, 127, 130, 255); // function keys
         table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 0);
-        table[NK_COLOR_BUTTON] = nk_rgba(69, 59, 58, 255);
+        table[NK_COLOR_BUTTON] = nk_rgba(69, 59, 58, 255); // regular keys
         table[NK_COLOR_BUTTON_HOVER] = nk_rgba(165, 163, 160, 255);
         table[NK_COLOR_BUTTON_ACTIVE] = nk_rgba(48, 44, 45, 255);
         table[NK_COLOR_TOGGLE] = nk_rgba(50, 58, 61, 255);
@@ -141,7 +141,37 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_SLIDER_CURSOR] = nk_rgba(48, 83, 111, 245);
         table[NK_COLOR_SLIDER_CURSOR_HOVER] = nk_rgba(53, 88, 116, 255);
         table[NK_COLOR_SLIDER_CURSOR_ACTIVE] = nk_rgba(58, 93, 121, 255);
-        table[NK_COLOR_PROPERTY] = nk_rgba(50, 58, 61, 255);
+        table[NK_COLOR_PROPERTY] = nk_rgba(144, 141, 124, 255); // hotkeys
+        table[NK_COLOR_EDIT] = nk_rgba(50, 58, 61, 225);
+        table[NK_COLOR_EDIT_CURSOR] = nk_rgba(210, 210, 210, 255);
+        table[NK_COLOR_COMBO] = nk_rgba(50, 58, 61, 255);
+        table[NK_COLOR_CHART] = nk_rgba(50, 58, 61, 255);
+        table[NK_COLOR_CHART_COLOR] = nk_rgba(48, 83, 111, 255);
+        table[NK_COLOR_CHART_COLOR_HIGHLIGHT] = nk_rgba(255, 0, 0, 255);
+        table[NK_COLOR_SCROLLBAR] = nk_rgba(50, 58, 61, 255);
+        table[NK_COLOR_SCROLLBAR_CURSOR] = nk_rgba(48, 83, 111, 255);
+        table[NK_COLOR_SCROLLBAR_CURSOR_HOVER] = nk_rgba(53, 88, 116, 255);
+        table[NK_COLOR_SCROLLBAR_CURSOR_ACTIVE] = nk_rgba(58, 93, 121, 255);
+        table[NK_COLOR_TAB_HEADER] = nk_rgba(48, 83, 111, 255);
+        nk_style_from_table(ctx, table);
+    } else if (theme == THEME_C64C) {
+        table[NK_COLOR_TEXT] = nk_rgba(1, 1, 1, 255);
+        table[NK_COLOR_WINDOW] = nk_rgba(0, 0, 0, 128);
+        table[NK_COLOR_HEADER] = nk_rgba(157, 152, 149, 255); // function keys
+        table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 0); 
+        table[NK_COLOR_BUTTON] = nk_rgba(216, 209, 201, 255); // regular keys
+        table[NK_COLOR_BUTTON_HOVER] = nk_rgba(165, 163, 160, 255);
+        table[NK_COLOR_BUTTON_ACTIVE] = nk_rgba(48, 44, 45, 255);
+        table[NK_COLOR_TOGGLE] = nk_rgba(50, 58, 61, 255);
+        table[NK_COLOR_TOGGLE_HOVER] = nk_rgba(45, 53, 56, 255);
+        table[NK_COLOR_TOGGLE_CURSOR] = nk_rgba(48, 83, 111, 255);
+        table[NK_COLOR_SELECT] = nk_rgba(57, 67, 61, 255);
+        table[NK_COLOR_SELECT_ACTIVE] = nk_rgba(48, 83, 111, 255);
+        table[NK_COLOR_SLIDER] = nk_rgba(50, 58, 61, 255);
+        table[NK_COLOR_SLIDER_CURSOR] = nk_rgba(48, 83, 111, 245);
+        table[NK_COLOR_SLIDER_CURSOR_HOVER] = nk_rgba(53, 88, 116, 255);
+        table[NK_COLOR_SLIDER_CURSOR_ACTIVE] = nk_rgba(58, 93, 121, 255);
+        table[NK_COLOR_PROPERTY] = nk_rgba(144, 141, 124, 255); // hotkeys
         table[NK_COLOR_EDIT] = nk_rgba(50, 58, 61, 225);
         table[NK_COLOR_EDIT_CURSOR] = nk_rgba(210, 210, 210, 255);
         table[NK_COLOR_COMBO] = nk_rgba(50, 58, 61, 255);

--- a/libretro/nukleargui/vkboard.i
+++ b/libretro/nukleargui/vkboard.i
@@ -1,6 +1,5 @@
 int x = 0,y = 0;
 
-char *name;
 ctx->style.window.padding = nk_vec2(10,2);
 ctx->style.window.spacing = nk_vec2(2,2);
 
@@ -9,7 +8,8 @@ ctx->style.button.border = 0;
 ctx->style.button.rounding = 1.0f;
 
 struct nk_style_item key_color_default = ctx->style.button.normal;
-struct nk_style_item key_color_alt = nk_style_item_color(nk_rgba(123, 127, 130, 255));
+struct nk_style_item key_color_alt = ctx->style.window.header.normal;
+struct nk_style_item key_color_hotkey = ctx->style.property.normal;
 
 nk_layout_row_dynamic(ctx, 26, NPLGN);
 nk_button_set_behavior(ctx, NK_BUTTON_REPEATER);
@@ -20,14 +20,21 @@ for(y=0;y<NLIGN;y++)
 {
       for(x=0;x<NPLGN;x++)
       {
-             // Reset default color
+             /* Reset default color */
              ctx->style.button.normal = key_color_default;
 
-             // Function key color
-             name = MVk[(y*NPLGN)+x].norml;
-             if (strcmp(name, "F1") == 0 || strcmp(name, "F3") == 0 || strcmp(name, "F5") == 0 || strcmp(name, "F7") == 0)
+             /* Function key color */
+             if(strcmp(MVk[(y*NPLGN)+x].norml, "F1") == 0 
+             || strcmp(MVk[(y*NPLGN)+x].norml, "F3") == 0 
+             || strcmp(MVk[(y*NPLGN)+x].norml, "F5") == 0 
+             || strcmp(MVk[(y*NPLGN)+x].norml, "F7") == 0)
                     ctx->style.button.normal = key_color_alt;
-
+                    
+             /* Hotkey color */
+             if(strcmp(MVk[(y*NPLGN)+x].norml, "Joy") == 0
+             || strcmp(MVk[(y*NPLGN)+x].norml, "StB") == 0)
+                    ctx->style.button.normal = key_color_hotkey;
+             
              if (nk_button_text(ctx, SHIFTON == -1 ? MVk[(y*NPLGN)+x].norml : MVk[(y*NPLGN)+x].shift , \
              SHIFTON == -1 ? strlen(MVk[(y*NPLGN)+x].norml) : strlen(MVk[(y*NPLGN)+x].shift)))
              {

--- a/libretro/vkbd.i
+++ b/libretro/vkbd.i
@@ -75,12 +75,12 @@ Mvk MVk[NPLGN*NLIGN*2]={
 
 	// 60
 	{ "C=" ,"C="  ,RETROK_LCTRL},
+	{ "ShL","ShL" ,-10},
 	{ "LSh","LSh" ,RETROK_LSHIFT},
 	{ "Spc","Spc" ,RETROK_SPACE},
-	{ "RSh","RSh" ,RETROK_RSHIFT},
-	{ "ShL","ShL" ,-10},
 	{ "Joy","Joy" ,-4},
 	{ "StB","StB" ,-5},
+	{ "RSh","RSh" ,RETROK_RSHIFT},
 	{ "CrL","CrL" ,RETROK_LEFT},
 	{ "CrD","CrD" ,RETROK_DOWN}, 
 	{ "CrR","CrR" ,RETROK_RIGHT},

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -64,6 +64,7 @@ int RETROUSERPORTJOY=-1;
 int RETROEXTPAL=-1;
 int RETROAUTOSTARTWARP=0;
 int RETROBORDERS=0;
+int RETROTHEME=0;
 char RETROEXTPALNAME[512]="pepto-pal";
 int retro_ui_finalized = 0;
 

--- a/vice/src/arch/libretro/uistatusbar.c
+++ b/vice/src/arch/libretro/uistatusbar.c
@@ -90,17 +90,15 @@ static void display_tape(void)
     }
 }
 
-
 static void display_joyport(void)
 {
     int len;
     char tmpstr[25];
     
-    sprintf(tmpstr, "j%d:%2d ", 1, joystick_value[1]);
-    sprintf(tmpstr + strlen(tmpstr), "j%d:%2d ", 2, joystick_value[2]);
-    sprintf(tmpstr + strlen(tmpstr), "j%d:%2d ", 3, joystick_value[3]);
-    sprintf(tmpstr + strlen(tmpstr), "j%d:%2d", 4, joystick_value[4]);
-    //Retro_Draw_string(&fake, x+200, y, tmpstr,16,1,1, color_f, color_b);
+    sprintf(tmpstr, "J%d:%2d ", 1, joystick_value[1]);
+    sprintf(tmpstr + strlen(tmpstr), "J%d:%2d ", 2, joystick_value[2]);
+    sprintf(tmpstr + strlen(tmpstr), "J%d:%2d ", 3, joystick_value[3]);
+    sprintf(tmpstr + strlen(tmpstr), "J%d:%2d", 4, joystick_value[4]);
 
     len = sprintf(&(statusbar_text[STATUSBAR_JOY_POS]), "%s", tmpstr);
     statusbar_text[STATUSBAR_JOY_POS + len] = ' ';
@@ -109,7 +107,6 @@ static void display_joyport(void)
         uistatusbar_state |= UISTATUSBAR_REPAINT;
     }
 }
-
 
 
 static int per = 0;
@@ -419,13 +416,30 @@ unsigned int color_f, color_b;
     fake.clip_rect.x=0;
     fake.clip_rect.y=0;
     
-    int x, y;
-    x=32;
-    y=236;
 
-    //sprintf(tmpstr,"joy%d:%2d ",1,joystick_value[1]);
-    //sprintf(tmpstr + strlen(tmpstr),"joy%d:%2d",2,joystick_value[2]);
-    //Retro_Draw_string(&fake, x+200, y, tmpstr,16,1,1, color_f, color_b);
+    /* Statusbar location with or without borders */
+    int x, y, border;
+#if defined(__VIC20__)
+    resources_get_int("VICBorderMode", &border);
+#elif defined(__PLUS4__)
+    resources_get_int("TEDBorderMode", &border);
+#else
+    resources_get_int("VICIIBorderMode", &border);
+#endif
+    
+    /* 0 : normal, 1: full, 2: debug, 3: none */
+    switch(border) {
+        default:
+        case 0:
+            x=32;
+            y=236;
+            break;
+        case 3: 
+            x=0;
+            y=192;
+            break;
+    }
+
     display_joyport();
 
     for (i = 0; i < MAX_STATUSBAR_LEN; ++i) {


### PR DESCRIPTION
"j1" or "j2" can be mentioned anywhere in the path, so all of these work, caps insensitive:
Arkanoid_j1.prg
Arkanoid (j1).prg
j1/Arkanoid.prg

Might this check be too loose? I don't recall cases where the name would already include j1 or j2.

And for those who don't want to rename or reorganize files it can be done with:
retroarch.exe -L core "x64sc -j1 \"path\Arkanoid.prg\""




The command line parsing should also be improved so the emutype is not needed first in the "path".

Also a bonus on pointless drive sound emulation muting with crt files.



Edit: Check is now stricter. Only these will work:
Arkanoid_j1.prg
Arkanoid (j1).prg


Closes #65 