### PR TITLE
RetroPad button layout conform + transparency toggle button for vkbd

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -70,7 +70,8 @@ int lastH=768;
 
 #include "vkbd.i"
 
-unsigned vice_devices[5];
+unsigned int vice_devices[5];
+unsigned int opt_theme;
 
 extern int RETROTDE;
 extern int RETRODSE;
@@ -148,7 +149,10 @@ static int runstate = RUNSTATE_FIRST_START; /* used to detect whether we are jus
 
 unsigned retro_get_borders(void) {
    return RETROBORDERS;
-} 
+}
+unsigned retro_toggle_theme(void) {
+   opt_theme = (opt_theme % 2) ? opt_theme-1 : opt_theme+1;
+}
 
 void retro_set_input_state(retro_input_state_t cb)
 {
@@ -792,13 +796,13 @@ void retro_set_environment(retro_environment_t cb)
          "Replaces mapped key with a turbo fire button",
          {
             { "None", NULL },
-            { "B", NULL },
-            { "X", NULL },
-            { "Y", NULL },
-            { "L", NULL },
-            { "R", NULL },
-            { "L2", NULL },
-            { "R2", NULL },
+            { "A", "RetroPad A" },
+            { "Y", "RetroPad Y" },
+            { "X", "RetroPad X" },
+            { "L", "RetroPad L" },
+            { "R", "RetroPad R" },
+            { "L2", "RetroPad L2" },
+            { "R2", "RetroPad R2" },
          },
          "None"
       },
@@ -843,27 +847,26 @@ void retro_set_environment(retro_environment_t cb)
          "---"
       },
       {
+         "vice_mapper_a",
+         "RetroPad A",
+         "",
+         {{ NULL, NULL }},
+         "---"
+      },
+      {
          "vice_mapper_y",
          "RetroPad Y",
          "",
          {{ NULL, NULL }},
-         "RETROK_SPACE"
+         "---"
       },
       {
          "vice_mapper_x",
          "RetroPad X",
          "",
          {{ NULL, NULL }},
-         "RETROK_F1"
+         "---"
       },
-      {
-         "vice_mapper_b",
-         "RetroPad B",
-         "",
-         {{ NULL, NULL }},
-         "RETROK_F7"
-      },
-
       {
          "vice_mapper_l",
          "RetroPad L",
@@ -1601,9 +1604,9 @@ static void update_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "None") == 0) turbo_fire_button=-1;
-      else if (strcmp(var.value, "B") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_B;
-      else if (strcmp(var.value, "X") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_X;
+      else if (strcmp(var.value, "A") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_A;
       else if (strcmp(var.value, "Y") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_Y;
+      else if (strcmp(var.value, "X") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_X;
       else if (strcmp(var.value, "L") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_L;
       else if (strcmp(var.value, "R") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_R;
       else if (strcmp(var.value, "L2") == 0) turbo_fire_button=RETRO_DEVICE_ID_JOYPAD_L2;
@@ -1655,83 +1658,85 @@ static void update_variables(void)
          RETROTHEME=4;
       else if (strcmp(var.value, "Light transparent") == 0) 
          RETROTHEME=5;
+
+      opt_theme=RETROTHEME;
    }
 
    var.key = "vice_mapper_select";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[2] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_SELECT] = keyId(var.value);
    }
 
    var.key = "vice_mapper_start";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[3] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_START] = keyId(var.value);
+   }
+
+   var.key = "vice_mapper_a";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_A] = keyId(var.value);
    }
 
    var.key = "vice_mapper_y";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[1] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_Y] = keyId(var.value);
    }
 
    var.key = "vice_mapper_x";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[9] = keyId(var.value);
-   }
-
-   var.key = "vice_mapper_b";
-   var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      mapper_keys[0] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_X] = keyId(var.value);
    }
 
    var.key = "vice_mapper_l";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[10] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_L] = keyId(var.value);
    }
 
    var.key = "vice_mapper_r";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[11] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_R] = keyId(var.value);
    }
 
    var.key = "vice_mapper_l2";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[12] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_L2] = keyId(var.value);
    }
 
    var.key = "vice_mapper_r2";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[13] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_R2] = keyId(var.value);
    }
 
    var.key = "vice_mapper_l3";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[14] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_L3] = keyId(var.value);
    }
 
    var.key = "vice_mapper_r3";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      mapper_keys[15] = keyId(var.value);
+      mapper_keys[RETRO_DEVICE_ID_JOYPAD_R3] = keyId(var.value);
    }
 
 
@@ -2123,7 +2128,7 @@ void retro_init(void)
 
 #define RETRO_DESCRIPTOR_BLOCK( _user )                                            \
    { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, "A" },               \
-   { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "B" },               \
+   { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "B / Fire" },        \
    { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X, "X" },               \
    { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y, "Y" },               \
    { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Select" },     \

--- a/libretro/nukleargui/app.c
+++ b/libretro/nukleargui/app.c
@@ -20,7 +20,6 @@ extern char core_key_state[512];
 extern char core_old_key_state[512];
 extern char RPATH[512];
 extern int SHOWKEY;
-extern int RETROTHEME;
 
 #define NK_INCLUDE_FIXED_TYPES
 #define NK_INCLUDE_STANDARD_IO

--- a/libretro/nukleargui/gui.i
+++ b/libretro/nukleargui/gui.i
@@ -19,7 +19,7 @@ int GUISTATE = GUI_NONE;
 
 extern int SHIFTON;
 extern int vkey_pressed;
-extern int RETROTHEME;
+extern int opt_theme;
 
 extern unsigned retro_get_borders(void);
 
@@ -33,7 +33,7 @@ static int gui(struct nk_context *ctx)
     {
         case GUI_VKBD:
             if (nk_begin(ctx,"Vice Keyboard", GUIRECT, NK_WINDOW_NO_SCROLLBAR)) {
-                switch(RETROTHEME) {
+                switch(opt_theme) {
                     default:
                     case 0:
                         set_style(ctx, THEME_C64);

--- a/libretro/nukleargui/retro/nuklear_retro_soft.h
+++ b/libretro/nukleargui/retro/nuklear_retro_soft.h
@@ -446,6 +446,7 @@ nk_retro_get_text_width(nk_handle handle, float height, const char *text, int le
 
 
 extern unsigned retro_get_borders(void);
+extern unsigned retro_toggle_theme(void);
 
 void reset_mouse_pos(){
 	/* Starting point on F1 */
