### PR TITLE
Start core with all parameters, not just core-name

### DIFF
--- a/vice/src/arch/libretro/archdep.c
+++ b/vice/src/arch/libretro/archdep.c
@@ -485,12 +485,17 @@ int archdep_expand_path(char **return_path, const char *orig_name)
     return 0;
 }
 
+char archdep_startup_error[4096];
+
 void archdep_startup_log_error(const char *format, ...)
 {
     va_list ap;
 
+    char *begin=archdep_startup_error+strlen(archdep_startup_error);
+    char *end=archdep_startup_error+sizeof(archdep_startup_error);
+
     va_start(ap, format);
-    vfprintf(stderr, format, ap);
+    begin+=vsnprintf(begin, end-begin, format, ap);
 }
 
 char *archdep_filename_parameter(const char *name)


### PR DESCRIPTION
This restores functionality of a few commandline-parameters.

As I found some commandline-options to have no effect at all, I changed this just to see what breaks and works - and was surprised that not only options like -autostart-delay now work, there were no ill side-effects to see, build_params() being declared right above the call suggests it was supposed to be used here.
Maybe some long-gone bug was reason to not pass the options here?
If it turns out there are options that cause an issue when parsed here but work fine when parsed later, they could still be filtered out here.