### PR TITLE
Add support for warp-mode even if vsync is enabled

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -18,6 +18,7 @@
 #include "cartridge.h"
 #endif
 #include "initcmdline.h"
+#include "vsync.h"
 
 #include "compat/strcasestr.h"
 
@@ -2930,9 +2931,33 @@ void retro_run(void)
       runstate = RUNSTATE_RUNNING;
    } 
 
-   while (cpuloop==1)
-      maincpu_mainloop_retro();
-   cpuloop=1;
+   /* Measure frame-time and time between frames to render as much frames as possible when warp is enabled. Does not work
+      perfectly as the time needed by the framework cannot be accounted, but should not reduce amount of actually rendered
+      frames too much. */
+   {
+      static struct retro_perf_callback pcb;
+      if (!pcb.get_time_usec)
+         environ_cb(RETRO_ENVIRONMENT_GET_PERF_INTERFACE, &pcb);
+
+      static retro_time_t t_frame=0, t_end_prev=0;
+
+      retro_time_t t_begin=pcb.get_time_usec();
+      retro_time_t t_interframe=(t_end_prev ? t_begin-t_end_prev : 0);
+
+      for (int frame_count=0;frame_count<(retro_warp_mode_enabled() ? (t_interframe+t_frame)/t_frame : 1);++frame_count)
+      {
+         while(cpuloop==1)
+            maincpu_mainloop_retro();
+         cpuloop=1;
+
+         if (!frame_count)
+         {
+            retro_time_t t_end=pcb.get_time_usec();
+            t_end_prev=t_end;
+            t_frame=t_end-t_begin;
+         }
+      }
+   }
 
    retro_blit();
    if (SHOWKEY==1) app_render();

--- a/vice/src/vsync.c
+++ b/vice/src/vsync.c
@@ -80,6 +80,13 @@ static int refresh_rate;
 /* "Warp mode".  If nonzero, attempt to run as fast as possible. */
 static int warp_mode_enabled;
 
+#ifdef __LIBRETRO__
+int retro_warp_mode_enabled()
+{
+	return warp_mode_enabled;
+}
+#endif
+
 
 static int set_relative_speed(int val, void *param)
 {

--- a/vice/src/vsync.h
+++ b/vice/src/vsync.h
@@ -33,6 +33,10 @@
 #define VSYNC_DEBUG
 #endif
 
+#ifdef __LIBRETRO__
+int retro_warp_mode_enabled();
+#endif
+
 struct video_canvas_s;
 
 extern int vsync_frame_counter;


### PR DESCRIPTION
Warp with vsync works by measuring render- and idle-times per frame, then rendering as many frames as fit in the remaining idle time. This ensure screen updates at full display framerate and prompt reaction on warp exit. Without vsync the loop just runs once as t_interframe is 0 because retro_blit() won't block.
The code could also be moved to vsync.c if keeping code in retro_run as small as possible is desired.