### PR TITLE
Fix m3u command

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -266,6 +266,8 @@ static void parse_cmdline(const char *argv)
                //... do something with the word ...
                for (c2 = 0,p2 = start_of_word; p2 < p; p2++, c2++)
                   ARGUV[ARGUC][c2] = (unsigned char) *p2;
+               /* terminate word */
+               ARGUV[ARGUC][c2] = '\0';
                ARGUC++;
 
                state = DULL; /* back to "not in word, not in string" state */
@@ -279,6 +281,8 @@ static void parse_cmdline(const char *argv)
                //... do something with the word ...
                for (c2 = 0,p2 = start_of_word; p2 <p; p2++,c2++)
                   ARGUV[ARGUC][c2] = (unsigned char) *p2;
+               /* terminate word */
+               ARGUV[ARGUC][c2] = '\0';
                ARGUC++;
 
                state = DULL; /* back to "not in word, not in string" state */

--- a/vice/src/c64/cart/c64cart.c
+++ b/vice/src/c64/cart/c64cart.c
@@ -362,7 +362,9 @@ static int set_cartridge_file(const char *name, void *param)
 
     if (name == NULL || !strlen(name)) {
         cartridge_detach_image(-1);
+#ifdef __LIBRETRO__
         util_string_set(&cartridge_file, ""); /* resource value modified */
+#endif /* __LIBRETRO__ */
         return 0;
     }
 

--- a/vice/src/initcmdline.c
+++ b/vice/src/initcmdline.c
@@ -66,10 +66,12 @@ int cmdline_get_autostart_mode(void)
     return autostart_mode;
 }
 
+#ifdef __LIBRETRO__
 const char* cmdline_get_autostart_string(void)
 {
     return autostart_string;
 }
+#endif /* __LIBRETRO__ */
 
 static void cmdline_free_autostart_string(void)
 {
@@ -382,7 +384,7 @@ void initcmdline_check_attach(void)
     // Keep autostart string for libretro-core
 #ifndef __LIBRETRO__
     cmdline_free_autostart_string();
-#endif
+#endif /* __LIBRETRO__ */
 }
 
 #ifdef __LIBRETRO__
@@ -413,4 +415,4 @@ int initcmdline_restart(int argc, char **argv)
     initcmdline_check_attach();
     return 0;
 }
-#endif
+#endif /* __LIBRETRO__ */

--- a/vice/src/initcmdline.h
+++ b/vice/src/initcmdline.h
@@ -32,10 +32,10 @@ extern int initcmdline_check_psid(void);
 extern int initcmdline_check_args(int argc, char **argv);
 extern void initcmdline_check_attach(void);
 extern int cmdline_get_autostart_mode(void);
-extern const char* cmdline_get_autostart_string(void);
 #ifdef __LIBRETRO__
+extern const char* cmdline_get_autostart_string(void);
 extern int initcmdline_cleanup();
 extern int initcmdline_restart(int argc, char **argv);
-#endif
+#endif /* __LIBRETRO__ */
 
 #endif


### PR DESCRIPTION
- Null-terminate parameters in parse_cmdline
- Mark modified vice code with ifdefs (except snapshot code)
