### PR TITLE
Saving and loading snapshots without temp files

### DIFF
--- a/vice/src/c128/c128-snapshot.c
+++ b/vice/src/c128/c128-snapshot.c
@@ -55,11 +55,11 @@
 #define SNAP_MAJOR        0
 #define SNAP_MINOR        0
 
-int c128_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+int c128_snapshot_write_to_stream(snapshot_stream_t *stream, int save_roms, int save_disks, int event_mode)
 {
     snapshot_t *s;
 
-    s = snapshot_create(name, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)), SNAP_MACHINE_NAME);
+    s = snapshot_create_from_stream(stream, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)), SNAP_MACHINE_NAME);
     if (s == NULL) {
         return -1;
     }
@@ -79,21 +79,36 @@ int c128_snapshot_write(const char *name, int save_roms, int save_disks, int eve
         || joyport_snapshot_write_module(s, JOYPORT_1) < 0
         || joyport_snapshot_write_module(s, JOYPORT_2) < 0
         || userport_snapshot_write_module(s) < 0) {
-        snapshot_close(s);
-        ioutil_remove(name);
+        snapshot_free(s);
         return -1;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
     return 0;
 }
 
-int c128_snapshot_read(const char *name, int event_mode)
+int c128_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_write_fopen(name);
+    res = c128_snapshot_write_to_stream(stream, save_roms, save_disks, event_mode);
+    if (res) {
+        snapshot_fclose_erase(stream);
+    } else if (snapshot_fclose(stream) == EOF) {
+        snapshot_set_error(SNAPSHOT_WRITE_CLOSE_EOF_ERROR);
+        res = -1;
+    }
+    return res;
+}
+
+int c128_snapshot_read_from_stream(snapshot_stream_t *stream, int event_mode)
 {
     snapshot_t *s;
     uint8_t minor, major;
 
-    s = snapshot_open(name, &major, &minor, SNAP_MACHINE_NAME);
+    s = snapshot_open_from_stream(stream, &major, &minor, SNAP_MACHINE_NAME);
     if (s == NULL) {
         return -1;
     }
@@ -124,7 +139,7 @@ int c128_snapshot_read(const char *name, int event_mode)
         goto fail;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
 
     sound_snapshot_finish();
 
@@ -132,10 +147,21 @@ int c128_snapshot_read(const char *name, int event_mode)
 
 fail:
     if (s != NULL) {
-        snapshot_close(s);
+        snapshot_free(s);
     }
 
     machine_trigger_reset(MACHINE_RESET_MODE_SOFT);
 
     return -1;
+}
+
+int c128_snapshot_read(const char *name, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_read_fopen(name);
+    res = c128_snapshot_read_from_stream(stream, event_mode);
+    snapshot_fclose(stream);
+    return res;
 }

--- a/vice/src/c128/c128-snapshot.h
+++ b/vice/src/c128/c128-snapshot.h
@@ -27,6 +27,11 @@
 #ifndef VICE_C128SNAPSHOT_H
 #define VICE_C128SNAPSHOT_H
 
+struct snapshot_stream_s;
+extern int c128_snapshot_write_to_stream(struct snapshot_stream_s *stream, int save_roms,
+                                          int save_disks, int event_mode);
+extern int c128_snapshot_read_from_stream(struct snapshot_stream_s *stream, int event_mode);
+
 extern int c128_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode);
 extern int c128_snapshot_read(const char *name, int event_mode);
 

--- a/vice/src/c128/c128.c
+++ b/vice/src/c128/c128.c
@@ -1345,6 +1345,18 @@ void machine_change_timing(int timeval, int border_mode)
 
 /* ------------------------------------------------------------------------- */
 
+int machine_write_snapshot_to_stream(snapshot_stream_t *stream, int save_roms,
+                                     int save_disks, int event_mode)
+{
+    return c128_snapshot_write_to_stream(stream, save_roms, save_disks,
+                                         event_mode);
+}
+
+int machine_read_snapshot_from_stream(snapshot_stream_t *stream, int event_mode)
+{
+    return c128_snapshot_read_from_stream(stream, event_mode);
+}
+
 int machine_write_snapshot(const char *name, int save_roms, int save_disks, int event_mode)
 {
     return c128_snapshot_write(name, save_roms, save_disks, event_mode);

--- a/vice/src/c64/c64-snapshot.c
+++ b/vice/src/c64/c64-snapshot.c
@@ -56,11 +56,11 @@
 #define SNAP_MAJOR 1
 #define SNAP_MINOR 1
 
-int c64_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+int c64_snapshot_write_to_stream(snapshot_stream_t *stream, int save_roms, int save_disks, int event_mode)
 {
     snapshot_t *s;
 
-    s = snapshot_create(name, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)), machine_get_name());
+    s = snapshot_create_from_stream(stream, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)), machine_get_name());
     if (s == NULL) {
         return -1;
     }
@@ -85,21 +85,36 @@ int c64_snapshot_write(const char *name, int save_roms, int save_disks, int even
         || joyport_snapshot_write_module(s, JOYPORT_1) < 0
         || joyport_snapshot_write_module(s, JOYPORT_2) < 0
         || userport_snapshot_write_module(s) < 0) {
-        snapshot_close(s);
-        ioutil_remove(name);
+        snapshot_free(s);
         return -1;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
     return 0;
 }
 
-int c64_snapshot_read(const char *name, int event_mode)
+int c64_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_write_fopen(name);
+    res = c64_snapshot_write_to_stream(stream, save_roms, save_disks, event_mode);
+    if (res) {
+        snapshot_fclose_erase(stream);
+    } else if (snapshot_fclose(stream) == EOF) {
+        snapshot_set_error(SNAPSHOT_WRITE_CLOSE_EOF_ERROR);
+        res = -1;
+    }
+    return res;
+}
+
+int c64_snapshot_read_from_stream(snapshot_stream_t *stream, int event_mode)
 {
     snapshot_t *s;
     uint8_t minor, major;
 
-    s = snapshot_open(name, &major, &minor, machine_get_name());
+    s = snapshot_open_from_stream(stream, &major, &minor, machine_get_name());
     if (s == NULL) {
         return -1;
     }
@@ -132,7 +147,7 @@ int c64_snapshot_read(const char *name, int event_mode)
         goto fail;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
 
     sound_snapshot_finish();
 
@@ -140,10 +155,21 @@ int c64_snapshot_read(const char *name, int event_mode)
 
 fail:
     if (s != NULL) {
-        snapshot_close(s);
+        snapshot_free(s);
     }
 
     machine_trigger_reset(MACHINE_RESET_MODE_SOFT);
 
     return -1;
+}
+
+int c64_snapshot_read(const char *name, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_read_fopen(name);
+    res = c64_snapshot_read_from_stream(stream, event_mode);
+    snapshot_fclose(stream);
+    return res;
 }

--- a/vice/src/c64/c64-snapshot.h
+++ b/vice/src/c64/c64-snapshot.h
@@ -27,6 +27,12 @@
 #ifndef VICE_C64_SNAPSHOT_H
 #define VICE_C64_SNAPSHOT_H
 
+struct snapshot_stream_s;
+extern int c64_snapshot_write_to_stream(struct snapshot_stream_s *stream, int save_roms,
+                                        int save_disks, int event_mode);
+extern int c64_snapshot_read_from_stream(struct snapshot_stream_s *stream, int event_mode);
+
 extern int c64_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode);
 extern int c64_snapshot_read(const char *name, int event_mode);
+
 #endif

--- a/vice/src/c64/c64.c
+++ b/vice/src/c64/c64.c
@@ -1308,6 +1308,18 @@ void machine_change_timing(int timeval, int border_mode)
 
 /* ------------------------------------------------------------------------- */
 
+int machine_write_snapshot_to_stream(snapshot_stream_t *stream, int save_roms,
+                                     int save_disks, int event_mode)
+{
+    return c64_snapshot_write_to_stream(stream, save_roms, save_disks,
+                                        event_mode);
+}
+
+int machine_read_snapshot_from_stream(snapshot_stream_t *stream, int event_mode)
+{
+    return c64_snapshot_read_from_stream(stream, event_mode);
+}
+
 int machine_write_snapshot(const char *name, int save_roms, int save_disks, int event_mode)
 {
     return c64_snapshot_write(name, save_roms, save_disks, event_mode);

--- a/vice/src/c64/vsid-snapshot.c
+++ b/vice/src/c64/vsid-snapshot.c
@@ -54,11 +54,11 @@
 #define SNAP_MAJOR 1
 #define SNAP_MINOR 1
 
-int c64_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+int c64_snapshot_write_to_stream(snapshot_stream_t *stream, int save_roms, int save_disks, int event_mode)
 {
     snapshot_t *s;
 
-    s = snapshot_create(name, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)), machine_get_name());
+    s = snapshot_create_from_stream(stream, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)), machine_get_name());
     if (s == NULL) {
         return -1;
     }
@@ -77,21 +77,36 @@ int c64_snapshot_write(const char *name, int save_roms, int save_disks, int even
         || c64_glue_snapshot_write_module(s) < 0
         || event_snapshot_write_module(s, event_mode) < 0
         || keyboard_snapshot_write_module(s)) {
-        snapshot_close(s);
-        ioutil_remove(name);
+        snapshot_free(s);
         return -1;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
     return 0;
 }
 
