### PR TITLE
Allow passing m3u and vfl with other parameters (again)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.so
 *.dll
 *.a
+GPATH
+GTAGS
+GRTAGS

--- a/libretro/retro_disk_control.c
+++ b/libretro/retro_disk_control.c
@@ -336,6 +336,19 @@ bool dc_add_file(dc_storage* dc, const char* filename)
     if (dc == NULL || filename == NULL)
         return false;
 
+    // Determine if tape or disk fliplist from first entry
+    if (dc->unit == 0)
+    {
+        if (strendswith(filename, "tap") || strendswith(filename, "t64"))
+        {
+            dc->unit = 1;
+        }
+        else
+        {
+            dc->unit = 8;
+        }
+    }
+
     // Copy and return
     return dc_add_file_int(dc, strdup(filename), get_label(filename));
 }
@@ -359,6 +372,12 @@ bool dc_remove_file(dc_storage* dc, int index)
         memmove(dc->files + index, dc->files + index + 1, (dc->count - 1 - index) * sizeof(dc->files[0]));
 
     dc->count--;
+
+    // Reset fliplist unit after removing last entry
+    if (dc->count == 0)
+    {
+        dc->unit = 0;
+    }
 
     return true;
 }
@@ -526,6 +545,20 @@ void dc_parse_list(dc_storage* dc, const char* list_file, bool is_vfl)
 
     // Close the file 
     fclose(fp);
+
+    // M3U - Determine if tape or disk fliplist from first entry
+    if (dc->unit == 0 && dc->count !=0)
+    {
+        if (strendswith(dc->files[0], "tap") || strendswith(dc->files[0], "t64"))
+        {
+            dc->unit = 1;
+        }
+        else
+        {
+            dc->unit = 8;
+        }
+    }
+
 }
 
 void dc_parse_m3u(dc_storage* dc, const char* m3u_file)

--- a/libretro/retro_disk_control.c
+++ b/libretro/retro_disk_control.c
@@ -19,281 +19,530 @@
 #include "retro_disk_control.h"
 #include "retro_strings.h"
 #include "retro_files.h"
+#include "libretro.h"
+
+#include "file/file_path.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-/*#include <sys/types.h> 
-#include <sys/stat.h> 
-#include <ctype.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>*/
 
-#define COMMENT "#"
+#define COMMENT '#'
 #define M3U_SPECIAL_COMMAND "#COMMAND:"
-#define VFL_UNIT_ENTRY "UNIT "
+#define M3U_NONSTD_LABEL    "#LABEL:"
+#define M3U_EXTSTD_LABEL    "#EXTINF:" // Title should be following comma
+#define VFL_UNIT_ENTRY      "UNIT "
 
-// Return the directory name of filename 'filename'.
-char* dirname_int(const char* filename)
+#define MAX_LABEL_LEN     27 // Max of disk (27) and tape (24)
+
+#define D64_NAME_POS      0x16590 // Sector 18/0, offset 0x90
+#define D64_FULL_NAME_LEN 27      // Including id, dos version and paddings
+#define D64_NAME_LEN      16
+
+#define T64_NAME_POS      40
+#define T64_NAME_LEN      24
+
+#undef  DISK_LABEL_RELAXED         // Use label even if it doesn't look sane (mostly for testing)
+#undef  DISK_LABEL_FORBID_SHIFTED  // Reject label if has shifted chars
+
+static const char flip_file_header[] = "# Vice fliplist file";
+
+extern retro_log_printf_t log_cb;
+
+// Return the directory name of 'filename' without trailing separator.
+// Allocates returned string.
+static char* dirname_int(const char* filename)
 {
-	if (filename == NULL)
-		return NULL;
-	
-	char* right;
-	int len = strlen(filename);
-	
-	if ((right = strrchr(filename, RETRO_PATH_SEPARATOR[0])) != NULL)
-		return strleft(filename, len - strlen(right));
-	
-#ifdef _WIN32
-	// Alternative search for windows beceause it also support the UNIX seperator
-	if ((right = strrchr(filename, RETRO_PATH_SEPARATOR_ALT[0])) != NULL)
-		return strleft(filename, len - strlen(right));
-#endif
-	
-	// Not found
-	return NULL;
+    if (filename == NULL)
+        return NULL;
+
+    // Find last separator
+    char* right = find_last_slash(filename);
+    if (right)
+        return strleft(filename, right - filename);
+
+    // Not found
+    return NULL;
 }
 
