### PR TITLE
Allow keyup also on keyboard while VKBD is visible

### DIFF
--- a/vice/src/arch/libretro/retrostubs.c
+++ b/vice/src/arch/libretro/retrostubs.c
@@ -210,8 +210,8 @@ void Core_Processkey(int disable_physical_cursor_keys)
                ;
             else if(disable_physical_cursor_keys && (i == RETROK_DOWN || i == RETROK_UP || i == RETROK_LEFT || i == RETROK_RIGHT))
                continue;
-            else if(SHOWKEY==1)
-               continue;
+            //else if(SHOWKEY==1) /* We need to allow keyup while SHOWKEY to prevent the summoning key from staying down, if keyboard is used as a RetroPad */
+            //   continue;
             Keymap_KeyUp(i);
          }
       }


### PR DESCRIPTION
Simple fix that already existed for joystick input. Without this the keyboard key used to show VKBD (not the RETROK_F11 hotkey) will get stuck down if RetroPad is a keyboard.
