### PR TITLE
Enable SID model to override C64 model

### DIFF
--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -241,11 +241,6 @@ int ui_init_finalize(void)
 
    log_resources_set_int("AutostartWarp", RETROAUTOSTARTWARP);
 
-#if !defined(__PET__) && !defined(__PLUS4__) && !defined(__VIC20__)
-   sid_set_engine_model((RETROSIDMODL >> 8), (RETROSIDMODL & 0xff));
-   log_resources_set_int("SidResidSampling", RETRORESIDSAMPLING);
-#endif
-
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
    log_resources_set_int("VICIIAudioLeak", RETROAUDIOLEAK);
 #elif defined(__VIC20__)
@@ -266,6 +261,11 @@ int ui_init_finalize(void)
    ;
 #else
    c64model_set(RETROC64MODL);
+#endif
+
+#if !defined(__PET__) && !defined(__PLUS4__) && !defined(__VIC20__)
+   sid_set_engine_model((RETROSIDMODL >> 8), (RETROSIDMODL & 0xff));
+   log_resources_set_int("SidResidSampling", RETRORESIDSAMPLING);
 #endif
 
 #if !defined(__PET__) && !defined(__CBM2__)


### PR DESCRIPTION
Previously the C64 model would always override the specified SID model,
this is fixed by reordering loading of core options.
New values 'Default FastSID/ReSID' have been added to explicitely enable
SID model selection by C64 model.