### PR TITLE
Improve command file operation

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -241,6 +241,7 @@ int pre_main(const char *argv)
    {
       parse_cmdline(CMDFILE);
       log_cb(RETRO_LOG_INFO, "Starting game from command line :%s\n",CMDFILE);
+      RETROC64MODL = 99; // set model to unknown for custom settings - prevents overriding of command line options
    }
    else
       parse_cmdline(argv);


### PR DESCRIPTION
Prevent some custom settings via command file being overridden by model setting. Previously a standard machine model was being set after custom options in the command line were being parsed. This meant that custom configuration settings were being forced back to standard models. This affected the ability to use the command file to set different Vic20 memory configurations and prevented the use of the command file to run some games and carts which could not be loaded using standard operation.

Now you can load up a Vic20 megacart by creating a text file with a .cmd extension containing the line - 
xvic -cartmega /path/to/rom/mega-cart-name.rom

You can also load Vic20 games which require specific memory configs such as 8k expansion -
xvic -memory 1 /path/to/rom/some-8k-game.d64
