### PR TITLE
Zoom mode streamlining

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -9,6 +9,7 @@ https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.tar.gz
 
 ## Recent improvements
 
+- Zoom mode
 - Savestates
 - Vice 3.3 update
 - x64sc / xpet
@@ -20,7 +21,7 @@ https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.tar.gz
 - C64 joystick disabled while using virtual keyboard
 - Cursor keys disabled while using C64 joystick
 - New settings:
-  - Drive Sound Emulation + Volume
+  - Drive sound emulation
   - Reset type (autostart, soft, hard)
   - Customizable keymaps for essential functions (virtual keyboard, statusbar, joyport switch, reset, datasette controls)
   - Analog sticks mappable

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -30,9 +30,13 @@
 #define uint32 uint32_t
 #define uint8 uint8_t
 
-#define WINDOW_WIDTH 1024
-#define WINDOW_HEIGHT 768
-#define WINDOW_SIZE (1024*768)
+#if defined(__X128__)
+#define WINDOW_WIDTH 856
+#else
+#define WINDOW_WIDTH 720
+#endif
+#define WINDOW_HEIGHT 576
+#define WINDOW_SIZE (WINDOW_WIDTH*WINDOW_HEIGHT)
 
 #ifdef FRONTEND_SUPPORTS_RGB565
 #define M16B

--- a/libretro/nukleargui/gui.i
+++ b/libretro/nukleargui/gui.i
@@ -65,6 +65,10 @@ static int gui(struct nk_context *ctx)
                         offset.x -= 16;
                         offset.y -= 26;
                     }
+#elif defined(__PLUS4__)
+                    offset.y += 5;
+                    if (retro_get_region() == RETRO_REGION_NTSC)
+                        offset.y -= 22;
 #else
                     if (retro_get_region() == RETRO_REGION_NTSC)
                         offset.y -= 12;

--- a/libretro/nukleargui/nuklear/style.c
+++ b/libretro/nukleargui/nuklear/style.c
@@ -42,12 +42,12 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_TAB_HEADER] = nk_rgba(48, 83, 111, 255);
         nk_style_from_table(ctx, table);
     } else if (theme == THEME_C64C) {
-        table[NK_COLOR_TEXT] = nk_rgba(1, 1, 1, 255);
+        table[NK_COLOR_TEXT] = nk_rgba(8, 8, 8, 255);
         table[NK_COLOR_WINDOW] = nk_rgba(0, 0, 0, 0);
         table[NK_COLOR_HEADER] = nk_rgba(157, 152, 149, 255); // function keys
-        table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 10); 
+        table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 10);
         table[NK_COLOR_BUTTON] = nk_rgba(216, 209, 201, 255); // regular keys
-        table[NK_COLOR_BUTTON_HOVER] = nk_rgba(240, 240, 240, 255);
+        table[NK_COLOR_BUTTON_HOVER] = nk_rgba(230, 230, 230, 255);
         table[NK_COLOR_BUTTON_ACTIVE] = nk_rgba(255, 255, 255, 255);
         table[NK_COLOR_TOGGLE] = nk_rgba(50, 58, 61, 255);
         table[NK_COLOR_TOGGLE_HOVER] = nk_rgba(45, 53, 56, 255);
@@ -72,13 +72,13 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_TAB_HEADER] = nk_rgba(48, 83, 111, 255);
         nk_style_from_table(ctx, table);
     } else if (theme == THEME_C64_TRANSPARENT) {
-        table[NK_COLOR_TEXT] = nk_rgba(250, 250, 250, 255);
+        table[NK_COLOR_TEXT] = nk_rgba(254, 254, 254, 255);
         table[NK_COLOR_WINDOW] = nk_rgba(0, 0, 0, 0);
-        table[NK_COLOR_HEADER] = nk_rgba(123, 127, 130, 200); // function keys
-        table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 1);
-        table[NK_COLOR_BUTTON] = nk_rgba(69, 59, 58, 200); // regular keys
-        table[NK_COLOR_BUTTON_HOVER] = nk_rgba(165, 163, 160, 200);
-        table[NK_COLOR_BUTTON_ACTIVE] = nk_rgba(48, 44, 45, 200);
+        table[NK_COLOR_HEADER] = nk_rgba(123, 127, 130, 180); // function keys
+        table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 0);
+        table[NK_COLOR_BUTTON] = nk_rgba(69, 59, 58, 180); // regular keys
+        table[NK_COLOR_BUTTON_HOVER] = nk_rgba(165, 163, 160, 180);
+        table[NK_COLOR_BUTTON_ACTIVE] = nk_rgba(48, 44, 45, 180);
         table[NK_COLOR_TOGGLE] = nk_rgba(50, 58, 61, 255);
         table[NK_COLOR_TOGGLE_HOVER] = nk_rgba(45, 53, 56, 255);
         table[NK_COLOR_TOGGLE_CURSOR] = nk_rgba(48, 83, 111, 255);
