### PR TITLE
C128 80 column mode option

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -83,6 +83,7 @@ extern int RETRODSE;
 extern int RETRORESET;
 extern int RETROSIDMODL;
 extern int RETRORESIDSAMPLING;
+extern int RETROAUDIOLEAK;
 extern int RETROC64MODL;
 #if defined(__X128__)
 extern int RETROC128COLUMNKEY;
@@ -838,7 +839,7 @@ void retro_set_environment(retro_environment_t cb)
          "Video Output",
          "",
          {
-            { "VICII", "VICII (40 cols)" },
+            { "VICII", "VIC-II (40 cols)" },
             { "VDC", "VCD (80 cols)" },
             { NULL, NULL },
          },
@@ -967,6 +968,23 @@ void retro_set_environment(retro_environment_t cb)
          },
          "disabled"
       },
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__VIC20__)
+      {
+         "vice_audio_leak_emulation",
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+         "VIC-II Audio Leak Emulation",
+#elif defined(__VIC20__)
+         "VIC Audio Leak Emulation",
+#endif
+         "",
+         {
+            { "disabled", NULL },
+            { "enabled", NULL },
+            { NULL, NULL },
+         },
+         "disabled"
+      },
+#endif
 #if !defined(__PET__) && !defined(__PLUS4__) && !defined(__VIC20__)
       {
          "vice_sid_model",
@@ -1581,6 +1599,27 @@ static void update_variables(void)
          else RETRODSE=val;
       }
    }
+
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__VIC20__)
+   var.key = "vice_audio_leak_emulation";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int audioleak=0;
+
+      if (strcmp(var.value, "disabled") == 0) audioleak=0;
+      else if (strcmp(var.value, "enabled") == 0) audioleak=1;
+
+      if (retro_ui_finalized && RETROAUDIOLEAK != audioleak)
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+         log_resources_set_int("VICIIAudioLeak", audioleak);
+#elif defined(__VIC20__)
+         log_resources_set_int("VICAudioLeak", audioleak);
+#endif
+      RETROAUDIOLEAK=audioleak;
+   }
+#endif
 
    var.key = "vice_sid_model";
    var.value = NULL;

--- a/vice/src/arch/libretro/retrostubs.c
+++ b/vice/src/arch/libretro/retrostubs.c
@@ -117,7 +117,7 @@ void Keymap_KeyUp(int symkey)
     /* Prevent LShift keyup if ShiftLock is on */
     else if (symkey == RETROK_LSHIFT)
     {
-        if(SHIFTON == -1)
+        if (SHIFTON == -1)
             kbd_handle_keyup(symkey);
     }
     else 
