### PR TITLE
Fix compiling x64scpu

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -107,7 +107,7 @@ extern int RETROTHEME;
 extern int RETROKEYRAHKEYPAD;
 extern int RETROKEYBOARDPASSTHROUGH;
 extern char RETROEXTPALNAME[512];
-#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
 extern int RETROVICIICOLORGAMMA;
 extern int RETROVICIICOLORSATURATION;
 extern int RETROVICIICOLORCONTRAST;

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -75,7 +75,7 @@ int RETROTHEME=0;
 int RETROKEYRAHKEYPAD=0;
 int RETROKEYBOARDPASSTHROUGH=0;
 char RETROEXTPALNAME[512]="pepto-pal";
-#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
 int RETROVICIICOLORGAMMA=2200;
 int RETROVICIICOLORSATURATION=1250;
 int RETROVICIICOLORCONTRAST=1250;


### PR DESCRIPTION
Added missing check for __XSCPU64__
As I found very few checks for that define but many for __X64__ I wonder, does this build currently include everything required to run properly?