@@ -86,9 +86,9 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_SELECT_ACTIVE] = nk_rgba(48, 83, 111, 255);
         table[NK_COLOR_SLIDER] = nk_rgba(50, 58, 61, 255);
         table[NK_COLOR_SLIDER_CURSOR] = nk_rgba(48, 83, 111, 245);
-        table[NK_COLOR_SLIDER_CURSOR_HOVER] = nk_rgba(89, 79, 78, 200); // datasette
-        table[NK_COLOR_SLIDER_CURSOR_ACTIVE] = nk_rgba(128, 0, 0, 200); // reset
-        table[NK_COLOR_PROPERTY] = nk_rgba(144, 141, 129, 200); // hotkeys
+        table[NK_COLOR_SLIDER_CURSOR_HOVER] = nk_rgba(89, 79, 78, 180); // datasette
+        table[NK_COLOR_SLIDER_CURSOR_ACTIVE] = nk_rgba(128, 0, 0, 180); // reset
+        table[NK_COLOR_PROPERTY] = nk_rgba(144, 141, 129, 180); // hotkeys
         table[NK_COLOR_EDIT] = nk_rgba(50, 58, 61, 225);
         table[NK_COLOR_EDIT_CURSOR] = nk_rgba(210, 210, 210, 255);
         table[NK_COLOR_COMBO] = nk_rgba(50, 58, 61, 255);
@@ -104,11 +104,11 @@ set_style(struct nk_context *ctx, enum theme theme)
     } else if (theme == THEME_C64C_TRANSPARENT) {
         table[NK_COLOR_TEXT] = nk_rgba(1, 1, 1, 255);
         table[NK_COLOR_WINDOW] = nk_rgba(0, 0, 0, 0);
-        table[NK_COLOR_HEADER] = nk_rgba(157, 152, 149, 200); // function keys
-        table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 10); 
-        table[NK_COLOR_BUTTON] = nk_rgba(216, 209, 201, 200); // regular keys
-        table[NK_COLOR_BUTTON_HOVER] = nk_rgba(240, 240, 240, 200);
-        table[NK_COLOR_BUTTON_ACTIVE] = nk_rgba(255, 255, 255, 200);
+        table[NK_COLOR_HEADER] = nk_rgba(157, 152, 149, 180); // function keys
+        table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 0);
+        table[NK_COLOR_BUTTON] = nk_rgba(216, 209, 201, 180); // regular keys
+        table[NK_COLOR_BUTTON_HOVER] = nk_rgba(240, 240, 240, 180);
+        table[NK_COLOR_BUTTON_ACTIVE] = nk_rgba(255, 255, 255, 180);
         table[NK_COLOR_TOGGLE] = nk_rgba(50, 58, 61, 255);
         table[NK_COLOR_TOGGLE_HOVER] = nk_rgba(45, 53, 56, 255);
         table[NK_COLOR_TOGGLE_CURSOR] = nk_rgba(48, 83, 111, 255);
@@ -116,9 +116,9 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_SELECT_ACTIVE] = nk_rgba(48, 83, 111, 255);
         table[NK_COLOR_SLIDER] = nk_rgba(50, 58, 61, 255);
         table[NK_COLOR_SLIDER_CURSOR] = nk_rgba(48, 83, 111, 245);
