### PR TITLE
Add a COMMONFLAG for x64 just like the others

### DIFF
--- a/Makefile.x64
+++ b/Makefile.x64
@@ -1,3 +1,5 @@
+COMMONFLAGS += -D__X64__
+
 INCFLAGS += \
 		-I$(EMU)/sid \
 		-I$(EMU) \


### PR DESCRIPTION
A couple of options was mistakenly relying on an unexisting flag, so why not add it also for clarity.