@@ -132,7 +132,7 @@ void Keymap_KeyDown(int symkey)
     /* CapsLock / ShiftLock */
     else if (symkey == RETROK_CAPSLOCK)
     {
-        if(SHIFTON == 1)
+        if (SHIFTON == 1)
             kbd_handle_keyup(RETROK_LSHIFT);
         else
             kbd_handle_keydown(RETROK_LSHIFT);
@@ -142,7 +142,7 @@ void Keymap_KeyDown(int symkey)
     else if (symkey == RETROK_UP || symkey == RETROK_DOWN || symkey == RETROK_LEFT || symkey == RETROK_RIGHT)
     {
         /* Cursors will not move if CTRL actually is pressed, so we need to fake keyup */
-        if(CTRLON == 1)
+        if (CTRLON == 1)
             kbd_handle_keyup(RETROK_TAB);
             kbd_handle_keydown(symkey);
     }
@@ -155,7 +155,7 @@ void app_vkb_handle(void)
     static int last_vkey_pressed = -1;
 
     /* key up */
-    if(vkey_pressed == -1 && last_vkey_pressed >= 0)
+    if (vkey_pressed == -1 && last_vkey_pressed >= 0)
         kbd_handle_keyup(last_vkey_pressed);
 
     /* key down */
@@ -177,12 +177,12 @@ void app_vkb_handle(void)
                 Keymap_KeyUp(RETROK_CAPSLOCK);
                 break;
             case -20:
-                if(turbo_fire_button_disabled == -1 && turbo_fire_button == -1)
+                if (turbo_fire_button_disabled == -1 && turbo_fire_button == -1)
                     break;
-                else if(turbo_fire_button_disabled != -1 && turbo_fire_button != -1)
+                else if (turbo_fire_button_disabled != -1 && turbo_fire_button != -1)
                     turbo_fire_button_disabled = -1;
 
-                if(turbo_fire_button_disabled != -1)
+                if (turbo_fire_button_disabled != -1)
                 {
                     turbo_fire_button = turbo_fire_button_disabled;
                     turbo_fire_button_disabled = -1;
@@ -223,38 +223,38 @@ void Core_Processkey(int disable_physical_cursor_keys)
 {
    int i;
 
-   for(i=0; i<320; i++)
+   for (i=0; i<320; i++)
       core_key_state[i]=input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0,i) ? 0x80: 0;
 
-   if(memcmp(core_key_state, core_old_key_state, sizeof(core_key_state)))
+   if (memcmp(core_key_state, core_old_key_state, sizeof(core_key_state)))
    {
-      for(i=0; i<320; i++)
+      for (i=0; i<320; i++)
       {
-         if(core_key_state[i] && core_key_state[i]!=core_old_key_state[i])
+         if (core_key_state[i] && core_key_state[i]!=core_old_key_state[i])
          {	
-            if(i==RETROK_LALT)
+            if (i==RETROK_LALT)
                continue;
-            else if(i==RETROK_TAB) /* CTRL acts as a cursor enabler */
+            else if (i==RETROK_TAB) /* CTRL acts as a cursor enabler */
                CTRLON=1;
-            else if(i==RETROK_CAPSLOCK) /* Allow CapsLock while SHOWKEY */
+            else if (i==RETROK_CAPSLOCK) /* Allow CapsLock while SHOWKEY */
                ;
-            else if(disable_physical_cursor_keys && (i == RETROK_DOWN || i == RETROK_UP || i == RETROK_LEFT || i == RETROK_RIGHT))
+            else if (disable_physical_cursor_keys && (i == RETROK_DOWN || i == RETROK_UP || i == RETROK_LEFT || i == RETROK_RIGHT))
                continue;
-            else if(SHOWKEY==1)
+            else if (SHOWKEY==1)
                continue;
             Keymap_KeyDown(i);
          }
-         else if(!core_key_state[i] && core_key_state[i] != core_old_key_state[i])
+         else if (!core_key_state[i] && core_key_state[i] != core_old_key_state[i])
          {
-            if(i==RETROK_LALT)
+            if (i==RETROK_LALT)
                continue;
-            else if(i==RETROK_TAB)
+            else if (i==RETROK_TAB)
                CTRLON=-1;
-            else if(i==RETROK_CAPSLOCK)
+            else if (i==RETROK_CAPSLOCK)
                ;
-            else if(disable_physical_cursor_keys && (i == RETROK_DOWN || i == RETROK_UP || i == RETROK_LEFT || i == RETROK_RIGHT))
+            else if (disable_physical_cursor_keys && (i == RETROK_DOWN || i == RETROK_UP || i == RETROK_LEFT || i == RETROK_RIGHT))
                continue;
-            //else if(SHOWKEY==1) /* We need to allow keyup while SHOWKEY to prevent the summoning key from staying down, if keyboard is used as a RetroPad */
+            //else if (SHOWKEY==1) /* We need to allow keyup while SHOWKEY to prevent the summoning key from staying down, if keyboard is used as a RetroPad */
             //   continue;
             Keymap_KeyUp(i);
          }
@@ -442,30 +442,30 @@ int Core_PollEvent(int disable_physical_cursor_keys)
             if (just_pressed)
             {
                 jbt[i] = 1;
-                if(mapper_keys[i] == 0) /* unmapped, e.g. set to "---" in core options */
+                if (mapper_keys[i] == 0) /* unmapped, e.g. set to "---" in core options */
                     continue;
 
-                if(mapper_keys[i] == mapper_keys[24]) /* Virtual keyboard */
+                if (mapper_keys[i] == mapper_keys[24]) /* Virtual keyboard */
                     emu_function(EMU_VKBD);
-                else if(mapper_keys[i] == mapper_keys[25]) /* Statusbar */
+                else if (mapper_keys[i] == mapper_keys[25]) /* Statusbar */
                     emu_function(EMU_STATUSBAR);
-                else if(mapper_keys[i] == mapper_keys[26]) /* Switch joyport */
+                else if (mapper_keys[i] == mapper_keys[26]) /* Switch joyport */
                     emu_function(EMU_JOYPORT);
-                else if(mapper_keys[i] == mapper_keys[27]) /* Reset */
+                else if (mapper_keys[i] == mapper_keys[27]) /* Reset */
                     emu_function(EMU_RESET);
-                else if(mapper_keys[i] == mapper_keys[28]) /* Warp mode */
+                else if (mapper_keys[i] == mapper_keys[28]) /* Warp mode */
                     emu_function(EMU_WARP_ON);
-                else if(mapper_keys[i] == mapper_keys[29]) /* Datasette toggle */
+                else if (mapper_keys[i] == mapper_keys[29]) /* Datasette toggle */
                     emu_function(EMU_DATASETTE_TOGGLE_HOTKEYS);
-                else if(datasette && mapper_keys[i] == mapper_keys[30]) /* Datasette stop */
+                else if (datasette && mapper_keys[i] == mapper_keys[30]) /* Datasette stop */
                     emu_function(EMU_DATASETTE_STOP);
-                else if(datasette && mapper_keys[i] == mapper_keys[31]) /* Datasette start */
+                else if (datasette && mapper_keys[i] == mapper_keys[31]) /* Datasette start */
                     emu_function(EMU_DATASETTE_START);
-                else if(datasette && mapper_keys[i] == mapper_keys[32]) /* Datasette forward */
+                else if (datasette && mapper_keys[i] == mapper_keys[32]) /* Datasette forward */
                     emu_function(EMU_DATASETTE_FORWARD);
-                else if(datasette && mapper_keys[i] == mapper_keys[33]) /* Datasette rewind */
+                else if (datasette && mapper_keys[i] == mapper_keys[33]) /* Datasette rewind */
                     emu_function(EMU_DATASETTE_REWIND);
-                else if(datasette && mapper_keys[i] == mapper_keys[34]) /* Datasette reset */
+                else if (datasette && mapper_keys[i] == mapper_keys[34]) /* Datasette reset */
                     emu_function(EMU_DATASETTE_RESET);
                 else
                     Keymap_KeyDown(mapper_keys[i]);
@@ -473,30 +473,30 @@ int Core_PollEvent(int disable_physical_cursor_keys)
             else if (just_released)
             {
                 jbt[i] = 0;
-                if(mapper_keys[i] == 0) /* unmapped, e.g. set to "---" in core options */
+                if (mapper_keys[i] == 0) /* unmapped, e.g. set to "---" in core options */
                     continue;
 
-                if(mapper_keys[i] == mapper_keys[24])
+                if (mapper_keys[i] == mapper_keys[24])
                     ; /* nop */
-                else if(mapper_keys[i] == mapper_keys[25])
+                else if (mapper_keys[i] == mapper_keys[25])
                     ; /* nop */
-                else if(mapper_keys[i] == mapper_keys[26])
+                else if (mapper_keys[i] == mapper_keys[26])
                     ; /* nop */
-                else if(mapper_keys[i] == mapper_keys[27])
+                else if (mapper_keys[i] == mapper_keys[27])
                     ; /* nop */
-                else if(mapper_keys[i] == mapper_keys[28])
+                else if (mapper_keys[i] == mapper_keys[28])
                     emu_function(EMU_WARP_OFF);
-                else if(mapper_keys[i] == mapper_keys[29])
+                else if (mapper_keys[i] == mapper_keys[29])
                     ; /* nop */
-                else if(datasette && mapper_keys[i] == mapper_keys[30])
+                else if (datasette && mapper_keys[i] == mapper_keys[30])
                     ; /* nop */
-                else if(datasette && mapper_keys[i] == mapper_keys[31])
+                else if (datasette && mapper_keys[i] == mapper_keys[31])
                     ; /* nop */
-                else if(datasette && mapper_keys[i] == mapper_keys[32])
+                else if (datasette && mapper_keys[i] == mapper_keys[32])
                     ; /* nop */
-                else if(datasette && mapper_keys[i] == mapper_keys[33])
+                else if (datasette && mapper_keys[i] == mapper_keys[33])
                     ; /* nop */
-                else if(datasette && mapper_keys[i] == mapper_keys[34])
+                else if (datasette && mapper_keys[i] == mapper_keys[34])
                     ; /* nop */
                 else
                     Keymap_KeyUp(mapper_keys[i]);
@@ -509,26 +509,30 @@ int Core_PollEvent(int disable_physical_cursor_keys)
 
 void retro_poll_event()
 {
-    /* If RetroPad is controlled with cursor keys, then prevent up/down/left/right/fire from generating */
+    /* If RetroPad is controlled with cursor keys, then prevent up/down/left/right/b/a/x/y from generating */
     /* keyboard key presses, this prevents cursor up from becoming a run/stop input */
     if ((vice_devices[0] == RETRO_DEVICE_VICE_JOYSTICK || vice_devices[0] == RETRO_DEVICE_JOYPAD) && CTRLON==-1 &&
-        input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) &&
+        (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) ||
+         input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) ||
+         input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) ||
+         input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y)
+        ) &&
         !RETROKEYBOARDPASSTHROUGH
     )
         Core_PollEvent(2); /* Skip all keyboard input when fire is pressed */
-    else if (
-        (vice_devices[0] == RETRO_DEVICE_VICE_JOYSTICK || vice_devices[0] == RETRO_DEVICE_JOYPAD) && CTRLON==-1 &&
+    else if ((vice_devices[0] == RETRO_DEVICE_VICE_JOYSTICK || vice_devices[0] == RETRO_DEVICE_JOYPAD) && CTRLON==-1 &&
         (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) ||
          input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) ||
          input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) ||
-         input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)) &&
-         !RETROKEYBOARDPASSTHROUGH
+         input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)
+        ) &&
+        !RETROKEYBOARDPASSTHROUGH
     )
         Core_PollEvent(1); /* Process all inputs but disable cursor keys */
     else
         Core_PollEvent(0); /* Process all inputs */
 