-        table[NK_COLOR_SLIDER_CURSOR_HOVER] = nk_rgba(109, 99, 98, 200); // datasette
-        table[NK_COLOR_SLIDER_CURSOR_ACTIVE] = nk_rgba(128, 0, 0, 200); // reset
-        table[NK_COLOR_PROPERTY] = nk_rgba(144, 141, 124, 200); // hotkeys
+        table[NK_COLOR_SLIDER_CURSOR_HOVER] = nk_rgba(109, 99, 98, 180); // datasette
+        table[NK_COLOR_SLIDER_CURSOR_ACTIVE] = nk_rgba(128, 0, 0, 180); // reset
+        table[NK_COLOR_PROPERTY] = nk_rgba(144, 141, 124, 180); // hotkeys
         table[NK_COLOR_EDIT] = nk_rgba(50, 58, 61, 225);
         table[NK_COLOR_EDIT_CURSOR] = nk_rgba(210, 210, 210, 255);
         table[NK_COLOR_COMBO] = nk_rgba(50, 58, 61, 255);
@@ -132,12 +132,12 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_TAB_HEADER] = nk_rgba(48, 83, 111, 255);
         nk_style_from_table(ctx, table);
     } else if (theme == THEME_DARK_TRANSPARENT) {
-        table[NK_COLOR_TEXT] = nk_rgba(250, 250, 250, 255);
+        table[NK_COLOR_TEXT] = nk_rgba(254, 254, 254, 255);
         table[NK_COLOR_WINDOW] = nk_rgba(0, 0, 0, 0);
-        table[NK_COLOR_HEADER] = nk_rgba(80, 80, 80, 200); // function keys
-        table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 1); 
-        table[NK_COLOR_BUTTON] = nk_rgba(32, 32, 32, 200); // regular keys
-        table[NK_COLOR_BUTTON_HOVER] = nk_rgba(144, 144, 144, 200);
+        table[NK_COLOR_HEADER] = nk_rgba(80, 80, 80, 180); // function keys
+        table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 0);
+        table[NK_COLOR_BUTTON] = nk_rgba(32, 32, 32, 180); // regular keys
+        table[NK_COLOR_BUTTON_HOVER] = nk_rgba(120, 120, 120, 180);
         table[NK_COLOR_BUTTON_ACTIVE] = nk_rgba(64, 64, 64, 224);
         table[NK_COLOR_TOGGLE] = nk_rgba(50, 58, 61, 255);
         table[NK_COLOR_TOGGLE_HOVER] = nk_rgba(45, 53, 56, 255);
@@ -146,9 +146,9 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_SELECT_ACTIVE] = nk_rgba(48, 83, 111, 255);
         table[NK_COLOR_SLIDER] = nk_rgba(50, 58, 61, 255);
         table[NK_COLOR_SLIDER_CURSOR] = nk_rgba(48, 83, 111, 245);
-        table[NK_COLOR_SLIDER_CURSOR_HOVER] = nk_rgba(50, 50, 50, 200); // datasette
-        table[NK_COLOR_SLIDER_CURSOR_ACTIVE] = nk_rgba(128, 0, 0, 200); // reset
-        table[NK_COLOR_PROPERTY] = nk_rgba(16, 16, 16, 200); // hotkeys
+        table[NK_COLOR_SLIDER_CURSOR_HOVER] = nk_rgba(50, 50, 50, 180); // datasette
+        table[NK_COLOR_SLIDER_CURSOR_ACTIVE] = nk_rgba(128, 0, 0, 180); // reset
+        table[NK_COLOR_PROPERTY] = nk_rgba(16, 16, 16, 180); // hotkeys
         table[NK_COLOR_EDIT] = nk_rgba(50, 58, 61, 225);
         table[NK_COLOR_EDIT_CURSOR] = nk_rgba(210, 210, 210, 255);
         table[NK_COLOR_COMBO] = nk_rgba(50, 58, 61, 255);
