### PR TITLE
Add support for warp-mode even if vsync is enabled

### DIFF
--- a/vice/src/vsync.c
+++ b/vice/src/vsync.c
@@ -80,6 +80,13 @@ static int refresh_rate;
 /* "Warp mode".  If nonzero, attempt to run as fast as possible. */
 static int warp_mode_enabled;
 
+#ifdef __LIBRETRO__
+int retro_warp_mode_enabled()
+{
+	return warp_mode_enabled;
+}
+#endif
+
 
 static int set_relative_speed(int val, void *param)
 {

--- a/vice/src/vsync.h
+++ b/vice/src/vsync.h
@@ -33,6 +33,10 @@
 #define VSYNC_DEBUG
 #endif
 
+#ifdef __LIBRETRO__
+int retro_warp_mode_enabled();
+#endif
+
 struct video_canvas_s;
 
 extern int vsync_frame_counter;


### PR DESCRIPTION
Warp with vsync works by measuring render- and idle-times per frame, then rendering as many frames as fit in the remaining idle time. This ensure screen updates at full display framerate and prompt reaction on warp exit. Without vsync the loop just runs once as t_interframe is 0 because retro_blit() won't block.
The code could also be moved to vsync.c if keeping code in retro_run as small as possible is desired.