-int c64_snapshot_read(const char *name, int event_mode)
+int c64_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_write_fopen(name);
+    res = c64_snapshot_write_to_stream(stream, save_roms, save_disks, event_mode);
+    if (res) {
+        snapshot_fclose_erase(stream);
+    } else if (snapshot_fclose(stream) == EOF) {
+        snapshot_set_error(SNAPSHOT_WRITE_CLOSE_EOF_ERROR);
+        res = -1;
+    }
+    return res;
+}
+
+int c64_snapshot_read_from_stream(snapshot_stream_t *stream, int event_mode)
 {
     snapshot_t *s;
     uint8_t minor, major;
 
-    s = snapshot_open(name, &major, &minor, machine_get_name());
+    s = snapshot_open_from_stream(stream, &major, &minor, machine_get_name());
     if (s == NULL) {
         return -1;
     }
@@ -116,7 +131,7 @@ int c64_snapshot_read(const char *name, int event_mode)
         goto fail;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
 
     sound_snapshot_finish();
 
@@ -124,10 +139,21 @@ int c64_snapshot_read(const char *name, int event_mode)
 
 fail:
     if (s != NULL) {
-        snapshot_close(s);
+        snapshot_free(s);
     }
 
     machine_trigger_reset(MACHINE_RESET_MODE_SOFT);
 
     return -1;
+}
+
+int c64_snapshot_read(const char *name, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_read_fopen(name);
+    res = c64_snapshot_read_from_stream(stream, event_mode);
+    snapshot_fclose(stream);
+    return res;
 }

--- a/vice/src/c64/vsid.c
+++ b/vice/src/c64/vsid.c
@@ -398,6 +398,18 @@ void machine_change_timing(int timeval, int border_mode)
 
 /* ------------------------------------------------------------------------- */
 
+int machine_write_snapshot_to_stream(snapshot_stream_t *stream, int save_roms,
+                                   int save_disks, int event_mode)
+{
+    return c64_snapshot_write_to_stream(stream, save_roms, save_disks,
+                                          event_mode);
+}
+
+int machine_read_snapshot_from_stream(snapshot_stream_t *stream, int event_mode)
+{
+    return c64_snapshot_read_from_stream(stream, event_mode);
+}
+
 int machine_write_snapshot(const char *name, int save_roms, int save_disks, int event_mode)
 {
     return c64_snapshot_write(name, save_roms, save_disks, event_mode);

--- a/vice/src/c64dtv/c64dtv-snapshot.c
+++ b/vice/src/c64dtv/c64dtv-snapshot.c
@@ -60,12 +60,12 @@
 #define SNAP_MAJOR 1
 #define SNAP_MINOR 1
 
-int c64dtv_snapshot_write(const char *name, int save_roms, int save_disks,
-                          int event_mode)
+int c64dtv_snapshot_write_to_stream(snapshot_stream_t *stream, int save_roms, int save_disks,
+                                    int event_mode)
 {
     snapshot_t *s;
 
-    s = snapshot_create(name, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)),
+    s = snapshot_create_from_stream(stream, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)),
                         machine_name);
     if (s == NULL) {
         return -1;
@@ -91,21 +91,36 @@ int c64dtv_snapshot_write(const char *name, int save_roms, int save_disks,
         || joyport_snapshot_write_module(s, JOYPORT_1) < 0
         || joyport_snapshot_write_module(s, JOYPORT_2) < 0
         || userport_snapshot_write_module(s) < 0) {
-        snapshot_close(s);
-        ioutil_remove(name);
+        snapshot_free(s);
         return -1;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
     return 0;
 }
 
-int c64dtv_snapshot_read(const char *name, int event_mode)
+int c64dtv_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_write_fopen(name);
+    res = c64dtv_snapshot_write_to_stream(stream, save_roms, save_disks, event_mode);
+    if (res) {
+        snapshot_fclose_erase(stream);
+    } else if (snapshot_fclose(stream) == EOF) {
+        snapshot_set_error(SNAPSHOT_WRITE_CLOSE_EOF_ERROR);
+        res = -1;
+    }
+    return res;
+}
+
+int c64dtv_snapshot_read_from_stream(snapshot_stream_t *stream, int event_mode)
 {
     snapshot_t *s;
     uint8_t minor, major;
 
-    s = snapshot_open(name, &major, &minor, machine_name);
+    s = snapshot_open_from_stream(stream, &major, &minor, machine_name);
     if (s == NULL) {
         return -1;
     }
@@ -138,7 +153,7 @@ int c64dtv_snapshot_read(const char *name, int event_mode)
         goto fail;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
 
     sound_snapshot_finish();
 
@@ -146,10 +161,21 @@ int c64dtv_snapshot_read(const char *name, int event_mode)
 
 fail:
     if (s != NULL) {
-        snapshot_close(s);
+        snapshot_free(s);
     }
 
     machine_trigger_reset(MACHINE_RESET_MODE_SOFT);
 
     return -1;
+}
+
+int c64dtv_snapshot_read(const char *name, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_read_fopen(name);
+    res = c64dtv_snapshot_read_from_stream(stream, event_mode);
+    snapshot_fclose(stream);
+    return res;
 }

--- a/vice/src/c64dtv/c64dtv-snapshot.h
+++ b/vice/src/c64dtv/c64dtv-snapshot.h
@@ -27,6 +27,11 @@
 #ifndef VICE_C64DTV_SNAPSHOT_H
 #define VICE_C64DTV_SNAPSHOT_H
 
+struct snapshot_stream_s;
+extern int c64dtv_snapshot_write_to_stream(struct snapshot_stream_s *stream, int save_roms,
+                                           int save_disks, int event_mode);
+extern int c64dtv_snapshot_read_from_stream(struct snapshot_stream_s *stream, int event_mode);
+
 extern int c64dtv_snapshot_write(const char *name, int save_roms, int save_disks,
                                  int event_mode);
 extern int c64dtv_snapshot_read(const char *name, int event_mode);

--- a/vice/src/c64dtv/c64dtv.c
+++ b/vice/src/c64dtv/c64dtv.c
@@ -869,6 +869,18 @@ void machine_change_timing(int timeval, int border_mode)
 
 /* ------------------------------------------------------------------------- */
 
