### PR TITLE
Makefile-fix to support .cpp-sources

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -339,7 +339,7 @@ include Makefile.common
 
 COMMONFLAGS += -DCORE_NAME=\"$(EMUTYPE)\"
 
-OBJECTS     += $(SOURCES_CXX:.cc=.o) $(SOURCES_C:.c=.o)
+OBJECTS     += $(patsubst %.cpp,%.o,$(SOURCES_CXX:.cc=.o)) $(SOURCES_C:.c=.o)
 CXXFLAGS    += -D__LIBRETRO__ $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 CFLAGS      += -D__LIBRETRO__ $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 LDFLAGS     += -lm $(fpic)


### PR DESCRIPTION
Currently these changes have no relevance as CFLAGS and CXXFLAGS are the
same and gcc autodetects C or C++-mode anyway, but this should prevent
future trouble.
Also properly support C++-sources with .cpp-extension, they need their
own sources-list (currently empty as their are no such files afaik).