@@ -164,11 +164,11 @@ set_style(struct nk_context *ctx, enum theme theme)
     } else if (theme == THEME_LIGHT_TRANSPARENT) {
         table[NK_COLOR_TEXT] = nk_rgba(1, 1, 1, 255);
         table[NK_COLOR_WINDOW] = nk_rgba(0, 0, 0, 0);
-        table[NK_COLOR_HEADER] = nk_rgba(180, 180, 180, 200); // function keys
-        table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 1); 
-        table[NK_COLOR_BUTTON] = nk_rgba(220, 220, 220, 200); // regular keys
-        table[NK_COLOR_BUTTON_HOVER] = nk_rgba(230, 230, 230, 224);
-        table[NK_COLOR_BUTTON_ACTIVE] = nk_rgba(255, 255, 255, 224);
+        table[NK_COLOR_HEADER] = nk_rgba(180, 180, 180, 180); // function keys
+        table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 0);
+        table[NK_COLOR_BUTTON] = nk_rgba(220, 220, 220, 180); // regular keys
+        table[NK_COLOR_BUTTON_HOVER] = nk_rgba(120, 120, 120, 180);
+        table[NK_COLOR_BUTTON_ACTIVE] = nk_rgba(255, 255, 255, 180);
         table[NK_COLOR_TOGGLE] = nk_rgba(50, 58, 61, 255);
         table[NK_COLOR_TOGGLE_HOVER] = nk_rgba(45, 53, 56, 255);
         table[NK_COLOR_TOGGLE_CURSOR] = nk_rgba(48, 83, 111, 255);
@@ -176,9 +176,9 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_SELECT_ACTIVE] = nk_rgba(48, 83, 111, 255);
         table[NK_COLOR_SLIDER] = nk_rgba(50, 58, 61, 255);
         table[NK_COLOR_SLIDER_CURSOR] = nk_rgba(48, 83, 111, 245);
-        table[NK_COLOR_SLIDER_CURSOR_HOVER] = nk_rgba(190, 190, 190, 200); // datasette
-        table[NK_COLOR_SLIDER_CURSOR_ACTIVE] = nk_rgba(128, 0, 0, 200); // reset
-        table[NK_COLOR_PROPERTY] = nk_rgba(160, 160, 160, 200); // hotkeys
+        table[NK_COLOR_SLIDER_CURSOR_HOVER] = nk_rgba(190, 190, 190, 180); // datasette
+        table[NK_COLOR_SLIDER_CURSOR_ACTIVE] = nk_rgba(128, 0, 0, 180); // reset
+        table[NK_COLOR_PROPERTY] = nk_rgba(160, 160, 160, 180); // hotkeys
         table[NK_COLOR_EDIT] = nk_rgba(50, 58, 61, 225);
         table[NK_COLOR_EDIT_CURSOR] = nk_rgba(210, 210, 210, 255);
         table[NK_COLOR_COMBO] = nk_rgba(50, 58, 61, 255);

--- a/libretro/nukleargui/retro/nuklear_retro_soft.h
+++ b/libretro/nukleargui/retro/nuklear_retro_soft.h
@@ -256,19 +256,17 @@ nk_retro_draw_text(RSDL_Surface *surface, short x, short y, unsigned short w, un
     for (i = 0; i < len; i++) {
         //characterRGBA(surface, x, y, text[i], cfg.r, cfg.g, cfg.b, cfg.a);
 #ifdef M16B
+        if (cfg.r == 1)
+            Retro_Draw_char(surface, x+1, y+1, text[i], 1, 1, 180<<8|180<<3|180>>3, 0);
+        else if (cfg.r == 254)
+            Retro_Draw_char(surface, x-1, y-1, text[i], 1, 1, 40<<8|40<<3|40>>3, 0);
 
-	Retro_Draw_char(surface,  x,  y,  text[i],  1, 1,cfg.r<<8|cfg.g<<3|cfg.b>>3,0);
-
-//	Retro_Draw_char(surface,  x,  y,  text[i],  1, 1,/*cfg.a<<8|*/cfg.r<<8|cfg.g<<3|cfg.b>>3, /*cbg.a<<24|*/cbg.r<<8|cbg.g<<3|cbg.b>>3);
+        Retro_Draw_char(surface, x, y, text[i], 1, 1, cfg.r<<8|cfg.g<<3|cfg.b>>3, 0);
 #else
-	Retro_Draw_char(surface,  x,  y,  text[i],  1, 1,cfg.a<<24|cfg.r<<16|cfg.g<<8|cfg.b, cbg.a<<24|cbg.r<<16|cbg.g<<8|cbg.b);
+        Retro_Draw_char(surface, x, y, text[i], 1, 1, cfg.a<<24|cfg.r<<16|cfg.g<<8|cfg.b, cbg.a<<24|cbg.r<<16|cbg.g<<8|cbg.b);
 #endif
         x += font->width;
     }
-
-//FIXME TODO
-// Retro_Draw_string(surface,  x,  y,  text, len, 1, 1,cfg.a<<24|cfg.r<<16|cfg.g<<8|cfg.b, cbg.a<<24|cbg.r<<16|cbg.g<<8|cbg.b);
-
 }
 static void
 interpolate_color(struct nk_color c1, struct nk_color c2, struct nk_color *result, float fraction)