-    //if(SHOWKEY==-1) /* retro joypad take control over keyboard joy */
+    /* retro joypad take control over keyboard joy */
     /* override keydown, but allow keyup, to prevent key sticking during keyboard use, if held down on opening keyboard */
     /* keyup allowing most likely not needed on actual keyboard presses even though they get stuck also */
     if (CTRLON==-1)
@@ -598,15 +602,15 @@ void retro_poll_event()
                     j &= ~0x10;
 
                 /* Turbo fire */
-                if(turbo_fire_button != -1)
+                if (turbo_fire_button != -1)
                 {
                     if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, turbo_fire_button))
                     {
-                        if(turbo_state[vice_port])
+                        if (turbo_state[vice_port])
                         {
                             if (turbo_toggle[vice_port] > turbo_pulse)
                             {
-                                if((turbo_toggle[vice_port] / 2) == turbo_pulse)
+                                if ((turbo_toggle[vice_port] / 2) == turbo_pulse)
                                     turbo_toggle[vice_port] = 0;
                                 j &= ~0x10;
                             }
@@ -631,7 +635,7 @@ void retro_poll_event()
                     
                 joystick_value[vice_port] = j;
                     
-                //if(vice_port == 2) {
+                //if (vice_port == 2) {
                 //    printf("Joy %d: Button %d, %2d %d %d\n", vice_port, turbo_fire_button, j, turbo_state[vice_port], turbo_toggle[vice_port]);
                 //}
             }

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -59,7 +59,12 @@ int RETRORESET=0;
 int RETROSIDMODL=0;
 int RETRORESIDSAMPLING=0;
 int RETROC64MODL=0;
+#if defined(__X128__)
+int RETROC128COLUMNKEY=1;
+#endif
+#if defined(__VIC20__)
 int RETROVIC20MEM=0;
+#endif
 int RETROUSERPORTJOY=-1;
 int RETROEXTPAL=-1;
 int RETROAUTOSTARTWARP=0;
@@ -264,6 +269,10 @@ int ui_init_finalize(void)
 #else
    log_resources_set_int("VICIIBorderMode", RETROBORDERS);
 #endif
+#endif
+
+#if defined(__X128__)
+   log_resources_set_int("C128ColumnKey", RETROC128COLUMNKEY);
 #endif
 
 #if defined(__VIC20__)

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -58,6 +58,7 @@ int RETRODSE=0;
 int RETRORESET=0;
 int RETROSIDMODL=0;
 int RETRORESIDSAMPLING=0;
+int RETROAUDIOLEAK=0;
 int RETROC64MODL=0;
 #if defined(__X128__)
 int RETROC128COLUMNKEY=1;
@@ -243,6 +244,12 @@ int ui_init_finalize(void)
 #if !defined(__PET__) && !defined(__PLUS4__) && !defined(__VIC20__)
    sid_set_engine_model((RETROSIDMODL >> 8), (RETROSIDMODL & 0xff));
    log_resources_set_int("SidResidSampling", RETRORESIDSAMPLING);
+#endif
+
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+   log_resources_set_int("VICIIAudioLeak", RETROAUDIOLEAK);
+#elif defined(__VIC20__)
+   log_resources_set_int("VICAudioLeak", RETROAUDIOLEAK);
 #endif
 
 #if defined(__VIC20__) 

--- a/vice/src/vic20/vic20embedded.c
+++ b/vice/src/vic20/vic20embedded.c
@@ -110,6 +110,9 @@ int embedded_palette_load(const char *fname, palette_t *p)
                 p->entries[j].blue = entries[(j * 4) + 2];
                 p->entries[j].dither = entries[(j * 4) + 3];
             }
+#ifdef __LIBRETRO__
+            return 0;
+#endif
         }
         i++;
     }


### PR DESCRIPTION
- Core option for C128 video output (VIC-II / VDC)
-- For now it does the same as pressing the "40/80 display"-key and restarting, because back & forth dual use probably is not practical here..?
-- C128 still needs a completely new virtual keyboard layout, but all in due time
Closes #137 

- Simple fix in VICE source for VIC-20 embedded palettes not working
- VIC & VIC-II audio leak emulation option for true freaks
- Bonus tidyings