+int machine_write_snapshot_to_stream(snapshot_stream_t *stream, int save_roms,
+                                   int save_disks, int event_mode)
+{
+    return c64dtv_snapshot_write_to_stream(stream, save_roms, save_disks,
+                                          event_mode);
+}
+
+int machine_read_snapshot_from_stream(snapshot_stream_t *stream, int event_mode)
+{
+    return c64dtv_snapshot_read_from_stream(stream, event_mode);
+}
+
 int machine_write_snapshot(const char *name, int save_roms, int save_disks,
                            int event_mode)
 {

--- a/vice/src/cbm2/cbm2-snapshot.c
+++ b/vice/src/cbm2/cbm2-snapshot.c
@@ -56,12 +56,12 @@
 #define SNAP_MAJOR          0
 #define SNAP_MINOR          0
 
-int cbm2_snapshot_write(const char *name, int save_roms, int save_disks,
-                        int event_mode)
+int cbm2_snapshot_write_to_stream(snapshot_stream_t *stream, int save_roms, int save_disks,
+                                  int event_mode)
 {
     snapshot_t *s;
 
-    s = snapshot_create(name, SNAP_MAJOR, SNAP_MINOR, machine_get_name());
+    s = snapshot_create_from_stream(stream, SNAP_MAJOR, SNAP_MINOR, machine_get_name());
 
     if (s == NULL) {
         return -1;
@@ -82,21 +82,36 @@ int cbm2_snapshot_write(const char *name, int save_roms, int save_disks,
         || tapeport_snapshot_write_module(s, save_disks) < 0
         || keyboard_snapshot_write_module(s) < 0
         || userport_snapshot_write_module(s) < 0) {
-        snapshot_close(s);
-        ioutil_remove(name);
+        snapshot_free(s);
         return -1;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
     return 0;
 }
 
-int cbm2_snapshot_read(const char *name, int event_mode)
+int cbm2_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_write_fopen(name);
+    res = cbm2_snapshot_write_to_stream(stream, save_roms, save_disks, event_mode);
+    if (res) {
+        snapshot_fclose_erase(stream);
+    } else if (snapshot_fclose(stream) == EOF) {
+        snapshot_set_error(SNAPSHOT_WRITE_CLOSE_EOF_ERROR);
+        res = -1;
+    }
+    return res;
+}
+
+int cbm2_snapshot_read_from_stream(snapshot_stream_t *stream, int event_mode)
 {
     snapshot_t *s;
     uint8_t minor, major;
 
-    s = snapshot_open(name, &major, &minor, machine_get_name());
+    s = snapshot_open_from_stream(stream, &major, &minor, machine_get_name());
 
     if (s == NULL) {
         return -1;
@@ -124,16 +139,28 @@ int cbm2_snapshot_read(const char *name, int event_mode)
         goto fail;
     }
 
+    snapshot_free(s);
     sound_snapshot_finish();
 
     return 0;
 
 fail:
     if (s != NULL) {
-        snapshot_close(s);
+        snapshot_free(s);
     }
 
     machine_trigger_reset(MACHINE_RESET_MODE_SOFT);
 
     return -1;
+}
+
+int cbm2_snapshot_read(const char *name, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_read_fopen(name);
+    res = cbm2_snapshot_read_from_stream(stream, event_mode);
+    snapshot_fclose(stream);
+    return res;
 }

--- a/vice/src/cbm2/cbm2-snapshot.h
+++ b/vice/src/cbm2/cbm2-snapshot.h
@@ -27,6 +27,11 @@
 #ifndef VICE_CBM2_SNAPSHOT_H
 #define VICE_CBM2_SNAPSHOT_H
 
+struct snapshot_stream_s;
+extern int cbm2_snapshot_write_to_stream(struct snapshot_stream_s *stream, int save_roms,
+                                          int save_disks, int event_mode);
+extern int cbm2_snapshot_read_from_stream(struct snapshot_stream_s *stream, int event_mode);
+
 extern int cbm2_snapshot_write(const char *name, int save_roms, int save_disks,
                                int event_mode);
 extern int cbm2_snapshot_read(const char *name, int event_mode);

--- a/vice/src/cbm2/cbm2.c
+++ b/vice/src/cbm2/cbm2.c
@@ -924,6 +924,18 @@ void machine_set_cycles_per_frame(long cpf)
 
 /* ------------------------------------------------------------------------- */
 
+int machine_write_snapshot_to_stream(snapshot_stream_t *stream, int save_roms,
+                                   int save_disks, int event_mode)
+{
+    return cbm2_snapshot_write_to_stream(stream, save_roms, save_disks,
+                                          event_mode);
+}
+
+int machine_read_snapshot_from_stream(snapshot_stream_t *stream, int event_mode)
+{
+    return cbm2_snapshot_read_from_stream(stream, event_mode);
+}
+
 int machine_write_snapshot(const char *name, int save_roms, int save_disks,
                            int event_mode)
 {

--- a/vice/src/cbm2/cbm5x0-snapshot.c
+++ b/vice/src/cbm2/cbm5x0-snapshot.c
@@ -56,12 +56,12 @@
 #define SNAP_MAJOR          0
 #define SNAP_MINOR          0
 
-int cbm2_snapshot_write(const char *name, int save_roms, int save_disks,
-                        int event_mode)
+int cbm2_snapshot_write_to_stream(snapshot_stream_t *stream, int save_roms, int save_disks,
+                                  int event_mode)
 {
     snapshot_t *s;
 
-    s = snapshot_create(name, SNAP_MAJOR, SNAP_MINOR, machine_get_name());
+    s = snapshot_create_from_stream(stream, SNAP_MAJOR, SNAP_MINOR, machine_get_name());
 
     if (s == NULL) {
         return -1;
@@ -84,21 +84,36 @@ int cbm2_snapshot_write(const char *name, int save_roms, int save_disks,
         || keyboard_snapshot_write_module(s) < 0
         || joyport_snapshot_write_module(s, JOYPORT_1) < 0
         || joyport_snapshot_write_module(s, JOYPORT_2) < 0) {
-        snapshot_close(s);
-        ioutil_remove(name);
+        snapshot_free(s);
         return -1;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
     return 0;
 }
 
-int cbm2_snapshot_read(const char *name, int event_mode)
+int cbm2_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_write_fopen(name);
+    res = cbm2_snapshot_write_to_stream(stream, save_roms, save_disks, event_mode);
+    if (res) {
+        snapshot_fclose_erase(stream);
+    } else if (snapshot_fclose(stream) == EOF) {
+        snapshot_set_error(SNAPSHOT_WRITE_CLOSE_EOF_ERROR);
+        res = -1;
+    }
+    return res;
+}
+
+int cbm2_snapshot_read_from_stream(snapshot_stream_t *stream, int event_mode)
 {
     snapshot_t *s;
     uint8_t minor, major;
 
-    s = snapshot_open(name, &major, &minor, machine_get_name());
+    s = snapshot_open_from_stream(stream, &major, &minor, machine_get_name());
 
     if (s == NULL) {
         return -1;
@@ -132,16 +147,29 @@ int cbm2_snapshot_read(const char *name, int event_mode)
         goto fail;
     }
 
+    snapshot_free(s);
+
     sound_snapshot_finish();
 
     return 0;
 
 fail:
     if (s != NULL) {
-        snapshot_close(s);
+        snapshot_free(s);
     }
 
     machine_trigger_reset(MACHINE_RESET_MODE_SOFT);
 
     return -1;
+}
+
+int cbm2_snapshot_read(const char *name, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_read_fopen(name);
+    res = cbm2_snapshot_read_from_stream(stream, event_mode);
+    snapshot_fclose(stream);
+    return res;
 }

--- a/vice/src/cbm2/cbm5x0.c
+++ b/vice/src/cbm2/cbm5x0.c
@@ -901,6 +901,18 @@ void machine_set_cycles_per_frame(long cpf)
 
 /* ------------------------------------------------------------------------- */
 
+int machine_write_snapshot_to_stream(snapshot_stream_t *stream, int save_roms,
+                                     int save_disks, int event_mode)
+{
+    return cbm2_snapshot_write_to_stream(stream, save_roms, save_disks,
+                                          event_mode);
+}
+
+int machine_read_snapshot_from_stream(snapshot_stream_t *stream, int event_mode)
+{
+    return cbm2_snapshot_read_from_stream(stream, event_mode);
+}
+
 int machine_write_snapshot(const char *name, int save_roms, int save_disks,
                            int event_mode)
 {

--- a/vice/src/machine.h
+++ b/vice/src/machine.h
@@ -135,6 +135,15 @@ extern void machine_set_cycles_per_frame(long cpf);
 /* Get current line and cycle. */
 extern void machine_get_line_cycle(unsigned int *line, unsigned int *cycle, int *half_cycle);
 
+struct snapshot_stream_s;
+
+/* Write a snapshot to stream (file or memory).  */
+extern int machine_write_snapshot_to_stream(struct snapshot_stream_s *stream, int save_roms, int save_disks,
+                                   int event_mode);
+
+/* Read a snapshot from stream (file or memory).  */
+extern int machine_read_snapshot_from_stream(struct snapshot_stream_s *stream, int event_mode);
+
 /* Write a snapshot.  */
 extern int machine_write_snapshot(const char *name, int save_roms,
                                   int save_disks, int even_mode);

--- a/vice/src/pet/pet-snapshot.h
+++ b/vice/src/pet/pet-snapshot.h
@@ -27,6 +27,11 @@
 #ifndef VICE_PET_SNAPSHOT_H
 #define VICE_PET_SNAPSHOT_H
 
+struct snapshot_stream_s;
+extern int pet_snapshot_write_to_stream(struct snapshot_stream_s *stream, int save_roms,
+                                          int save_disks, int event_mode);
+extern int pet_snapshot_read_from_stream(struct snapshot_stream_s *stream, int event_mode);
+
 extern int pet_snapshot_write(const char *name, int save_roms, int save_disks,
                               int event_mode);
 extern int pet_snapshot_read(const char *name, int event_mode);

--- a/vice/src/pet/pet.c
+++ b/vice/src/pet/pet.c
@@ -881,6 +881,18 @@ void machine_set_cycles_per_frame(long cpf)
 
 /* ------------------------------------------------------------------------- */
 
+int machine_write_snapshot_to_stream(snapshot_stream_t *stream, int save_roms,
+                                   int save_disks, int event_mode)
+{
+    return pet_snapshot_write_to_stream(stream, save_roms, save_disks,
+                                        event_mode);
+}
+
+int machine_read_snapshot_from_stream(snapshot_stream_t *stream, int event_mode)
+{
+    return pet_snapshot_read_from_stream(stream, event_mode);
+}
+
 int machine_write_snapshot(const char *name, int save_roms, int save_disks,
                            int event_mode)
 {

--- a/vice/src/plus4/plus4-snapshot.h
+++ b/vice/src/plus4/plus4-snapshot.h
@@ -27,6 +27,11 @@
 #ifndef VICE_PLUS4_SNAPSHOT_H
 #define VICE_PLUS4_SNAPSHOT_H
 
+struct snapshot_stream_s;
+extern int plus4_snapshot_write_to_stream(struct snapshot_stream_s *stream, int save_roms,
+                                          int save_disks, int event_mode);
+extern int plus4_snapshot_read_from_stream(struct snapshot_stream_s *stream, int event_mode);
+
 extern int plus4_snapshot_write(const char *name, int save_roms, int save_disks,
                                 int event_mode);
 extern int plus4_snapshot_read(const char *name, int event_mode);

--- a/vice/src/plus4/plus4.c
+++ b/vice/src/plus4/plus4.c
@@ -1018,6 +1018,18 @@ void machine_change_timing(int timeval, int border_mode)
 
 /* ------------------------------------------------------------------------- */
 
+int machine_write_snapshot_to_stream(snapshot_stream_t *stream, int save_roms,
+                                   int save_disks, int event_mode)
+{
+    return plus4_snapshot_write_to_stream(stream, save_roms, save_disks,
+                                          event_mode);
+}
+
+int machine_read_snapshot_from_stream(snapshot_stream_t *stream, int event_mode)
+{
+    return plus4_snapshot_read_from_stream(stream, event_mode);
+}
+
 int machine_write_snapshot(const char *name, int save_roms, int save_disks,
                            int event_mode)
 {

--- a/vice/src/scpu64/scpu64-snapshot.c
+++ b/vice/src/scpu64/scpu64-snapshot.c
@@ -56,11 +56,11 @@
 #define SNAP_MAJOR 1
 #define SNAP_MINOR 1
 
-int scpu64_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+int scpu64_snapshot_write_to_stream(snapshot_stream_t *stream, int save_roms, int save_disks, int event_mode)
 {
     snapshot_t *s;
 
-    s = snapshot_create(name, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)), machine_get_name());
+    s = snapshot_create_from_stream(stream, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)), machine_get_name());
     if (s == NULL) {
         return -1;
     }
@@ -83,21 +83,36 @@ int scpu64_snapshot_write(const char *name, int save_roms, int save_disks, int e
         || joyport_snapshot_write_module(s, JOYPORT_1) < 0
         || joyport_snapshot_write_module(s, JOYPORT_2) < 0
         || userport_snapshot_write_module(s) < 0) {
-        snapshot_close(s);
-        ioutil_remove(name);
+        snapshot_free(s);
         return -1;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
     return 0;
 }
 
-int scpu64_snapshot_read(const char *name, int event_mode)
+int scpu64_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_write_fopen(name);
+    res = scpu64_snapshot_write_to_stream(stream, save_roms, save_disks, event_mode);
+    if (res) {
+        snapshot_fclose_erase(stream);
+    } else if (snapshot_fclose(stream) == EOF) {
+        snapshot_set_error(SNAPSHOT_WRITE_CLOSE_EOF_ERROR);
+        res = -1;
+    }
+    return res;
+}
+
+int scpu64_snapshot_read_from_stream(snapshot_stream_t *stream, int event_mode)
 {
     snapshot_t *s;
     uint8_t minor, major;
 
-    s = snapshot_open(name, &major, &minor, machine_get_name());
+    s = snapshot_open_from_stream(stream, &major, &minor, machine_get_name());
     if (s == NULL) {
         return -1;
     }
@@ -128,7 +143,7 @@ int scpu64_snapshot_read(const char *name, int event_mode)
         goto fail;
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
 
     sound_snapshot_finish();
 
@@ -136,10 +151,21 @@ int scpu64_snapshot_read(const char *name, int event_mode)
 
 fail:
     if (s != NULL) {
-        snapshot_close(s);
+        snapshot_free(s);
     }
 
     machine_trigger_reset(MACHINE_RESET_MODE_SOFT);
 
     return -1;
+}
+
+int scpu64_snapshot_read(const char *name, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_read_fopen(name);
+    res = scpu64_snapshot_read_from_stream(stream, event_mode);
+    snapshot_fclose(stream);
+    return res;
 }

--- a/vice/src/scpu64/scpu64-snapshot.h
+++ b/vice/src/scpu64/scpu64-snapshot.h
@@ -28,6 +28,12 @@
 #ifndef VICE_SCPU64_SNAPSHOT_H
 #define VICE_SCPU64_SNAPSHOT_H
 
+struct snapshot_stream_s;
+extern int scpu64_snapshot_write_to_stream(struct snapshot_stream_s *stream, int save_roms,
+                                           int save_disks, int event_mode);
+extern int scpu64_snapshot_read_from_stream(struct snapshot_stream_s *stream, int event_mode);
+
 extern int scpu64_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode);
 extern int scpu64_snapshot_read(const char *name, int event_mode);
+
 #endif

--- a/vice/src/scpu64/scpu64.c
+++ b/vice/src/scpu64/scpu64.c
@@ -1113,6 +1113,18 @@ void machine_change_timing(int timeval, int border_mode)
 
 /* ------------------------------------------------------------------------- */
 
+int machine_write_snapshot_to_stream(snapshot_stream_t *stream, int save_roms,
+                                     int save_disks, int event_mode)
+{
+    return scpu64_snapshot_write_to_stream(stream, save_roms, save_disks,
+                                          event_mode);
+}
+
+int machine_read_snapshot_from_stream(snapshot_stream_t *stream, int event_mode)
+{
+    return scpu64_snapshot_read_from_stream(stream, event_mode);
+}
+
 int machine_write_snapshot(const char *name, int save_roms, int save_disks, int event_mode)
 {
     return scpu64_snapshot_write(name, save_roms, save_disks, event_mode);

--- a/vice/src/snapshot.c
+++ b/vice/src/snapshot.c
@@ -45,6 +45,17 @@
 #include "vsync.h"
 #include "zfile.h"
 
+#ifndef offsetof
+#define offsetof(type, member) ((size_t)((char*)&(((type*)0)->member) - (char*)0))
+#endif
+
+#ifndef container_of
+#define container_of(ptr, type, member) ((type*)((char*)(ptr) - offsetof(type, member)))
+#endif
+
+typedef struct snapshot_file_stream_s snapshot_file_stream_t;
+typedef struct snapshot_memory_stream_s snapshot_memory_stream_t;
+
 static int snapshot_error = SNAPSHOT_NO_ERROR;
 static char *current_module = NULL;
 static char read_name[SNAPSHOT_MACHINE_NAME_LEN];
@@ -57,9 +68,73 @@ char snapshot_version_magic_string[] = "VICE Version\032";
 #define SNAPSHOT_MAGIC_LEN              19
 #define SNAPSHOT_VERSION_MAGIC_LEN      13
 
+/* Stream operations interface */
+struct snapshot_stream_ops_s {
+
+    /* Read stream */
+    size_t      (*read)(snapshot_stream_t* stream, void* ptr, size_t size);
+
+    /* Write stream */
+    size_t      (*write)(snapshot_stream_t* stream, const void* ptr, size_t size);
+
+    /* Get stream position */
+    long        (*tell)(snapshot_stream_t* stream);
+
+    /* Set stream position */
+    int         (*seek)(snapshot_stream_t* stream, long offset, int whence);
+
+    /* Close stream */
+    int         (*close)(snapshot_stream_t* stream);
+
+    /* Close stream and erase file */
+    int         (*close_erase)(snapshot_stream_t* stream);
+
+    /* Get filename or counterpart for logging */
+    const char* (*filename)(snapshot_stream_t* stream);
+};
+
+/* Stream base */
+struct snapshot_stream_s {
+    /* Operations */
+    struct snapshot_stream_ops_s *ops;
+};
+
+/* FILE based stream */
+struct snapshot_file_stream_s {
+    /* Operations interface */
+    snapshot_stream_t istream;
+
+    /* File descriptor */
+    FILE* file;
+
+    /* File name */
+    char* filename;
+};
+
+/* Memory based stream */
+struct snapshot_memory_stream_s {
+    /* Operations interface */
+    snapshot_stream_t istream;
+
+    /* Flag: are we writing it?  */
+    int write_mode;
+
+    /* Memory buffer */
+    uint8_t* buffer;
+
+    /* Memory buffer size */
+    size_t buffer_size;
+
+    /* Stream pointer */
+    long pointer;
+
+    /* Stream size */
+    size_t stream_size;
+};
+
 struct snapshot_module_s {
-    /* File descriptor.  */
-    FILE *file;
+    /* Snapshot stream */
+    snapshot_stream_t* file;
 
     /* Flag: are we writing it?  */
     int write_mode;
@@ -75,8 +150,8 @@ struct snapshot_module_s {
 };
 
 struct snapshot_s {
-    /* File descriptor.  */
-    FILE *file;
+    /* Snapshot stream */
+    snapshot_stream_t* file;
 
     /* Offset of the first module.  */
     long first_module_offset;
@@ -86,10 +161,347 @@ struct snapshot_s {
 };
 
 /* ------------------------------------------------------------------------- */
+/* FILE based stream */
 
-static int snapshot_write_byte(FILE *f, uint8_t data)
+static size_t snapshot_file_read(snapshot_stream_t* f, void* ptr, size_t size)
 {
-    if (fputc(data, f) == EOF) {
+    snapshot_file_stream_t* file_stream = container_of(f, snapshot_file_stream_t, istream);
+    return fread(ptr, size, 1, file_stream->file);
+}
+
+static size_t snapshot_file_write(snapshot_stream_t* f, const void* ptr, size_t size)
+{
+    snapshot_file_stream_t* file_stream = container_of(f, snapshot_file_stream_t, istream);
+    return fwrite(ptr, size, 1, file_stream->file);
+}
+
+static long snapshot_file_ftell(snapshot_stream_t* f)
+{
+    snapshot_file_stream_t* file_stream = container_of(f, snapshot_file_stream_t, istream);
+    return ftell(file_stream->file);
+}
+
+static int snapshot_file_fseek(snapshot_stream_t *f, long offset, int whence)
+{
+    snapshot_file_stream_t* file_stream = container_of(f, snapshot_file_stream_t, istream);
+    return fseek(file_stream->file, offset, whence);
+}
+
+static int snapshot_file_fclose(snapshot_stream_t *f)
+{
+    snapshot_file_stream_t* file_stream = container_of(f, snapshot_file_stream_t, istream);
+    int res = fclose(file_stream->file);
+    lib_free(file_stream->filename);
+    lib_free(file_stream);
+    return res;
+}
+
+static int snapshot_file_fclose_erase(snapshot_stream_t *f)
+{
+    snapshot_file_stream_t* file_stream = container_of(f, snapshot_file_stream_t, istream);
+    int res = fclose(file_stream->file);
+    ioutil_remove(file_stream->filename);
+    lib_free(file_stream->filename);
+    lib_free(file_stream);
+    return res;
+}
+
+static const char* snapshot_file_filename(snapshot_stream_t *f)
+{
+    snapshot_file_stream_t* file_stream = container_of(f, snapshot_file_stream_t, istream);
+    return file_stream->filename;
+}
+
+static int snapshot_zfile_fclose(snapshot_stream_t *f)
+{
+    snapshot_file_stream_t* file_stream = container_of(f, snapshot_file_stream_t, istream);
+    int res = zfile_fclose(file_stream->file);
+    lib_free(file_stream->filename);
+    lib_free(file_stream);
+    return res;
+}
+
+static int snapshot_zfile_fclose_erase(snapshot_stream_t *f)
+{
+    snapshot_file_stream_t* file_stream = container_of(f, snapshot_file_stream_t, istream);
+    int res = zfile_fclose(file_stream->file);
+    ioutil_remove(file_stream->filename);
+    lib_free(file_stream->filename);
+    lib_free(file_stream);
+    return res;
+}
+
+static struct snapshot_stream_ops_s snapshot_file_ops = {
+    /* read */ snapshot_file_read,
+    /* write */ snapshot_file_write,
+    /* tell */ snapshot_file_ftell,
+    /* seek */ snapshot_file_fseek,
+    /* close */ snapshot_file_fclose,
+    /* close_erase */ snapshot_file_fclose_erase,
+    /* filename */ snapshot_file_filename
+};
+
+snapshot_stream_t* snapshot_file_fopen(const char* pathname, const char* mode)
+{
+    snapshot_file_stream_t* stream = lib_malloc(sizeof(snapshot_file_stream_t));
+
+    lib_free(current_filename);
+    current_filename = lib_stralloc(pathname);
+
+    if (stream == NULL) {
+        goto fail;
+    }
+
+    stream->filename = lib_stralloc(pathname);
+    if (stream->filename == NULL) {
+        goto delete_stream;
+    }
+
+    stream->file = fopen(pathname, mode);
+    if (stream->file == NULL) {
+        goto delete_filename;
+    }
+
+    stream->istream.ops = &snapshot_file_ops;
+    return &stream->istream;
+
+delete_filename:
+    lib_free(stream->filename);
+delete_stream:
+    lib_free(stream);
+fail:
+    return NULL;
+}
+
+snapshot_stream_t* snapshot_file_write_fopen(const char* pathname)
+{
+    return snapshot_file_fopen(pathname, MODE_WRITE);
+}
+
+static struct snapshot_stream_ops_s snapshot_zfile_ops = {
+    /* read */ snapshot_file_read,
+    /* write */ snapshot_file_write,
+    /* tell */ snapshot_file_ftell,
+    /* seek */ snapshot_file_fseek,
+    /* close */ snapshot_zfile_fclose,
+    /* close_erase */ snapshot_zfile_fclose_erase,
+    /* filename */ snapshot_file_filename
+};
+
+snapshot_stream_t* snapshot_zfile_fopen(const char* pathname, const char* mode)
+{
+    snapshot_file_stream_t* stream = lib_malloc(sizeof(snapshot_file_stream_t));
+
+    lib_free(current_filename);
+    current_filename = lib_stralloc(pathname);
+
+    if (stream == NULL) {
+        goto fail;
+    }
+
+    stream->filename = lib_stralloc(pathname);
+    if (stream->filename == NULL) {
+        goto delete_stream;
+    }
+
+    stream->file = zfile_fopen(pathname, mode);
+    if (stream->file == NULL) {
+        goto delete_filename;
+    }
+
+    stream->istream.ops = &snapshot_zfile_ops;
+    return &stream->istream;
+
+delete_filename:
+    lib_free(stream->filename);
+delete_stream:
+    lib_free(stream);
+fail:
+    return NULL;
+}
+
+snapshot_stream_t* snapshot_file_read_fopen(const char* pathname)
+{
+    return snapshot_zfile_fopen(pathname, MODE_READ);
+}
+
+
+/* ------------------------------------------------------------------------- */
+/* Memory based stream */
+
+static size_t snapshot_memory_read(snapshot_stream_t* f, void* ptr, size_t size)
+{
+    snapshot_memory_stream_t* stream = container_of(f, snapshot_memory_stream_t, istream);
+    long pointer = stream->pointer;
+    if (stream->buffer == NULL) {
+        return -1;
+    }
+
+    if (pointer + size > stream->stream_size) {
+        return -1;
+    }
+
+    memcpy(ptr, stream->buffer + pointer, size);
+    stream->pointer = pointer + size;
+    return 1;
+}
+
+static size_t snapshot_memory_write(snapshot_stream_t* f, const void* ptr, size_t size)
+{
+    snapshot_memory_stream_t* stream = container_of(f, snapshot_memory_stream_t, istream);
+    long pointer = stream->pointer;
+    if (stream->write_mode == 0) {
+        return -1;
+    }
+
+    if (stream->buffer != NULL) {
+        if (pointer + size > stream->buffer_size) {
+            return -1;
+        }
+
+        memcpy(stream->buffer + pointer, ptr, size);
+    }
+
+    stream->pointer = pointer + size;
+    if (stream->pointer > stream->stream_size) {
+        stream->stream_size = stream->pointer;
+    }
+
+    return 1;
+}
+
+static long snapshot_memory_ftell(snapshot_stream_t* f)
+{
+    snapshot_memory_stream_t* stream = container_of(f, snapshot_memory_stream_t, istream);
+    return stream->pointer;
+}
+
+static int snapshot_memory_fseek(snapshot_stream_t *f, long offset, int whence)
+{
+    snapshot_memory_stream_t* stream = container_of(f, snapshot_memory_stream_t, istream);
+    if (whence == SEEK_SET) {
+        stream->pointer = offset;
+    } else if (whence == SEEK_CUR) {
+        stream->pointer += offset;
+    } else if (whence == SEEK_END) {
+        stream->pointer = stream->stream_size + offset;
+    } else {
+        return -1;
+    }
+    return 0;
+}
+
+static int snapshot_memory_fclose(snapshot_stream_t *f)
+{
+    snapshot_memory_stream_t* stream = container_of(f, snapshot_memory_stream_t, istream);
+    lib_free(stream);
+    return 0;
+}
+
+static const char* snapshot_memory_filename(snapshot_stream_t* f)
+{
+    return "<memory>";
+}
+
+static struct snapshot_stream_ops_s snapshot_memory_ops = {
+    /* read */ snapshot_memory_read,
+    /* write */ snapshot_memory_write,
+    /* tell */ snapshot_memory_ftell,
+    /* seek */ snapshot_memory_fseek,
+    /* close */ snapshot_memory_fclose,
+    /* close_erase */ snapshot_memory_fclose,
+    /* filename */ snapshot_memory_filename
+};
+
+snapshot_stream_t* snapshot_memory_write_fopen(void* buffer, size_t buffer_size)
+{
+    snapshot_memory_stream_t* stream = lib_malloc(sizeof(snapshot_memory_stream_t));
+
+    lib_free(current_filename);
+    current_filename = lib_stralloc("<memory>");
+
+    if (stream == NULL) {
+        goto fail;
+    }
+
+    stream->write_mode = 1;
+    stream->buffer = (uint8_t*) buffer;
+    stream->buffer_size = buffer_size;
+    stream->pointer = 0;
+    stream->stream_size = 0;
+    stream->istream.ops = &snapshot_memory_ops;
+    return &stream->istream;
+
+fail:
+    return NULL;
+}
+
+snapshot_stream_t* snapshot_memory_read_fopen(const void* buffer, size_t buffer_size)
+{
+    snapshot_memory_stream_t* stream = lib_malloc(sizeof(snapshot_memory_stream_t));
+    if (stream == NULL) {
+        goto fail;
+    }
+
+    stream->write_mode = 0;
+    stream->buffer = (uint8_t*) buffer;
+    stream->buffer_size = buffer_size;
+    stream->pointer = 0;
+    stream->stream_size = buffer_size;
+    stream->istream.ops = &snapshot_memory_ops;
+    return &stream->istream;
+
+fail:
+    return NULL;
+}
+
+
+/* ------------------------------------------------------------------------- */
+
+size_t snapshot_read(snapshot_stream_t* f, void* ptr, size_t size)
+{
+    return f->ops->read(f, ptr, size);
+}
+
+size_t snapshot_write(snapshot_stream_t* f, const void* ptr, size_t size)
+{
+    return f->ops->write(f, ptr, size);
+}
+
+long snapshot_ftell(snapshot_stream_t *f)
+{
+    return f->ops->tell(f);
+}
+
+int snapshot_fseek(snapshot_stream_t *f, long offset, int whence)
+{
+    return f->ops->seek(f, offset, whence);
+}
+
+int snapshot_fclose(snapshot_stream_t *f)
+{
+    if (f == NULL)
+        return 0;
+    return f->ops->close(f);
+}
+
+int snapshot_fclose_erase(snapshot_stream_t *f)
+{
+    if (f == NULL)
+        return 0;
+    return f->ops->close_erase(f);
+}
+
+static const char* snapshot_filename(snapshot_stream_t *f)
+{
+    return f->ops->filename(f);
+}
+
+/* ------------------------------------------------------------------------- */
+
+static int snapshot_write_byte(snapshot_stream_t *f, uint8_t data)
+{
+    if (snapshot_write(f, &data, 1) != 1) {
         snapshot_error = SNAPSHOT_WRITE_EOF_ERROR;
         return -1;
     }
@@ -97,7 +509,7 @@ static int snapshot_write_byte(FILE *f, uint8_t data)
     return 0;
 }
 
-static int snapshot_write_word(FILE *f, uint16_t data)
+static int snapshot_write_word(snapshot_stream_t *f, uint16_t data)
 {
     if (snapshot_write_byte(f, (uint8_t)(data & 0xff)) < 0
         || snapshot_write_byte(f, (uint8_t)(data >> 8)) < 0) {
@@ -107,7 +519,7 @@ static int snapshot_write_word(FILE *f, uint16_t data)
     return 0;
 }
 
-static int snapshot_write_dword(FILE *f, uint32_t data)
+static int snapshot_write_dword(snapshot_stream_t *f, uint32_t data)
 {
     if (snapshot_write_word(f, (uint16_t)(data & 0xffff)) < 0
         || snapshot_write_word(f, (uint16_t)(data >> 16)) < 0) {
@@ -117,7 +529,7 @@ static int snapshot_write_dword(FILE *f, uint32_t data)
     return 0;
 }
 
-static int snapshot_write_double(FILE *f, double data)
+static int snapshot_write_double(snapshot_stream_t *f, double data)
 {
     uint8_t *byte_data = (uint8_t *)&data;
     int i;
@@ -130,7 +542,7 @@ static int snapshot_write_double(FILE *f, double data)
     return 0;
 }
 
-static int snapshot_write_padded_string(FILE *f, const char *s, uint8_t pad_char,
+static int snapshot_write_padded_string(snapshot_stream_t *f, const char *s, uint8_t pad_char,
                                         int len)
 {
     int i, found_zero;
@@ -149,9 +561,9 @@ static int snapshot_write_padded_string(FILE *f, const char *s, uint8_t pad_char
     return 0;
 }
 
-static int snapshot_write_byte_array(FILE *f, const uint8_t *data, unsigned int num)
+static int snapshot_write_byte_array(snapshot_stream_t *f, const uint8_t *data, unsigned int num)
 {
-    if (num > 0 && fwrite(data, (size_t)num, 1, f) < 1) {
+    if (num > 0 && snapshot_write(f, data, (size_t)num) != 1) {
         snapshot_error = SNAPSHOT_WRITE_BYTE_ARRAY_ERROR;
         return -1;
     }
@@ -159,7 +571,7 @@ static int snapshot_write_byte_array(FILE *f, const uint8_t *data, unsigned int 
     return 0;
 }
 
-static int snapshot_write_word_array(FILE *f, const uint16_t *data, unsigned int num)
+static int snapshot_write_word_array(snapshot_stream_t *f, const uint16_t *data, unsigned int num)
 {
     unsigned int i;
 
@@ -172,7 +584,7 @@ static int snapshot_write_word_array(FILE *f, const uint16_t *data, unsigned int
     return 0;
 }
 
-static int snapshot_write_dword_array(FILE *f, const uint32_t *data, unsigned int num)
+static int snapshot_write_dword_array(snapshot_stream_t *f, const uint32_t *data, unsigned int num)
 {
     unsigned int i;
 
@@ -186,7 +598,7 @@ static int snapshot_write_dword_array(FILE *f, const uint32_t *data, unsigned in
 }
 
 
-static int snapshot_write_string(FILE *f, const char *s)
+static int snapshot_write_string(snapshot_stream_t *f, const char *s)
 {
     size_t len, i;
 
@@ -205,20 +617,19 @@ static int snapshot_write_string(FILE *f, const char *s)
     return (int)(len + sizeof(uint16_t));
 }
 
-static int snapshot_read_byte(FILE *f, uint8_t *b_return)
+static int snapshot_read_byte(snapshot_stream_t *f, uint8_t *b_return)
 {
-    int c;
+    uint8_t b;
 
-    c = fgetc(f);
-    if (c == EOF) {
+    if (snapshot_read(f, &b, 1) != 1) {
         snapshot_error = SNAPSHOT_READ_EOF_ERROR;
         return -1;
     }
-    *b_return = (uint8_t)c;
+    *b_return = b;
     return 0;
 }
 
-static int snapshot_read_word(FILE *f, uint16_t *w_return)
+static int snapshot_read_word(snapshot_stream_t *f, uint16_t *w_return)
 {
     uint8_t lo, hi;
 
@@ -230,7 +641,7 @@ static int snapshot_read_word(FILE *f, uint16_t *w_return)
     return 0;
 }
 
-static int snapshot_read_dword(FILE *f, uint32_t *dw_return)
+static int snapshot_read_dword(snapshot_stream_t *f, uint32_t *dw_return)
 {
     uint16_t lo, hi;
 
@@ -242,28 +653,27 @@ static int snapshot_read_dword(FILE *f, uint32_t *dw_return)
     return 0;
 }
 
-static int snapshot_read_double(FILE *f, double *d_return)
+static int snapshot_read_double(snapshot_stream_t *f, double *d_return)
 {
     int i;
-    int c;
+    uint8_t b;
     double val;
     uint8_t *byte_val = (uint8_t *)&val;
 
     for (i = 0; i < sizeof(double); i++) {
-        c = fgetc(f);
-        if (c == EOF) {
+        if (snapshot_read(f, &b, 1) != 1) {
             snapshot_error = SNAPSHOT_READ_EOF_ERROR;
             return -1;
         }
-        byte_val[i] = (uint8_t)c;
+        byte_val[i] = b;
     }
     *d_return = val;
     return 0;
 }
 
-static int snapshot_read_byte_array(FILE *f, uint8_t *b_return, unsigned int num)
+static int snapshot_read_byte_array(snapshot_stream_t *f, uint8_t *b_return, unsigned int num)
 {
-    if (num > 0 && fread(b_return, (size_t)num, 1, f) < 1) {
+    if (num > 0 && snapshot_read(f, b_return, (size_t)num) != 1) {
         snapshot_error = SNAPSHOT_READ_BYTE_ARRAY_ERROR;
         return -1;
     }
@@ -271,7 +681,7 @@ static int snapshot_read_byte_array(FILE *f, uint8_t *b_return, unsigned int num
     return 0;
 }
 
-static int snapshot_read_word_array(FILE *f, uint16_t *w_return, unsigned int num)
+static int snapshot_read_word_array(snapshot_stream_t *f, uint16_t *w_return, unsigned int num)
 {
     unsigned int i;
 
@@ -284,7 +694,7 @@ static int snapshot_read_word_array(FILE *f, uint16_t *w_return, unsigned int nu
     return 0;
 }
 
-static int snapshot_read_dword_array(FILE *f, uint32_t *dw_return, unsigned int num)
+static int snapshot_read_dword_array(snapshot_stream_t *f, uint32_t *dw_return, unsigned int num)
 {
     unsigned int i;
 
@@ -297,7 +707,7 @@ static int snapshot_read_dword_array(FILE *f, uint32_t *dw_return, unsigned int 
     return 0;
 }
 
-static int snapshot_read_string(FILE *f, char **s)
+static int snapshot_read_string(snapshot_stream_t *f, char **s)
 {
     int i, len;
     uint16_t w;
@@ -427,7 +837,7 @@ int snapshot_module_write_string(snapshot_module_t *m, const char *s)
 
 int snapshot_module_read_byte(snapshot_module_t *m, uint8_t *b_return)
 {
-    if (ftell(m->file) + sizeof(uint8_t) > m->offset + m->size) {
+    if (snapshot_ftell(m->file) + sizeof(uint8_t) > m->offset + m->size) {
         snapshot_error = SNAPSHOT_READ_OUT_OF_BOUNDS_ERROR;
         return -1;
     }
@@ -437,7 +847,7 @@ int snapshot_module_read_byte(snapshot_module_t *m, uint8_t *b_return)
 
 int snapshot_module_read_word(snapshot_module_t *m, uint16_t *w_return)
 {
-    if (ftell(m->file) + sizeof(uint16_t) > m->offset + m->size) {
+    if (snapshot_ftell(m->file) + sizeof(uint16_t) > m->offset + m->size) {
         snapshot_error = SNAPSHOT_READ_OUT_OF_BOUNDS_ERROR;
         return -1;
     }
@@ -447,7 +857,7 @@ int snapshot_module_read_word(snapshot_module_t *m, uint16_t *w_return)
 
 int snapshot_module_read_dword(snapshot_module_t *m, uint32_t *dw_return)
 {
-    if (ftell(m->file) + sizeof(uint32_t) > m->offset + m->size) {
+    if (snapshot_ftell(m->file) + sizeof(uint32_t) > m->offset + m->size) {
         snapshot_error = SNAPSHOT_READ_OUT_OF_BOUNDS_ERROR;
         return -1;
     }
@@ -457,7 +867,7 @@ int snapshot_module_read_dword(snapshot_module_t *m, uint32_t *dw_return)
 
 int snapshot_module_read_double(snapshot_module_t *m, double *db_return)
 {
-    if (ftell(m->file) + sizeof(double) > m->offset + m->size) {
+    if (snapshot_ftell(m->file) + sizeof(double) > m->offset + m->size) {
         snapshot_error = SNAPSHOT_READ_OUT_OF_BOUNDS_ERROR;
         return -1;
     }
@@ -467,7 +877,7 @@ int snapshot_module_read_double(snapshot_module_t *m, double *db_return)
 
 int snapshot_module_read_byte_array(snapshot_module_t *m, uint8_t *b_return, unsigned int num)
 {
-    if ((long)(ftell(m->file) + num) > (long)(m->offset + m->size)) {
+    if ((long)(snapshot_ftell(m->file) + num) > (long)(m->offset + m->size)) {
         snapshot_error = SNAPSHOT_READ_OUT_OF_BOUNDS_ERROR;
         return -1;
     }
@@ -477,7 +887,7 @@ int snapshot_module_read_byte_array(snapshot_module_t *m, uint8_t *b_return, uns
 
 int snapshot_module_read_word_array(snapshot_module_t *m, uint16_t *w_return, unsigned int num)
 {
-    if ((long)(ftell(m->file) + num * sizeof(uint16_t)) > (long)(m->offset + m->size)) {
+    if ((long)(snapshot_ftell(m->file) + num * sizeof(uint16_t)) > (long)(m->offset + m->size)) {
         snapshot_error = SNAPSHOT_READ_OUT_OF_BOUNDS_ERROR;
         return -1;
     }
@@ -487,7 +897,7 @@ int snapshot_module_read_word_array(snapshot_module_t *m, uint16_t *w_return, un
 
 int snapshot_module_read_dword_array(snapshot_module_t *m, uint32_t *dw_return, unsigned int num)
 {
-    if ((long)(ftell(m->file) + num * sizeof(uint32_t)) > (long)(m->offset + m->size)) {
+    if ((long)(snapshot_ftell(m->file) + num * sizeof(uint32_t)) > (long)(m->offset + m->size)) {
         snapshot_error = SNAPSHOT_READ_OUT_OF_BOUNDS_ERROR;
         return -1;
     }
@@ -497,7 +907,7 @@ int snapshot_module_read_dword_array(snapshot_module_t *m, uint32_t *dw_return, 
 
 int snapshot_module_read_string(snapshot_module_t *m, char **charp_return)
 {
-    if (ftell(m->file) + sizeof(uint16_t) > m->offset + m->size) {
+    if (snapshot_ftell(m->file) + sizeof(uint16_t) > m->offset + m->size) {
         snapshot_error = SNAPSHOT_READ_OUT_OF_BOUNDS_ERROR;
         return -1;
     }
@@ -570,7 +980,7 @@ snapshot_module_t *snapshot_module_create(snapshot_t *s, const char *name, uint8
 
     m = lib_malloc(sizeof(snapshot_module_t));
     m->file = s->file;
-    m->offset = ftell(s->file);
+    m->offset = snapshot_ftell(s->file);
     if (m->offset == -1) {
         snapshot_error = SNAPSHOT_ILLEGAL_OFFSET_ERROR;
         lib_free(m);
@@ -585,8 +995,8 @@ snapshot_module_t *snapshot_module_create(snapshot_t *s, const char *name, uint8
         return NULL;
     }
 
-    m->size = ftell(s->file) - m->offset;
-    m->size_offset = ftell(s->file) - sizeof(uint32_t);
+    m->size = snapshot_ftell(s->file) - m->offset;
+    m->size_offset = snapshot_ftell(s->file) - sizeof(uint32_t);
 
     return m;
 }
@@ -599,7 +1009,7 @@ snapshot_module_t *snapshot_module_open(snapshot_t *s, const char *name, uint8_t
 
     current_module = (char *)name;
 
-    if (fseek(s->file, s->first_module_offset, SEEK_SET) < 0) {
+    if (snapshot_fseek(s->file, s->first_module_offset, SEEK_SET) < 0) {
         snapshot_error = SNAPSHOT_FIRST_MODULE_NOT_FOUND_ERROR;
         return NULL;
     }
@@ -629,18 +1039,18 @@ snapshot_module_t *snapshot_module_open(snapshot_t *s, const char *name, uint8_t
         }
 
         m->offset += m->size;
-        if (fseek(s->file, m->offset, SEEK_SET) < 0) {
+        if (snapshot_fseek(s->file, m->offset, SEEK_SET) < 0) {
             snapshot_error = SNAPSHOT_MODULE_NOT_FOUND_ERROR;
             goto fail;
         }
     }
 
-    m->size_offset = ftell(s->file) - sizeof(uint32_t);
+    m->size_offset = snapshot_ftell(s->file) - sizeof(uint32_t);
 
     return m;
 
 fail:
-    fseek(s->file, s->first_module_offset, SEEK_SET);
+    snapshot_fseek(s->file, s->first_module_offset, SEEK_SET);
     lib_free(m);
     return NULL;
 }
@@ -649,14 +1059,14 @@ int snapshot_module_close(snapshot_module_t *m)
 {
     /* Backpatch module size if writing.  */
     if (m->write_mode
-        && (fseek(m->file, m->size_offset, SEEK_SET) < 0
+        && (snapshot_fseek(m->file, m->size_offset, SEEK_SET) < 0
             || snapshot_write_dword(m->file, m->size) < 0)) {
         snapshot_error = SNAPSHOT_MODULE_CLOSE_ERROR;
         return -1;
     }
 
     /* Skip module.  */
-    if (fseek(m->file, m->offset + m->size, SEEK_SET) < 0) {
+    if (snapshot_fseek(m->file, m->offset + m->size, SEEK_SET) < 0) {
         snapshot_error = SNAPSHOT_MODULE_SKIP_ERROR;
         return -1;
     }
@@ -667,15 +1077,11 @@ int snapshot_module_close(snapshot_module_t *m)
 
 /* ------------------------------------------------------------------------- */
 
-snapshot_t *snapshot_create(const char *filename, uint8_t major_version, uint8_t minor_version, const char *snapshot_machine_name)
+snapshot_t *snapshot_create_from_stream(snapshot_stream_t *f, uint8_t major_version, uint8_t minor_version, const char *snapshot_machine_name)
 {
-    FILE *f;
     snapshot_t *s;
     unsigned char viceversion[4] = { VERSION_RC_NUMBER };
 
-    current_filename = (char *)filename;
-
-    f = fopen(filename, MODE_WRITE);
     if (f == NULL) {
         snapshot_error = SNAPSHOT_CANNOT_CREATE_SNAPSHOT_ERROR;
         return NULL;
@@ -721,38 +1127,47 @@ snapshot_t *snapshot_create(const char *filename, uint8_t major_version, uint8_t
 
     s = lib_malloc(sizeof(snapshot_t));
     s->file = f;
-    s->first_module_offset = ftell(f);
+    s->first_module_offset = snapshot_ftell(f);
     s->write_mode = 1;
 
     return s;
 
 fail:
-    fclose(f);
-    ioutil_remove(filename);
     return NULL;
+}
+
+
+snapshot_t *snapshot_create(const char *filename, uint8_t major_version, uint8_t minor_version, const char *snapshot_machine_name)
+{
+    snapshot_stream_t *file;
+    snapshot_t *snapshot;
+
+    file = snapshot_file_write_fopen(filename);
+    snapshot = snapshot_create_from_stream(file, major_version, minor_version, snapshot_machine_name);
+    if (!snapshot) {
+        snapshot_fclose_erase(file);
+    }
+    return snapshot;
 }
 
 /* informal only, used by the error message created below */
 static unsigned char snapshot_viceversion[4];
 static uint32_t snapshot_vicerevision;
 
-snapshot_t *snapshot_open(const char *filename, uint8_t *major_version_return, uint8_t *minor_version_return, const char *snapshot_machine_name)
+snapshot_t *snapshot_open_from_stream(snapshot_stream_t *f, uint8_t *major_version_return, uint8_t *minor_version_return, const char *snapshot_machine_name)
 {
-    FILE *f;
     char magic[SNAPSHOT_MAGIC_LEN];
     snapshot_t *s = NULL;
     int machine_name_len;
     size_t offs;
 
-    current_machine_name = (char *)snapshot_machine_name;
-    current_filename = (char *)filename;
-    current_module = NULL;
-
-    f = zfile_fopen(filename, MODE_READ);
     if (f == NULL) {
         snapshot_error = SNAPSHOT_CANNOT_OPEN_FOR_READ_ERROR;
         return NULL;
     }
+
+    current_machine_name = (char *)snapshot_machine_name;
+    current_module = NULL;
 
     /* Magic string.  */
     if (snapshot_read_byte_array(f, (uint8_t *)magic, SNAPSHOT_MAGIC_LEN) < 0
@@ -786,12 +1201,12 @@ snapshot_t *snapshot_open(const char *filename, uint8_t *major_version_return, u
     /* VICE version and revision */
     memset(snapshot_viceversion, 0, 4);
     snapshot_vicerevision = 0;
-    offs = ftell(f);
+    offs = snapshot_ftell(f);
 
     if (snapshot_read_byte_array(f, (uint8_t *)magic, SNAPSHOT_VERSION_MAGIC_LEN) < 0
         || memcmp(magic, snapshot_version_magic_string, SNAPSHOT_VERSION_MAGIC_LEN) != 0) {
         /* old snapshots do not contain VICE version */
-        fseek(f, offs, SEEK_SET);
+        snapshot_fseek(f, offs, SEEK_SET);
         log_warning(LOG_DEFAULT, "attempting to load pre 2.4.30 snapshot");
     } else {
         /* actually read the version */
@@ -807,15 +1222,27 @@ snapshot_t *snapshot_open(const char *filename, uint8_t *major_version_return, u
 
     s = lib_malloc(sizeof(snapshot_t));
     s->file = f;
-    s->first_module_offset = ftell(f);
+    s->first_module_offset = snapshot_ftell(f);
     s->write_mode = 0;
 
     vsync_suspend_speed_eval();
     return s;
 
 fail:
-    fclose(f);
     return NULL;
+}
+
+snapshot_t *snapshot_open(const char *filename, uint8_t *major_version_return, uint8_t *minor_version_return, const char *snapshot_machine_name)
+{
+    snapshot_stream_t *file;
+    snapshot_t *snapshot;
+
+    file = snapshot_file_read_fopen(filename);
+    snapshot = snapshot_open_from_stream(file, major_version_return, minor_version_return, snapshot_machine_name);
+    if (!snapshot) {
+        snapshot_fclose(file);
+    }
+    return snapshot;
 }
 
 int snapshot_close(snapshot_t *s)
@@ -823,14 +1250,14 @@ int snapshot_close(snapshot_t *s)
     int retval;
 
     if (!s->write_mode) {
-        if (zfile_fclose(s->file) == EOF) {
+        if (snapshot_fclose(s->file) == EOF) {
             snapshot_error = SNAPSHOT_READ_CLOSE_EOF_ERROR;
             retval = -1;
         } else {
             retval = 0;
         }
     } else {
-        if (fclose(s->file) == EOF) {
+        if (snapshot_fclose(s->file) == EOF) {
             snapshot_error = SNAPSHOT_WRITE_CLOSE_EOF_ERROR;
             retval = -1;
         } else {
@@ -840,6 +1267,12 @@ int snapshot_close(snapshot_t *s)
 
     lib_free(s);
     return retval;
+}
+
+int snapshot_free(snapshot_t *s)
+{
+    lib_free(s);
+    return 0;
 }
 
 static void display_error_with_vice_version(char *text, char *filename)

--- a/vice/src/snapshot.h
+++ b/vice/src/snapshot.h
@@ -62,6 +62,7 @@
 
 typedef struct snapshot_module_s snapshot_module_t;
 typedef struct snapshot_s snapshot_t;
+typedef struct snapshot_stream_s snapshot_stream_t;
 
 extern void snapshot_display_error(void);
 
@@ -143,11 +144,36 @@ extern snapshot_t *snapshot_open(const char *filename,
                                  uint8_t *major_version_return,
                                  uint8_t *minor_version_return,
                                  const char *snapshot_machine_name);
+/* Close stream and delete snapshot struct */
 extern int snapshot_close(snapshot_t *s);
+/* Delete snapshot struct, leave stream open */
+extern int snapshot_free(snapshot_t *s);
+
+extern snapshot_t *snapshot_create_from_stream(snapshot_stream_t *f,
+                                               uint8_t major_version, uint8_t minor_version, 
+                                               const char *snapshot_machine_name);
+extern snapshot_t *snapshot_open_from_stream(snapshot_stream_t *f,
+                                             uint8_t *major_version_return,
+                                             uint8_t *minor_version_return,
+                                             const char *snapshot_machine_name);
 
 extern void snapshot_set_error(int error);
 
 extern int snapshot_version_at_least(uint8_t major_version, uint8_t minor_version, uint8_t major_version_required, uint8_t minor_version_required);
+
+extern snapshot_stream_t* snapshot_file_read_fopen(const char* pathname);
+extern snapshot_stream_t* snapshot_file_write_fopen(const char* pathname);
+
+extern snapshot_stream_t* snapshot_memory_read_fopen(const void* buffer, size_t buffer_size);
+extern snapshot_stream_t* snapshot_memory_write_fopen(void* buffer, size_t buffer_size);
+
+extern size_t snapshot_read(snapshot_stream_t* f, void* ptr, size_t size);
+extern size_t snapshot_write(snapshot_stream_t* f, const void* ptr, size_t size);
+extern int snapshot_fseek(snapshot_stream_t *f, long offset, int whence);
+extern long snapshot_ftell(snapshot_stream_t *f);
+
+extern int snapshot_fclose(snapshot_stream_t *f);
+extern int snapshot_fclose_erase(snapshot_stream_t *f);
 
 #define SNAPVAL snapshot_version_at_least
 

--- a/vice/src/types.h
+++ b/vice/src/types.h
@@ -41,6 +41,9 @@
 #  endif
 #endif
 
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
 
 #ifdef __LIBRETRO__
 

--- a/vice/src/vic20/vic20-snapshot.c
+++ b/vice/src/vic20/vic20-snapshot.c
@@ -59,13 +59,13 @@
 #define SNAP_MINOR          0
 
 
-int vic20_snapshot_write(const char *name, int save_roms, int save_disks,
-                         int event_mode)
+int vic20_snapshot_write_to_stream(snapshot_stream_t *stream, int save_roms, int save_disks,
+                                   int event_mode)
 {
     snapshot_t *s;
     int ieee488;
 
-    s = snapshot_create(name, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)),
+    s = snapshot_create_from_stream(stream, ((uint8_t)(SNAP_MAJOR)), ((uint8_t)(SNAP_MINOR)),
                         machine_name);
     if (s == NULL) {
         return -1;
@@ -85,8 +85,7 @@ int vic20_snapshot_write(const char *name, int save_roms, int save_disks,
         || keyboard_snapshot_write_module(s) < 0
         || joyport_snapshot_write_module(s, JOYPORT_1) < 0
         || userport_snapshot_write_module(s) < 0) {
-        snapshot_close(s);
-        ioutil_remove(name);
+        snapshot_free(s);
         return -1;
     }
 
@@ -94,22 +93,37 @@ int vic20_snapshot_write(const char *name, int save_roms, int save_disks,
     if (ieee488) {
         if (viacore_snapshot_write_module(machine_context.ieeevia1, s) < 0
             || viacore_snapshot_write_module(machine_context.ieeevia2, s) < 0) {
-            snapshot_close(s);
-            ioutil_remove(name);
-            return 1;
+            snapshot_free(s);
+            return -1;
         }
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
     return 0;
 }
 
-int vic20_snapshot_read(const char *name, int event_mode)
+int vic20_snapshot_write(const char *name, int save_roms, int save_disks, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_write_fopen(name);
+    res = vic20_snapshot_write_to_stream(stream, save_roms, save_disks, event_mode);
+    if (res) {
+        snapshot_fclose_erase(stream);
+    } else if (snapshot_fclose(stream) == EOF) {
+        snapshot_set_error(SNAPSHOT_WRITE_CLOSE_EOF_ERROR);
+        res = -1;
+    }
+    return res;
+}
+
+int vic20_snapshot_read_from_stream(snapshot_stream_t *stream, int event_mode)
 {
     snapshot_t *s;
     uint8_t minor, major;
 
-    s = snapshot_open(name, &major, &minor, machine_name);
+    s = snapshot_open_from_stream(stream, &major, &minor, machine_name);
     if (s == NULL) {
         return -1;
     }
@@ -145,7 +159,7 @@ int vic20_snapshot_read(const char *name, int event_mode)
         resources_set_int("IEEE488", 1);
     }
 
-    snapshot_close(s);
+    snapshot_free(s);
 
     sound_snapshot_finish();
 
@@ -153,10 +167,21 @@ int vic20_snapshot_read(const char *name, int event_mode)
 
 fail:
     if (s != NULL) {
-        snapshot_close(s);
+        snapshot_free(s);
     }
 
     machine_trigger_reset(MACHINE_RESET_MODE_SOFT);
 
     return -1;
+}
+
+int vic20_snapshot_read(const char *name, int event_mode)
+{
+    snapshot_stream_t *stream;
+    int res;
+
+    stream = snapshot_file_read_fopen(name);
+    res = vic20_snapshot_read_from_stream(stream, event_mode);
+    snapshot_fclose(stream);
+    return res;
 }

--- a/vice/src/vic20/vic20-snapshot.h
+++ b/vice/src/vic20/vic20-snapshot.h
@@ -27,6 +27,11 @@
 #ifndef VICE_VIC20_SNAPSHOT_H
 #define VICE_VIC20_SNAPSHOT_H
 
+struct snapshot_stream_s;
+extern int vic20_snapshot_write_to_stream(struct snapshot_stream_s *stream, int save_roms,
+                                          int save_disks, int event_mode);
+extern int vic20_snapshot_read_from_stream(struct snapshot_stream_s *stream, int event_mode);
+
 extern int vic20_snapshot_write(const char *name, int save_roms, int save_disks,
                                 int event_mode);
 extern int vic20_snapshot_read(const char *name, int event_mode);

--- a/vice/src/vic20/vic20.c
+++ b/vice/src/vic20/vic20.c
@@ -1177,6 +1177,18 @@ void machine_change_timing(int timeval, int border_mode)
 
 /* ------------------------------------------------------------------------- */
 
+int machine_write_snapshot_to_stream(snapshot_stream_t *stream, int save_roms,
+                                     int save_disks, int event_mode)
+{
+    return vic20_snapshot_write_to_stream(stream, save_roms, save_disks,
+                                          event_mode);
+}
+
+int machine_read_snapshot_from_stream(snapshot_stream_t *stream, int event_mode)
+{
+    return vic20_snapshot_read_from_stream(stream, event_mode);
+}
+
 int machine_write_snapshot(const char *name, int save_roms, int save_disks,
                            int event_mode)
 {


### PR DESCRIPTION
- Added functions `int machine_write_snapshot_to_stream(snapshot_stream_t *stream, int save_roms,
int save_disks, int event_mode)` and `int machine_read_snapshot_from_stream(snapshot_stream_t *stream, int event_mode)` to each model
- Functions `snapshot_stream_t* snapshot_file_read_fopen(const char* pathname)` and `snapshot_stream_t* snapshot_file_write_fopen(const char* pathname)` creates `snapshot_stream_t` object using regular `FILE`
- Functions `snapshot_stream_t* snapshot_memory_read_fopen(const void* buffer, size_t buffer_size)` and `snapshot_stream_t* snapshot_memory_write_fopen(void* buffer, size_t buffer_size)` create memory based stream
- Call `snapshot_memory_write_fopen(NULL, 0)` creates dummy memory stream which is used for calculating snapshot size