--- a/libretro/nukleargui/vkboard.i
+++ b/libretro/nukleargui/vkboard.i
@@ -8,14 +8,14 @@ ctx->style.window.padding = nk_vec2(3,2);
 ctx->style.window.spacing = nk_vec2(2,2);
 
 ctx->style.button.padding = nk_vec2(0,0);
-ctx->style.button.border = 1;
-ctx->style.button.rounding = 1;
+ctx->style.button.border = 0;
+ctx->style.button.rounding = 0;
 
 struct nk_style_item key_color_default = ctx->style.button.normal;
-struct nk_style_item key_color_alt = ctx->style.window.header.normal;
+struct nk_style_item key_color_function = ctx->style.window.header.normal;
 struct nk_style_item key_color_hotkey = ctx->style.property.normal;
-struct nk_style_item key_color_reset = ctx->style.slider.cursor_active;
 struct nk_style_item key_color_datasette = ctx->style.slider.cursor_hover;
+struct nk_style_item key_color_reset = ctx->style.slider.cursor_active;
 
 #if defined(__VIC20__)
 nk_layout_row_dynamic(ctx, 23, NPLGN);
@@ -26,47 +26,48 @@ nk_button_set_behavior(ctx, NK_BUTTON_REPEATER);
 
 vkey_pressed = -1;
 
