### PR TITLE
Core option for enabling/disabling 'vicerc'

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -113,6 +113,7 @@ unsigned int zoomed_height;
 unsigned int opt_read_vicerc = 0;
 static unsigned int opt_read_vicerc_prev = 0;
 static unsigned int request_reload_restart = 0;
+static unsigned int sound_volume_counter = 3;
 
 extern unsigned int datasette_hotkeys;
 extern unsigned int cur_port;
@@ -3156,12 +3157,22 @@ void retro_run(void)
    retro_blit();
    if (SHOWKEY==1) app_render();
 
+   /* Virtual keyboard mouse position reset */
    if (request_reset_mouse_pos)
    {
       request_reset_mouse_pos = false;
       reset_mouse_pos();
    }
 
+   /* Set volume back to maximum after starting with mute, due to ReSID 6581 init pop */
+   if (sound_volume_counter > 0)
+   {
+       sound_volume_counter--;
+       if (sound_volume_counter == 0)
+           log_resources_set_int("SoundVolume", 100);
+   }
+
+   /* Zoom mode init */
    if (zoom_mode_id_prev == -1)
    {
       zoomed_width = retroW;

--- a/vice/src/arch/libretro/archdep.c
+++ b/vice/src/arch/libretro/archdep.c
@@ -78,7 +78,7 @@ int maincpu_stretch;
 #include "../shared/archdep_atexit.c"
 #include "../shared/archdep_extra_title_text.c"
 
-
+extern unsigned int opt_read_vicerc;
 
 static char *argv0 = NULL;
 static char *boot_path = NULL;
@@ -296,7 +296,10 @@ char *archdep_default_resource_file_name(void)
       home = archdep_home_path();
       return util_concat(home, "/.vice/vicerc", NULL);
     } else {
-      return util_concat(archdep_pref_path, "/vicerc", NULL);
+        if (opt_read_vicerc)
+            return util_concat(archdep_pref_path, FSDEV_DIR_SEP_STR, "vicerc", NULL);
+        else
+            return NULL;
     }
 }
 

--- a/vice/src/arch/libretro/archdep.h
+++ b/vice/src/arch/libretro/archdep.h
@@ -88,9 +88,8 @@
 #define archdep_signals_pipe_set()
 #define archdep_signals_pipe_unset()
 
-#define ARCHDEP_SOUND_FRAGMENT_SIZE SOUND_FRAGMENT_MEDIUM
-
 #else
+
 /* Filesystem dependant operators.  */
 #define FSDEVICE_DEFAULT_DIR   "."
 #define FSDEV_DIR_SEP_STR      "/"
@@ -141,9 +140,11 @@
 #define archdep_signals_pipe_set()
 #define archdep_signals_pipe_unset()
 
-/* Default sound fragment size */
-#define ARCHDEP_SOUND_FRAGMENT_SIZE 1
 #endif
+
+/* Default sound fragment size */
+#define ARCHDEP_SOUND_FRAGMENT_SIZE SOUND_FRAGMENT_VERY_SMALL
+
 /* Video chip scaling.  */
 #define ARCHDEP_VICII_DSIZE   1
 #define ARCHDEP_VICII_DSCAN   1

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -164,6 +164,9 @@ int ui_init_finalize(void)
    log_resources_set_int("Mouse", 0);
    log_resources_set_int("AutostartPrgMode", 1);
 
+   /* Mute sound at startup to hide 6581 ReSID init pop, and set back to 100 in retro_run() after 3 frames */
+   log_resources_set_int("SoundVolume", 0);
+
 #if defined(__CBM2__) || defined(__PET__)
    log_resources_set_int("CrtcFilter", 0);
    log_resources_set_int("CrtcStretchVertical", 0);

--- a/vice/src/sounddrv/soundretro.c
+++ b/vice/src/sounddrv/soundretro.c
@@ -9,23 +9,21 @@
 
 #include "sound.h"
 
-extern void retro_audiocb(signed short int *sound_buffer,int sndbufsize);
+extern void retro_audiocb(signed short int *sound_buffer, int sndbufsize);
 
-static int retro_sound_init(const char *param, int *speed,
-            int *fragsize, int *fragnr, int *channels)
+static int retro_sound_init(const char *param, int *speed, int *fragsize, int *fragnr, int *channels)
 {
-  *speed = 44100;
-  *fragsize = (*speed)/50;
-  *channels = 1;
-
-  //int buffer_size = (*fragnr) * (*channels) * (*fragsize) + 1;
-
-  return 0;
+    //*speed = 44100;
+    *fragsize = 1;
+    *fragnr = 0;
+    //*channels = 1;
+    //printf("speed:%d fragsize:%d fragnr:%d channels:%d\n", *speed, *fragsize, *fragnr, *channels);
+    return 0;
 }
 
 static int retro_write(SWORD *pbuf, size_t nr)
 {
-    //printf("nr:%d ",nr);
+    //printf("pbuf:%d nr:%d\n", *pbuf, nr);
     retro_audiocb(pbuf, nr);
     return 0;
 }


### PR DESCRIPTION
Helps out with #164 but does not solve it.

Also tweaked soundretro a bit, and hopefully the small reduction in sound delay was not placebo, so please test intensively. No ill-effects noticed after a long test session.

And added a small hack to mute the sound at startup and bring it back to max after 3 frames, because 6581 ReSID does that little nasty pop at init.