@@ -559,7 +560,8 @@ static void mousebut(int but,int down,int x,int y){
 	struct nk_context *ctx = &retro.ctx;
 
  	if(but==1)nk_input_button(ctx, NK_BUTTON_LEFT, x, y, down);
- 	else if(but==2)nk_input_button(ctx, NK_BUTTON_RIGHT, x, y, down);
+ 	//else if(but==2)nk_input_button(ctx, NK_BUTTON_RIGHT, x, y, down);
+ 	else if(but==2 && down)retro_toggle_theme();
  	else if(but==3)nk_input_button(ctx, NK_BUTTON_MIDDLE, x, y, down);
 	else if(but==4)nk_input_scroll(ctx,(float)down);
 }
@@ -616,9 +618,9 @@ nk_retro_handle_event(int *evt,int poll)
    if(revent.mouse_wu || revent.mouse_wd)mousebut(4,revent.mouse_wd?-1:1,0,0);
 
     // Joypad buttons
-    mouse_l = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A);
-    mouse_r = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
-    mouse_m = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y);
+    mouse_l = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
+    mouse_r = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A);
+    //mouse_m = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y);
        
     if(!mouse_l && !mouse_r && !mouse_m) {
         // Keyboard buttons
@@ -629,7 +631,7 @@ nk_retro_handle_event(int *evt,int poll)
        // Mouse buttons
        mouse_l = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
        mouse_r = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT);
-       mouse_m = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_MIDDLE); 
+       //mouse_m = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_MIDDLE);
     }
 
     //relative

--- a/vice/src/arch/libretro/retrostubs.c
+++ b/vice/src/arch/libretro/retrostubs.c
@@ -17,7 +17,7 @@ extern retro_input_state_t input_state_cb;
 
 extern void emu_reset(void);
 extern void Screen_SetFullUpdate(int scr);
-extern unsigned vice_devices[5];
+extern unsigned int vice_devices[5];
 
 //EMU FLAGS
 int SHOWKEY=-1;
@@ -313,7 +313,8 @@ int Core_PollEvent(int disable_physical_cursor_keys)
     if (processkey)
         Core_Processkey(disable_physical_cursor_keys);
 
-    if (vice_devices[0] == RETRO_DEVICE_VICE_JOYSTICK || vice_devices[0] == RETRO_DEVICE_JOYPAD)
+    /* RetroPad extra mappings */
+    if (vice_devices[0] == RETRO_DEVICE_JOYPAD)
     {
         LX = input_state_cb(0, RETRO_DEVICE_ANALOG, 0, 0);
         LY = input_state_cb(0, RETRO_DEVICE_ANALOG, 0, 1);
@@ -325,8 +326,12 @@ int Core_PollEvent(int disable_physical_cursor_keys)
         {
             int just_pressed = 0;
             int just_released = 0;
-            if((i<4 || i>8) && i < 16) /* remappable retropad buttons (all apart from DPAD and A) */
+            if(i > 0 && (i<4 || i>7) && i < 16) /* remappable retropad buttons (all apart from DPAD and B) */
             {
+                /* Skip the transparency toggle button if vkbd is visible */
+                if(SHOWKEY==1 && i==RETRO_DEVICE_ID_JOYPAD_A)
+                    continue;
+
                 if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && jbt[i]==0 && i!=turbo_fire_button)
                     just_pressed = 1;
                 else if (jbt[i]==1 && ! input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i))
@@ -452,7 +457,7 @@ int Core_PollEvent(int disable_physical_cursor_keys)
                     Keymap_KeyUp(mapper_keys[i]);
             }
         } /* for i */
-    } /* if vice_devices[0]==joypad or joystick */
+    } /* if vice_devices[0]==joypad */
 
     return 1;
 }
@@ -532,7 +537,7 @@ void retro_poll_event()
                 else
                     j &= ~0x08;
                     
-                if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) || 
+                if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) ||
                     (RETROKEYRAHKEYPAD && vice_port < 3 && vice_port != cur_port && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_KP0)) ||
                     (RETROKEYRAHKEYPAD && vice_port < 3 && vice_port == cur_port && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_KP5))
                 )


### PR DESCRIPTION
Changed the fire button location according to the Retro Standards, which is Retro B is the fire button, not A.

Cleared some default mappings, disabled RetroPad hotkeys for joystick device type, clarified some namings and Retro A toggles virtual keyboard transparency.