-for(y=0;y<NLIGN;y++)
+for(y=0; y<NLIGN; y++)
 {
-      for(x=0;x<NPLGN;x++)
-      {
-             /* Reset default color */
-             ctx->style.button.normal = key_color_default;
+    for(x=0; x<NPLGN; x++)
+    {
+        /* Reset default color */
+        ctx->style.button.normal = key_color_default;
 
-             /* Function key color */
-             if(strcmp(MVk[(y*NPLGN)+x].norml, "F1") == 0 
-             || strcmp(MVk[(y*NPLGN)+x].norml, "F3") == 0 
-             || strcmp(MVk[(y*NPLGN)+x].norml, "F5") == 0 
-             || strcmp(MVk[(y*NPLGN)+x].norml, "F7") == 0
-             )
-                    ctx->style.button.normal = key_color_alt;
+        /* Function key color */
+        if(strcmp(MVk[(y*NPLGN)+x].norml, "F1") == 0
+        || strcmp(MVk[(y*NPLGN)+x].norml, "F3") == 0
+        || strcmp(MVk[(y*NPLGN)+x].norml, "F5") == 0
+        || strcmp(MVk[(y*NPLGN)+x].norml, "F7") == 0
+        )
+            ctx->style.button.normal = key_color_function;
 
-             /* Hotkey color */
-             if(strcmp(MVk[(y*NPLGN)+x].norml, "Joy") == 0
-             || strcmp(MVk[(y*NPLGN)+x].norml, "Stb") == 0
-             || strcmp(MVk[(y*NPLGN)+x].norml, "Rst") == 0
-             || strcmp(MVk[(y*NPLGN)+x].norml, "Ttf") == 0
-             )
-                    ctx->style.button.normal = key_color_hotkey;
+        /* Hotkey color */
+        if(strcmp(MVk[(y*NPLGN)+x].norml, "Joy") == 0
+        || strcmp(MVk[(y*NPLGN)+x].norml, "Stb") == 0
+        || strcmp(MVk[(y*NPLGN)+x].norml, "Rst") == 0
+        || strcmp(MVk[(y*NPLGN)+x].norml, "Ttf") == 0
+        )
+            ctx->style.button.normal = key_color_hotkey;
 
-             /* Reset color */
-             if(strcmp(MVk[(y*NPLGN)+x].norml, "Rst") == 0)
-                    ctx->style.button.normal = key_color_reset;
+        /* Datasette color */
+        if(strcmp(MVk[(y*NPLGN)+x].norml, "DRe") == 0
+        || strcmp(MVk[(y*NPLGN)+x].norml, "DSt") == 0
+        || strcmp(MVk[(y*NPLGN)+x].norml, "DFw") == 0
+        || strcmp(MVk[(y*NPLGN)+x].norml, "DRs") == 0
+        || strcmp(MVk[(y*NPLGN)+x].norml, "DPl") == 0
+        )
+            ctx->style.button.normal = key_color_datasette;
 
-             /* Datasette color */
-             if(strcmp(MVk[(y*NPLGN)+x].norml, "DRe") == 0
-             || strcmp(MVk[(y*NPLGN)+x].norml, "DSt") == 0
-             || strcmp(MVk[(y*NPLGN)+x].norml, "DFw") == 0
-             || strcmp(MVk[(y*NPLGN)+x].norml, "DRs") == 0
-             || strcmp(MVk[(y*NPLGN)+x].norml, "DPl") == 0
-             )
-                    ctx->style.button.normal = key_color_datasette;
+        /* Reset color */
+        if(strcmp(MVk[(y*NPLGN)+x].norml, "Rst") == 0)
+            ctx->style.button.normal = key_color_reset;
 
-             if (nk_button_text(ctx, SHIFTON == -1 ? MVk[(y*NPLGN)+x].norml : MVk[(y*NPLGN)+x].shift , \
-             SHIFTON == -1 ? strlen(MVk[(y*NPLGN)+x].norml) : strlen(MVk[(y*NPLGN)+x].shift)))
-             {
-                    //LOGI("(%s) pressed! (%d,%d)\n", SHIFTON == -1 ? MVk[(y*NPLGN)+x].norml : MVk[(y*NPLGN)+x].shift,x,y);
-                    vkey_pressed=MVk[(y*NPLGN)+x].val;
-             }
-      }
+        if (nk_button_text(ctx, SHIFTON == -1 ? MVk[(y*NPLGN)+x].norml : MVk[(y*NPLGN)+x].shift, \
+            SHIFTON == -1 ? strlen(MVk[(y*NPLGN)+x].norml) : strlen(MVk[(y*NPLGN)+x].shift)))
+        {
+            //LOGI("(%s) pressed! (%d,%d)\n", SHIFTON == -1 ? MVk[(y*NPLGN)+x].norml : MVk[(y*NPLGN)+x].shift,x,y);
+            vkey_pressed=MVk[(y*NPLGN)+x].val;
+        }
+    }
 }
+

--- a/vice/src/arch/libretro/uistatusbar.c
+++ b/vice/src/arch/libretro/uistatusbar.c
@@ -535,9 +535,32 @@ unsigned int color_f, color_b;
     /* Placement on bottom + inside VICII */
     int x, y;
     int border = 0;
-#if !defined(__PET__) && !defined(__CBM2__)
-#if defined(__PLUS4__)
+#if defined(__CBM2__)
+    x=32;
+    y=226;
+#elif defined(__PET__)
+    x=32;
+    y=226;
+#elif defined(__PLUS4__)
     resources_get_int("TEDBorderMode", &border);
+    switch (border)
+    {
+        default:
+        case 0:
+            x=32;
+            y=232;
+            if (retro_get_region() == RETRO_REGION_NTSC)
+            {
+                x=32;
+                y=210;
+            }
+            break;
+
+        case 3:
+            x=0;
+            y=192;
+            break;
+    }
 #elif defined(__VIC20__)
     resources_get_int("VICBorderMode", &border);
     switch (border)
@@ -578,7 +601,6 @@ unsigned int color_f, color_b;
 #endif
     x -= retroXS_offset;
     y -= retroYS_offset;
-#endif
 
     if (imagename_timer > 0)
         imagename_timer--;


### PR DESCRIPTION
- Enabled zoom mode on X128 & XPLUS4
- Fixed statusbar location on XPET & XCBM2 & PLUS4
- Finetuned VKBD for legibility on transparency modes with text shadow

Plus performance bonuses:
- Removed VKBD buttons rounded borders
- Made Retro_Screen size smaller

Both of those allowed to add 1 more ms of frame delay while VKBD is on. Before those I could only do 12 without getting skipped frames, but now 14 is ok.
