### PR TITLE
Fix for cartridge from vicerc ignored

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -40,10 +40,6 @@ static char buf[64][4096] = { 0 };
 long microSecCounter=0;
 int cpuloop=1;
 
-// If this parameter is set, we always initialize vice core without parameters
-// and pass params later
-#define START_WITHOUT_PARAMS
-
 #ifdef FRONTEND_SUPPORTS_RGB565
 	uint16_t *Retro_Screen;
 	uint16_t bmp[WINDOW_SIZE];
@@ -653,24 +649,16 @@ int pre_main()
 {
     int argc = PARAMCOUNT;
 
-#ifndef START_WITHOUT_PARAMS
-    build_params();
-#else
     /* start core with empty params */
     xargv_cmd[0] = CORE_NAME;
     xargv_cmd[1] = NULL;
     argc = 1;
-#endif
 
     if (skel_main(argc, (char**)xargv_cmd) < 0)
     {
         log_cb(RETRO_LOG_ERROR, "Core startup failed\n");
         environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, NULL);
     }
-
-#ifndef START_WITHOUT_PARAMS
-    update_from_vice();
-#endif
 
     return 0;
 }
@@ -681,12 +669,12 @@ extern int ui_init_finalize(void);
 
 void reload_restart()
 {
-    /* Load content was called while core was already running, pass command line to core for restart */
+
+    /* Stop datasette */
     datasette_control(DATASETTE_CONTROL_STOP);
 
-    /* Reset resources to defaults */
-    resources_set_defaults();
-    resources_load(NULL);
+    /* Cleanup after previous content and reset resources */
+    initcmdline_cleanup();
 
     /* Update resources from environment just like on fresh start of core */
     retro_ui_finalized = 0;
@@ -699,7 +687,7 @@ void reload_restart()
     if (initcmdline_restart(PARAMCOUNT, (char**)xargv_cmd) < 0)
     {
         log_cb(RETRO_LOG_ERROR, "Restart failed\n");
-        // Nevermind, the core is already running
+        /* Nevermind, the core is already running */
     }
 
     /* Now read disk image and autostart file (may be the same or not) from vice */
@@ -2711,11 +2699,7 @@ void retro_run(void)
       retro_load_ok = true;
       app_init();
       pre_main();
-#ifdef START_WITHOUT_PARAMS
       reload_restart();
-#else
-      update_variables();
-#endif
       runstate = RUNSTATE_RUNNING;
       return;
    } 

--- a/vice/src/c64/cart/c64cart.c
+++ b/vice/src/c64/cart/c64cart.c
@@ -362,6 +362,7 @@ static int set_cartridge_file(const char *name, void *param)
 
     if (name == NULL || !strlen(name)) {
         cartridge_detach_image(-1);
+        util_string_set(&cartridge_file, ""); /* resource value modified */
         return 0;
     }
 

--- a/vice/src/initcmdline.c
+++ b/vice/src/initcmdline.c
@@ -385,19 +385,27 @@ void initcmdline_check_attach(void)
 #endif
 }
 
-int initcmdline_restart(int argc, char **argv)
+#ifdef __LIBRETRO__
+int initcmdline_cleanup()
 {
     cmdline_free_autostart_string();
 
+    /* Detach all tapes and disks from previous content */
     tape_image_detach(1);
-    file_system_detach_disk(8);
-    file_system_detach_disk(9);
-    file_system_detach_disk(10);
-    file_system_detach_disk(11);
-    if (mon_cart_cmd.cartridge_detach_image != NULL) {
-        (mon_cart_cmd.cartridge_detach_image)(-1);
+    file_system_detach_disk(-1);
+
+    /* Detach cartridge and reset default name */
+    if (resources_query_type("CartridgeFile") == RES_STRING) {
+        resources_set_string("CartridgeFile", "");
     }
 
+    /* Reset resources to defaults */
+    resources_set_defaults();
+    resources_load(NULL);
+}
+
+int initcmdline_restart(int argc, char **argv)
+{
     if (initcmdline_check_args(argc, argv) == -1) {
         return -1;
     }
@@ -405,3 +413,4 @@ int initcmdline_restart(int argc, char **argv)
     initcmdline_check_attach();
     return 0;
 }
+#endif

--- a/vice/src/initcmdline.h
+++ b/vice/src/initcmdline.h
@@ -33,6 +33,9 @@ extern int initcmdline_check_args(int argc, char **argv);
 extern void initcmdline_check_attach(void);
 extern int cmdline_get_autostart_mode(void);
 extern const char* cmdline_get_autostart_string(void);
+#ifdef __LIBRETRO__
+extern int initcmdline_cleanup();
 extern int initcmdline_restart(int argc, char **argv);
+#endif
 
 #endif


### PR DESCRIPTION
Close #140

Apart from incorrect initialization sequence in `reload_restart` there was a problem in `c64cart.c`, that if you set `CartridgeFile` to some string, then to empty string (e.g. via `resources_set_defaults`) and then back to the same string, it would detach the cartridge, but not attach it again.