-char* m3u_search_file(const char* basedir, const char* dskName)
-{
-	// Verify if this item is an absolute pathname (or the file is in working dir)
-	if (file_exists(dskName))
-	{
-		// Copy and return
-		char* result = calloc(strlen(dskName) + 1, sizeof(char));
-		strcpy(result, dskName);
-		return result;
-	}
-	
-	// If basedir was provided
-	if(basedir != NULL)
-	{
-		// Join basedir and dskName
-		char* dskPath = calloc(RETRO_PATH_MAX, sizeof(char));
-		path_join(dskPath, basedir, dskName);
+// Add known disk labels from conversion tools, famous collectors etc.
+static const char const* rude_words[] = {
+    "semprini",
+    "ass presents",
+    "ass presents:"
+};
 
-		// Verify if this item is a relative filename (append it to the m3u path)
-		if (file_exists(dskPath))
-		{
-			// Return
-			return dskPath;
-		}
-		free(dskPath);
-	}
-	
-	// File not found
-	return NULL;
+// Filter out this annoying "ASS PRESENTS"
+static bool is_ugly(const char* label)
+{
+    size_t i;
+    for (i = 0; i < sizeof(rude_words) / sizeof(rude_words[0]); ++i)
+    {
+        if (strcasecmp(label, rude_words[i]) == 0)
+            return true;
+    }
+    return false;
+}
+
+#define PETSCII_SHIFTED_BIT       0x20
+
+#define PETSCII_SPACE             0x20
+#define PETSCII_NBSP              0xA0
+#define PETSCII_UNSHIFTED_A       0x40
+#define PETSCII_UNSHIFTED_Z       0x5A
+#define PETSCII_SHIFTED_A         0x60
+#define PETSCII_SHIFTED_Z         0x7A
+
+// Try to read disk or tape name from image
+// Allocates returned string
+static char* get_label(const char* filename)
+{
+    unsigned char label[MAX_LABEL_LEN + 1];
+    bool have_disk_label = false;
+    bool have_tape_label = false;
+    bool have_shifted = false;
+    int i;
+
+    label[0] = '\0';
+    // Disk image which we can read name from
+    if (strendswith(filename, "d64") || strendswith(filename, "d71"))
+    {
+        FILE* fd = fopen(filename, "rb");
+
+        if (fd != NULL)
+        {
+            if (fseek(fd, D64_NAME_POS, SEEK_SET) == 0
+                && fread(label, D64_FULL_NAME_LEN, 1, fd) == 1)
+            {
+                label[D64_FULL_NAME_LEN] = '\0';
+                have_disk_label = true;
+            }
+            fclose(fd);
+        }
+    }
+
+    // Tape image which we can read name from
+    if (strendswith(filename, "t64"))
+    {
+        FILE* fd = fopen(filename, "rb");
+
+        if (fd != NULL)
+        {
+            if (fseek(fd, T64_NAME_POS, SEEK_SET) == 0
+                && fread(label, T64_NAME_LEN, 1, fd) == 1)
+            {
+                label[T64_NAME_LEN] = '\0';
+                have_tape_label = true;
+            }
+            fclose(fd);
+        }
+    }
+
+    // Nothing found
+    if (!have_disk_label && !have_tape_label)
+        return NULL;
+
+    // Special processing for disk label - sanity check and trimming
+    if (have_disk_label)
+    {
+#if !defined(DISK_LABEL_RELAXED)
+        // Chack if all characters in disk name and padding areas look valid
+        // that may be too picky, but it's better to show nothing than garbage
+        for (i = 0; i < D64_FULL_NAME_LEN; ++i)
+        {
+            unsigned char c = label[i];
+            if (c != PETSCII_NBSP && (c < PETSCII_SPACE || c > PETSCII_SHIFTED_Z))
+            {
+                return NULL;
+            }
+        }
+#endif
+        label[D64_NAME_LEN - 1] = '\0';
+    }
+
+    // Remove trailing spaces
+    i = strlen((char*)label) - 1;
+    while (i > 0 && (label[i] == PETSCII_NBSP || label[i] == PETSCII_SPACE))
+        label[i--] = '\0';
+
+    // Replace other nbsp with spaces
+    while (i > 0)
+    {
+        if (label[i] == PETSCII_NBSP)
+            label[i] = ' ';
+        --i;
+    }
+
+    // Check for shifted chars
+    for (i=0; label[i] != '\0'; ++i)
+    {
+        unsigned char c = label[i];
+        if (c >= PETSCII_SHIFTED_A)
+        {
+#if defined(DISK_LABEL_FORBID_SHIFTED)
+            return NULL;
+#endif
+            // Have shifted chars
+            have_shifted = true;
+            break;
+        }
+    }
+
+    int mode = disk_label_mode;
+    if (have_shifted 
+        && (mode == DISK_LABEL_MODE_ASCII_OR_UPPERCASE || mode == DISK_LABEL_MODE_ASCII_OR_CAMELCASE))
+    {
+        mode = DISK_LABEL_MODE_ASCII;
+    }
+
+    bool was_space = true;
+    // Convert petscii to ascii
+    for (i=0; label[i] != '\0'; ++i)
+    {
+        unsigned char c = label[i];
+        if (c == PETSCII_SPACE)
+        {
+            was_space = true;
+        }
+        else
+        {
+            if (c >= PETSCII_UNSHIFTED_A && c <= PETSCII_UNSHIFTED_Z)
+            {
+                // Unshifted - starts as uppercase, toggles to lowercase
+                if (mode == DISK_LABEL_MODE_ASCII || mode == DISK_LABEL_MODE_LOWERCASE
+                    || (mode == DISK_LABEL_MODE_ASCII_OR_CAMELCASE && !was_space))
+                {
+                    label[i] = c ^ PETSCII_SHIFTED_BIT;
+                }
+            }
+            else if (c >= PETSCII_SHIFTED_A && c <= PETSCII_SHIFTED_Z)
+            {
+                // Shifted - starts as lowercase, toggles to uppercase
+                if (mode == DISK_LABEL_MODE_ASCII || mode == DISK_LABEL_MODE_UPPERCASE)
+                {
+                    label[i] = c ^ PETSCII_SHIFTED_BIT;
+                }
+            }
+            was_space = false;
+        }
+    }
+
+    if (is_ugly((char*)label))
+    {
+        return NULL;
+    }
+
+    return strdup((char*)label);
+}
+
+// Search for image file relative to M3U
+// Allocates returned string
+static char* m3u_search_file(const char* basedir, const char* dskName)
+{
+    // If basedir was provided and path is relative, search relative to M3U file location
+    if (basedir != NULL && !path_is_absolute(dskName))
+    {
+        // Join basedir and dskName
+        char* dskPath = path_join_dup(basedir, dskName);
+
+        // Verify if this item is a relative filename (append it to the m3u path)
+        if (file_exists(dskPath))
+        {
+            // Return
+            return dskPath;
+        }
+        free(dskPath);
+    }
+
+    // Verify if this item is an absolute pathname (or the file is in working dir)
+    if (file_exists(dskName))
+    {
+        // Copy and return
+        return strdup(dskName);
+    }
+
+    // File not found
+    return NULL;
 }
 
 void dc_reset(dc_storage* dc)
 {
-	// Verify
-	if(dc == NULL)
-		return;
-	
-	// Clean the command
-	if(dc->command)
-	{
-		free(dc->command);
-		dc->command = NULL;
-	}
+    // Verify
+    if (dc == NULL)
+        return;
 
-	// Clean the struct
-	for(unsigned i=0; i < dc->count; i++)
-	{
-		free(dc->files[i]);
-		dc->files[i] = NULL;
-	}
-	dc->unit = 0;
-	dc->count = 0;
-	dc->index = -1;
-	dc->eject_state = true;
+    // Clean the command
+    free(dc->command);
+    dc->command = NULL;
+
+    // Clean the struct
+    for (unsigned i=0; i < dc->count; i++)
+    {
+        free(dc->files[i]);
+        dc->files[i] = NULL;
+        free(dc->labels[i]);
+        dc->labels[i] = NULL;
+    }
+
+    dc->unit = 0;
+    dc->count = 0;
+    dc->index = 0; // index should never be -1
+    dc->eject_state = true;
 }
 
 dc_storage* dc_create(void)
 {
-	// Initialize the struct
-	dc_storage* dc = NULL;
-	
-	if((dc = malloc(sizeof(dc_storage))) != NULL)
-	{
-		dc->unit = 0;
-		dc->count = 0;
-		dc->index = -1;
-		dc->eject_state = true;
-		dc->command = NULL;
-		for(int i = 0; i < DC_MAX_SIZE; i++)
-		{
-			dc->files[i] = NULL;
-		}
-	}
-	
-	return dc;
+    // Initialize the struct
+    dc_storage* dc = NULL;
+
+    if((dc = malloc(sizeof(dc_storage))) != NULL)
+    {
+        dc->unit = 0;
+        dc->count = 0;
+        dc->index = 0; // index should never be -1
+        dc->eject_state = true;
+        dc->command = NULL;
+        for(int i = 0; i < DC_MAX_SIZE; i++)
+        {
+            dc->files[i] = NULL;
+            dc->labels[i] = NULL;
+        }
+    }
+
+    return dc;
 }
 
-bool dc_add_file_int(dc_storage* dc, char* filename)
+bool dc_add_file_int(dc_storage* dc, char* filename, char* label)
 {
-	// Verify
-	if(filename == NULL)
-		return false;
+    // Verify
+    if (filename == NULL || dc == NULL || dc->count > DC_MAX_SIZE)
+    {
+        free(filename);
+        free(label);
 
-	if(dc == NULL)
-	{
-		free(filename);
-		return false;
-	}
+        return false;
+    }
 
-	// If max size is not
-	if(dc->count < DC_MAX_SIZE)
-	{
-		// Add the file
-		dc->count++;
-		dc->files[dc->count-1] = filename;
-		return true;
-	}
-	
-	free(filename);
-
-	return false;
+    // Add the file
+    dc->count++;
+    dc->files[dc->count-1] = filename;
+    dc->labels[dc->count-1] = label;
+    return true;
 }
 
 bool dc_add_file(dc_storage* dc, const char* filename)
 {
-	// Verify
-	if(dc == NULL)
-		return false;
+    // Verify
+    if (dc == NULL || filename == NULL)
+        return false;
 
-	if(filename == NULL)
-		return false;
-
-	// Copy and return
-	char* filename_int = calloc(strlen(filename) + 1, sizeof(char));
-	strcpy(filename_int, filename);
-	return dc_add_file_int(dc, filename_int);
+    // Copy and return
+    return dc_add_file_int(dc, strdup(filename), get_label(filename));
 }
 
 bool dc_remove_file(dc_storage* dc, int index)
 {
-	if (dc == NULL)
-		return false;
+    if (dc == NULL)
+        return false;
 
-	if (index >= dc->count)
-		return false;
+    if (index < 0 || index >= dc->count)
+        return false;
 
-	// Shift entries after index up
-	if (index != dc->count - 1)
-		memmove(dc->files + index, dc->files + index + 1, (dc->count - 1 - index) * sizeof(dc->files[0]));
+    // "If ptr is a null pointer, no action occurs"
+    free(dc->files[index]);
+    dc->files[index] = NULL;
+    free(dc->labels[index]);
+    dc->labels[index] = NULL;
 
-	dc->count--;
+    // Shift all entries after index one slot up
+    if (index != dc->count - 1)
+        memmove(dc->files + index, dc->files + index + 1, (dc->count - 1 - index) * sizeof(dc->files[0]));
 
-	return true;
+    dc->count--;
+
+    return true;
+}
+
+bool dc_replace_file(dc_storage* dc, int index, const char* filename)
+{
+    if (dc == NULL)
+        return false;
+
+    if (index < 0 || index >= dc->count)
+        return false;
+
+    // "If ptr is a null pointer, no action occurs"
+    free(dc->files[index]);
+    dc->files[index] = NULL;
+    free(dc->labels[index]);
+    dc->labels[index] = NULL;
+
+    if (filename == NULL)
+    {
+        dc_remove_file(dc, index);
+    }
+    else
+    {
+        dc->files[index] = strdup(filename);
+        dc->labels[index] = get_label(filename);
+    }
+
+    return true;
 }
 
 void dc_parse_list(dc_storage* dc, const char* list_file, bool is_vfl)
 {
-	// Verify
-	if(dc == NULL)
-		return;
-	
-	if(list_file == NULL)
-		return;
+    // Verify
+    if (dc == NULL)
+        return;
 
-	FILE* fp = NULL;
+    // Reset
+    dc_reset(dc);
 
-	// Try to open the file
-	if ((fp = fopen(list_file, "r")) == NULL)
-		return;
+    if (list_file == NULL)
+        return;
 
-	// Reset
-	dc_reset(dc);
-	
-	// Get the list base dir for resolving relative path
-	char* basedir = dirname_int(list_file);
-	
-	// Read the lines while there is line to read and we have enough space
-	char buffer[2048];
-	while ((dc->count <= DC_MAX_SIZE) && (fgets(buffer, sizeof(buffer), fp) != NULL))
-	{
-		char* string = trimwhitespace(buffer);
+    FILE* fp = NULL;
 
-		if (string[0] == '\0')
-			continue;
+    // Try to open the file
+    if ((fp = fopen(list_file, "r")) == NULL)
+    {
+        log_cb(RETRO_LOG_ERROR, "Failed to open list file %s\n", list_file);
+        return;
+    }
 
-		// If it's a m3u special key or a file
-		if (!is_vfl && strstartswith(string, M3U_SPECIAL_COMMAND))
-		{
-			dc->command = strright(string, strlen(string) - strlen(M3U_SPECIAL_COMMAND));
-		}
-		else if (is_vfl && strstartswith(string, VFL_UNIT_ENTRY))
-		{
-			int unit = strtol(string + strlen(VFL_UNIT_ENTRY), NULL, 10);
-			// VICE doesn't allow flip list for tape (unit 1),
-			// but let's not split hairs
-			if (unit != 1 && !(unit >= 8 && unit <= 11))
-			{
-				// Invalid unit number - just ignore the list
-				break;
-			}
-			if (dc->unit != 0 && dc->count != 0)
-			{
-				// VFL file could teoretically contain flip lists
-				// for multliple drives. Read only the first one.
-				break;
-			}
-			dc->unit = unit;
-		}
-		else if (!strstartswith(string, COMMENT))
-		{
-			// Search the file (absolute, relative to m3u)
-			char* filename;
-			if ((filename = m3u_search_file(basedir, string)) != NULL)
-			{
-				// Add the file to the struct
-				dc_add_file_int(dc, filename);
-			}
+    // Read the lines while there is line to read and we have enough space
+    char buffer[2048];
 
-		}
-	}
+    // Enforce standard compatibility to avoid invalid vfl files on the loose
+    if (is_vfl)
+    {
+        // Read and verify header
+        if (fgets(buffer, sizeof(buffer), fp) == NULL
+            || strncmp(buffer, flip_file_header, strlen(flip_file_header)) != 0)
+        {
+            log_cb(RETRO_LOG_ERROR, "File %s is not a fliplist file\n", list_file);
+            fclose(fp);
+            return;
+        }
+    }
 
-	// If it's vfl, we have to reverse it
-	if (is_vfl)
-	{
-		int idx = 0;
-		int ridx = dc->count - 1;
-		while (idx < ridx)
-		{
-			char* tmp = dc->files[idx];
-			dc->files[idx] = dc->files[ridx];
-			dc->files[ridx] = tmp;
-			++idx; --ridx;
-		}
-	}
+    // Get the list base dir for resolving relative path
+    char* basedir = dirname_int(list_file);
 
-	// If basedir was provided
-	if(basedir != NULL)
-		free(basedir);
+    // Label for the following file
+    char* label = NULL;
 
-	// Close the file 
-	fclose(fp);
+    while ((dc->count <= DC_MAX_SIZE) && (fgets(buffer, sizeof(buffer), fp) != NULL))
+    {
+        char* string = trimwhitespace(buffer);
+
+        if (string[0] == '\0')
+            continue;
+
+        // Is it a m3u special key? (#COMMAND:)
+        if (!is_vfl && strstartswith(string, M3U_SPECIAL_COMMAND))
+        {
+            dc->command = strright(string, strlen(string) - strlen(M3U_SPECIAL_COMMAND));
+        }
+        // Disk name / label (#LABEL:)
+        else if (!is_vfl && strstartswith(string, M3U_NONSTD_LABEL))
+        {
+            char* newlabel = trimwhitespace(buffer + strlen(M3U_NONSTD_LABEL));
+            free(label);
+            label = newlabel[0] ? strdup(newlabel) : NULL;
+        }
+        // Disk name / label - EXTM3U standard compiant (#EXTINF)
+        else if (!is_vfl && strstartswith(string, M3U_EXTSTD_LABEL))
+        {
+            // "Track" description should be following comma (https://en.wikipedia.org/wiki/M3U#Extended_M3U)
+            char* newlabel = strchr(buffer + strlen(M3U_EXTSTD_LABEL), ',');
+            if (newlabel)
+                newlabel = trimwhitespace(newlabel);
+            free(label);
+            label = (newlabel && newlabel[0]) ? strdup(newlabel) : NULL;
+        }
+        // VFL UNIT number (UNIT)
+        else if (is_vfl && strstartswith(string, VFL_UNIT_ENTRY))
+        {
+            int unit = strtol(string + strlen(VFL_UNIT_ENTRY), NULL, 10);
+            // VICE doesn't allow flip list for tape (unit 1),
+            // but let's not split hairs
+            if (unit != 1 && !(unit >= 8 && unit <= 11))
+            {
+                // Invalid unit number - just ignore the list
+                log_cb(RETRO_LOG_ERROR, "Invalid unit number %d in fliplist %s", unit, list_file);
+                break;
+            }
+            if (dc->unit != 0 && dc->unit != unit && dc->count != 0)
+            {
+                // VFL file could theoretically contain flip lists for multliple drives - read only the first one.
+                log_cb(RETRO_LOG_WARN, "Ignored entries for other unit(s) in fliplist %s", list_file);
+                break;
+            }
+            dc->unit = unit;
+        }
+        // Vice doesn't allow comments in vfl files - enforce the standard
+        // Not a comment
+        else if (is_vfl || string[0] != COMMENT)
+        {
+            // Search the file (absolute, relative to m3u)
+            char* filename;
+            if ((filename = m3u_search_file(basedir, string)) != NULL)
+            {
+                // Add the file to the struct
+                dc_add_file_int(dc, filename, label ? label : get_label(filename));
+                label = NULL;
+            }
+            else
+            {
+                log_cb(RETRO_LOG_WARN, "File %s from list %s not found\n", list_file);
+                // Throw away the label
+                free(label);
+                label = NULL;
+            }
+        }
+    }
+
+    // If it's vfl, we have to reverse it
+    if (is_vfl)
+    {
+        int idx = 0;
+        int ridx = dc->count - 1;
+        while (idx < ridx)
+        {
+            char* tmp = dc->files[idx];
+            dc->files[idx] = dc->files[ridx];
+            dc->files[ridx] = tmp;
+            tmp = dc->labels[idx];
+            dc->labels[idx] = dc->labels[ridx];
+            dc->labels[ridx] = tmp;
+            ++idx; --ridx;
+        }
+    }
+
+    free(basedir);
+    free(label);
+
+    // Close the file 
+    fclose(fp);
 }
 
 void dc_parse_m3u(dc_storage* dc, const char* m3u_file)
 {
-	dc_parse_list(dc, m3u_file, false);
+    dc_parse_list(dc, m3u_file, false);
 }
 
 void dc_parse_vfl(dc_storage* dc, const char* vfl_file)
 {
-	dc_parse_list(dc, vfl_file, true);
+    dc_parse_list(dc, vfl_file, true);
 }
 
 void dc_free(dc_storage* dc)
 {
-	// Clean the struct
-	dc_reset(dc);
-	free(dc);
-	dc = NULL;
-	return;
+    // Clean the struct
+    dc_reset(dc);
+    free(dc);
+    dc = NULL;
+    return;
 }

--- a/libretro/retro_disk_control.h
+++ b/libretro/retro_disk_control.h
@@ -21,13 +21,25 @@
 
 #include <stdbool.h>
 
+// See which looks best in most cases and tweak (or make configurable)
+#define DISK_LABEL_MODE_ASCII              1 // Convert to ascii - unshifted chars are lowercase
+#define DISK_LABEL_MODE_UPPERCASE          2 // All characters are always uppercase
+#define DISK_LABEL_MODE_LOWERCASE          3 // All characters are always lowercase
+#define DISK_LABEL_MODE_ASCII_OR_UPPERCASE 4 // If all chars are unshifted - convert to uppercase
+#define DISK_LABEL_MODE_ASCII_OR_CAMELCASE 5 // If all chars are unshifted - convert to camelcase
+#define DISK_LABEL_MODE_PETSCII            6 // Unmodified petscii codes - case is inverted
+
+extern int disk_label_mode;
+
 //*****************************************************************************
 // Disk control structure and functions
 #define DC_MAX_SIZE 20
 
-struct dc_storage{
+struct dc_storage
+{
 	char* command;
 	char* files[DC_MAX_SIZE];
+    char* labels[DC_MAX_SIZE];
 	unsigned unit;
 	unsigned count;
 	int index;
@@ -40,6 +52,8 @@ void dc_parse_m3u(dc_storage* dc, const char* m3u_file);
 void dc_parse_vfl(dc_storage* dc, const char* vfl_file);
 bool dc_add_file(dc_storage* dc, const char* filename);
 void dc_free(dc_storage* dc);
+void dc_reset(dc_storage* dc);
+bool dc_replace_file(dc_storage* dc, int index, const char* filename);
 bool dc_remove_file(dc_storage* dc, int index);
 
 #endif

--- a/libretro/retro_files.c
+++ b/libretro/retro_files.c
@@ -38,4 +38,16 @@ bool file_exists(const char *filename)
 void path_join(char* out, const char* basedir, const char* filename)
 {
 	snprintf(out, RETRO_PATH_MAX, "%s%s%s", basedir, RETRO_PATH_SEPARATOR, filename);
-}	
+}
+
+char* path_join_dup(const char* basedir, const char* filename)
+{
+    size_t dirlen = strlen(basedir);
+    size_t seplen = strlen(RETRO_PATH_SEPARATOR);
+    size_t filelen = strlen(filename);
+    char* result = (char*)malloc(dirlen + seplen + filelen + 1);
+    strcpy(result, basedir);
+    strcpy(result + dirlen, RETRO_PATH_SEPARATOR);
+    strcpy(result + dirlen + seplen, filename);
+    return result;
+}

--- a/libretro/retro_files.c
+++ b/libretro/retro_files.c
@@ -21,6 +21,7 @@
 #include <sys/stat.h> 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 // Verify if file exists
 bool file_exists(const char *filename)

--- a/libretro/retro_files.h
+++ b/libretro/retro_files.h
@@ -34,6 +34,7 @@
 #endif
 
 void path_join(char* out, const char* basedir, const char* filename);
+char* path_join_dup(const char* basedir, const char* filename);
 bool file_exists(const char *filename);
 
 #endif

--- a/vice/src/arch/libretro/main.c
+++ b/vice/src/arch/libretro/main.c
@@ -7,8 +7,7 @@
 
 int skel_main(int argc, char *argv[])
 {
-   main_program(argc, argv);
-   return(0);
+   return main_program(argc, argv);
 }
 
 void vice_main_exit()

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -148,81 +148,84 @@ int ui_init_finish(void)
    return 0;
 }
 
+extern int log_resources_set_int(const char *name, int value);
+extern int log_resources_set_string(const char *name, const char* value);
+
 int ui_init_finalize(void)
 {
    /* Sensible defaults */
-   resources_set_int("Mouse", 0);
-   resources_set_int("AutostartPrgMode", 1);
+   log_resources_set_int("Mouse", 0);
+   log_resources_set_int("AutostartPrgMode", 1);
 
 #if defined(__CBM2__) || defined(__PET__)
-   resources_set_int("CrtcFilter", 0);
-   resources_set_int("CrtcStretchVertical", 0);
+   log_resources_set_int("CrtcFilter", 0);
+   log_resources_set_int("CrtcStretchVertical", 0);
 #endif
 
    /* Core options */
-   if(RETROSTATUS==1) {
-      resources_set_int("SDLStatusbar", 1);
-   } else if(RETROSTATUS==0) {
-      resources_set_int("SDLStatusbar", 0);
+   if (RETROSTATUS==1) {
+      log_resources_set_int("SDLStatusbar", 1);
+   } else if (RETROSTATUS==0) {
+      log_resources_set_int("SDLStatusbar", 0);
    }
 
 #if defined(__VIC20__)
-   if(RETROEXTPAL==-1)resources_set_int("VICExternalPalette", 0);
+   if(RETROEXTPAL==-1) log_resources_set_int("VICExternalPalette", 0);
    else {
-      resources_set_int("VICExternalPalette", 1);
-      resources_set_string_sprintf("%sPaletteFile", RETROEXTPALNAME, "VIC");
+      log_resources_set_int("VICExternalPalette", 1);
+      log_resources_set_string("VICPaletteFile", RETROEXTPALNAME);
    }
 #elif defined(__PLUS4__)
-   if(RETROEXTPAL==-1)resources_set_int("TEDExternalPalette", 0);
+   if(RETROEXTPAL==-1) log_resources_set_int("TEDExternalPalette", 0);
    else {
-      resources_set_int("TEDExternalPalette", 1);
-      resources_set_string_sprintf("%sPaletteFile", RETROEXTPALNAME, "TED");
+      log_resources_set_int("TEDExternalPalette", 1);
+      log_resources_set_string("TEDPaletteFile", RETROEXTPALNAME);
    }
 #elif defined(__PET__)
-   if(RETROEXTPAL==-1)resources_set_int("CrtcExternalPalette", 0);
+   if(RETROEXTPAL==-1) log_resources_set_int("CrtcExternalPalette", 0);
    else {
-      resources_set_int("CrtcExternalPalette", 1);
-      resources_set_string_sprintf("%sPaletteFile", RETROEXTPALNAME, "Crtc");
+      log_resources_set_int("CrtcExternalPalette", 1);
+      log_resources_set_string("CrtcPaletteFile", RETROEXTPALNAME);
    }
 #elif defined(__CBM2__)
-   if(RETROEXTPAL==-1)resources_set_int("CrtcExternalPalette", 0);
+   if(RETROEXTPAL==-1) log_resources_set_int("CrtcExternalPalette", 0);
    else {
-      resources_set_int("CrtcExternalPalette", 1);
-      resources_set_string_sprintf("%sPaletteFile", RETROEXTPALNAME, "Crtc");
+      log_resources_set_int("CrtcExternalPalette", 1);
+      log_resources_set_string("CrtcPaletteFile", RETROEXTPALNAME);
    }
 #else
-   if(RETROEXTPAL==-1)resources_set_int("VICIIExternalPalette", 0);
+   if(RETROEXTPAL==-1) log_resources_set_int("VICIIExternalPalette", 0);
    else {
-      resources_set_int("VICIIExternalPalette", 1);
-      resources_set_string_sprintf("%sPaletteFile", RETROEXTPALNAME, "VICII");
+      log_resources_set_int("VICIIExternalPalette", 1);
+      log_resources_set_string("VICIIPaletteFile", RETROEXTPALNAME);
    }
 #endif
 
-   if(RETROUSERPORTJOY==-1)resources_set_int("UserportJoy", 0);
+   if(RETROUSERPORTJOY==-1) log_resources_set_int("UserportJoy", 0);
    else {
-      resources_set_int("UserportJoy", 1);
-      resources_set_int("UserportJoyType", RETROUSERPORTJOY);
+      log_resources_set_int("UserportJoy", 1);
+      log_resources_set_int("UserportJoyType", RETROUSERPORTJOY);
    }
 
-   if(RETROTDE==1){
-      resources_set_int("DriveTrueEmulation", 1);
-      resources_set_int("VirtualDevices", 0);
+   if (RETROTDE==1) {
+      log_resources_set_int("DriveTrueEmulation", 1);
+      log_resources_set_int("VirtualDevices", 0);
    }
-   else if(RETROTDE==0){
-      resources_set_int("DriveTrueEmulation", 0);
-      resources_set_int("VirtualDevices", 1);
+   else if (RETROTDE==0) {
+      log_resources_set_int("DriveTrueEmulation", 0);
+      log_resources_set_int("VirtualDevices", 1);
    }
 
-   if(RETRODSE>0) {
-      resources_set_int("DriveSoundEmulation", 1);
-      resources_set_int("DriveSoundEmulationVolume", RETRODSE);
+   if (RETRODSE>0) {
+      log_resources_set_int("DriveSoundEmulation", 1);
+      log_resources_set_int("DriveSoundEmulationVolume", RETRODSE);
    } else
-      resources_set_int("DriveSoundEmulation", 0);
+      log_resources_set_int("DriveSoundEmulation", 0);
 
-   resources_set_int("AutostartWarp", RETROAUTOSTARTWARP);
+   log_resources_set_int("AutostartWarp", RETROAUTOSTARTWARP);
 
    sid_set_engine_model((RETROSIDMODL >> 8),  (RETROSIDMODL & 0xff));
-   resources_set_int("SidResidSampling", RETRORESIDSAMPLING);
+   log_resources_set_int("SidResidSampling", RETRORESIDSAMPLING);
 
 #if defined(__VIC20__) 
    vic20model_set(RETROC64MODL);
@@ -242,11 +245,11 @@ int ui_init_finalize(void)
 
 #if !defined(__PET__) && !defined(__CBM2__)
 #if defined(__VIC20__)
-   resources_set_int("VICBorderMode", RETROBORDERS);
+   log_resources_set_int("VICBorderMode", RETROBORDERS);
 #elif defined(__PLUS4__)
-   resources_set_int("TEDBorderMode", RETROBORDERS);
+   log_resources_set_int("TEDBorderMode", RETROBORDERS);
 #else
-   resources_set_int("VICIIBorderMode", RETROBORDERS);
+   log_resources_set_int("VICIIBorderMode", RETROBORDERS);
 #endif
 #endif
 

--- a/vice/src/initcmdline.c
+++ b/vice/src/initcmdline.c
@@ -48,6 +48,7 @@
 #include "tape.h"
 #include "util.h"
 #include "vicefeatures.h"
+#include "monitor.h"
 
 #ifdef DEBUG_CMDLINE
 #define DBG(x)  printf x
@@ -382,4 +383,25 @@ void initcmdline_check_attach(void)
 #ifndef __LIBRETRO__
     cmdline_free_autostart_string();
 #endif
+}
+
+int initcmdline_restart(int argc, char **argv)
+{
+    cmdline_free_autostart_string();
+
+    tape_image_detach(1);
+    file_system_detach_disk(8);
+    file_system_detach_disk(9);
+    file_system_detach_disk(10);
+    file_system_detach_disk(11);
+    if (mon_cart_cmd.cartridge_detach_image != NULL) {
+        (mon_cart_cmd.cartridge_detach_image)(-1);
+    }
+
+    if (initcmdline_check_args(argc, argv) == -1) {
+        return -1;
+    }
+
+    initcmdline_check_attach();
+    return 0;
 }

--- a/vice/src/initcmdline.c
+++ b/vice/src/initcmdline.c
@@ -65,6 +65,11 @@ int cmdline_get_autostart_mode(void)
     return autostart_mode;
 }
 
+const char* cmdline_get_autostart_string(void)
+{
+    return autostart_string;
+}
+
 static void cmdline_free_autostart_string(void)
 {
     lib_free(autostart_string);
@@ -373,5 +378,8 @@ void initcmdline_check_attach(void)
         }
     }
 
+    // Keep autostart string for libretro-core
+#ifndef __LIBRETRO__
     cmdline_free_autostart_string();
+#endif
 }

--- a/vice/src/initcmdline.h
+++ b/vice/src/initcmdline.h
@@ -32,5 +32,6 @@ extern int initcmdline_check_psid(void);
 extern int initcmdline_check_args(int argc, char **argv);
 extern void initcmdline_check_attach(void);
 extern int cmdline_get_autostart_mode(void);
+extern const char* cmdline_get_autostart_string(void);
 
 #endif

--- a/vice/src/initcmdline.h
+++ b/vice/src/initcmdline.h
@@ -33,5 +33,6 @@ extern int initcmdline_check_args(int argc, char **argv);
 extern void initcmdline_check_attach(void);
 extern int cmdline_get_autostart_mode(void);
 extern const char* cmdline_get_autostart_string(void);
+extern int initcmdline_restart(int argc, char **argv);
 
 #endif

--- a/vice/src/video/video-resources.c
+++ b/vice/src/video/video-resources.c
@@ -99,6 +99,8 @@ typedef struct video_resource_chip_mode_s video_resource_chip_mode_t;
 
 static int set_double_size_enabled(int value, void *param)
 {
+    // Don't allow double size mode - it won't work
+#ifndef __LIBRETRO__
     cap_render_t *cap_render;
     video_canvas_t *canvas = (video_canvas_t *)param;
     int old_scalex, old_scaley;
@@ -149,6 +151,7 @@ static int set_double_size_enabled(int value, void *param)
     }
 
     canvas->videoconfig->double_size_enabled = val;
+#endif
     return 0;
 }
 


### PR DESCRIPTION
This reverts commit cd528814507c9fa772c810d8f171776a7f21baa6.
This reverts commit f8be12c0cad25609bb80c9bb35fd355ce3297c16.

- Reading vfl and m3u files specified in 'x64 ...' command line
- Reading vfl and m3u files specified in cmd file
- Executing #COMMAND from m3u file
- Displaying disk image name and possibly disk name on change
  instead of default retroarch message

Fixed since previous attempt:
- Crash if command line was empty
- Crash on insert/eject disk (and/or other operations) if image list was empty
- Deleting temporary file before it was closed