### PR TITLE
Bunch of fixes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -78,8 +78,6 @@ xvic -memory 1 /path/to/rom/some-8k-game.d64
 
 LIBDIR set to retro_system_dir
 
-Add WANT_RGB565=1 to make for RGB565 16 bits depth (32 bits depth default)
-
 ### Linux
 ```
 CC=gcc make -f Makefile.libretro -j10

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3496,7 +3496,7 @@ void update_geometry(int mode)
                   break;
                case 3:
                   zoomed_width        = (retro_region == RETRO_REGION_NTSC) ? retroW : 392;
-                  zoomed_XS_offset    = (retro_region == RETRO_REGION_NTSC) ? 8 : 28;
+                  zoomed_XS_offset    = (retro_region == RETRO_REGION_NTSC) ? 8 : 14;
                   zoomed_height       = 184;
                   zoomed_YS_offset    = (retro_region == RETRO_REGION_NTSC) ? 22 : 48;
                   break;
@@ -3747,7 +3747,11 @@ void retro_run(void)
            log_resources_set_int("SoundVolume", 100);
    }
 
-   video_cb(Retro_Screen, zoomed_width, zoomed_height, retrow<<(pix_bytes / 2));
+   /* Statusbar disk display timer */
+   if (imagename_timer > 0)
+      imagename_timer--;
+
+   video_cb(Retro_Screen+(retroXS_offset*pix_bytes)+(retroYS_offset*(retrow<<(pix_bytes/4))), zoomed_width, zoomed_height, retrow<<(pix_bytes/2));
    microSecCounter += (1000000/(retro_get_region() == RETRO_REGION_NTSC ? C64_NTSC_RFSH_PER_SEC : C64_PAL_RFSH_PER_SEC));
 }
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3521,7 +3521,7 @@ void update_geometry(int mode)
                   break;
                case 3:
                   zoomed_width        = (retro_region == RETRO_REGION_NTSC) ? retroW : 392;
-                  zoomed_XS_offset    = (retro_region == RETRO_REGION_NTSC) ? 8 : 14;
+                  zoomed_XS_offset    = (retro_region == RETRO_REGION_NTSC) ? 8 : 28;
                   zoomed_height       = 184;
                   zoomed_YS_offset    = (retro_region == RETRO_REGION_NTSC) ? 22 : 48;
                   break;
@@ -3776,7 +3776,7 @@ void retro_run(void)
    if (imagename_timer > 0)
       imagename_timer--;
 
-   video_cb(Retro_Screen+(retroXS_offset*pix_bytes)+(retroYS_offset*(retrow<<(pix_bytes/4))), zoomed_width, zoomed_height, retrow<<(pix_bytes/2));
+   video_cb(Retro_Screen+(retroXS_offset*pix_bytes/2)+(retroYS_offset*(retrow<<(pix_bytes/4))), zoomed_width, zoomed_height, retrow<<(pix_bytes/2));
    microSecCounter += (1000000/(retro_get_region() == RETRO_REGION_NTSC ? C64_NTSC_RFSH_PER_SEC : C64_PAL_RFSH_PER_SEC));
 }
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3582,19 +3582,14 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    }
 }
 
-void retro_set_audio_sample(retro_audio_sample_t cb)
-{
-   audio_cb = cb;
-}
-
-void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb)
-{
-   audio_batch_cb = cb;
-}
-
 void retro_set_video_refresh(retro_video_refresh_t cb)
 {
    video_cb = cb;
+}
+
+void retro_set_audio_sample(retro_audio_sample_t cb)
+{
+   audio_cb = cb;
 }
 
 void retro_audio_cb(short l, short r)
@@ -3602,10 +3597,24 @@ void retro_audio_cb(short l, short r)
    audio_cb(l, r);
 }
 
-void retro_audiocb(signed short int *sound_buffer, int sndbufsize)
+void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb)
+{
+   audio_batch_cb = cb;
+}
+
+void retro_audio_batch_cb(const int16_t *data, size_t frames)
+{
+   audio_batch_cb(data, frames);
+}
+
+void retro_audio_render(signed short int *sound_buffer, int sndbufsize)
 {
    int x;
+#if 1
    for (x=0; x<sndbufsize; x++) audio_cb(sound_buffer[x], sound_buffer[x]);
+#else
+   //FIXME audio_batch_cb(sound_buffer, sndbufsize);
+#endif
 }
 
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -98,6 +98,7 @@ extern int RETROC128COLUMNKEY;
 #endif
 #if defined(__VIC20__)
 extern int RETROVIC20MEM;
+extern int vic20mem_forced;
 #endif
 extern int RETROUSERPORTJOY;
 extern int RETROEXTPAL;
@@ -454,6 +455,30 @@ static int process_cmdline(const char* argv)
             Add_Option("-cartA");
         else if (strendswith(argv, ".b0"))
             Add_Option("-cartB");
+
+        char vic20buf1[6]   = "\0";
+        char vic20buf2[6]   = "\0";
+        int vic20mem        = 0;
+        int vic20mems[5]    = {0, 3, 8, 16, 24};
+
+        for (int i = 0; i < 5; i++)
+        {
+            vic20mem = vic20mems[i];
+            snprintf(vic20buf1, 6, "%c%d%c%c", '(', vic20mem, 'k', ')');
+            snprintf(vic20buf2, 6, "%c%d%c%c", FSDEV_DIR_SEP_CHR, vic20mem, 'k', FSDEV_DIR_SEP_CHR);
+            if (strcasestr(argv, vic20buf1))
+            {
+                vic20mem_forced = i;
+                log_cb(RETRO_LOG_INFO, "VIC-20 memory expansion force found in filename '%s': %dKB\n", argv, vic20mem);
+                break;
+            }
+            else if (strcasestr(argv, vic20buf2))
+            {
+                vic20mem_forced = i;
+                log_cb(RETRO_LOG_INFO, "VIC-20 memory expansion force found in path '%s': %dKB\n", argv, vic20mem);
+                break;
+            }
+        }
 #endif
 
         if (strendswith(argv, ".m3u"))
@@ -849,7 +874,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_vic20_memory_expansions",
-         "Memory expansions",
+         "Memory Expansions",
          "",
          {
             { "none", "disabled" },

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -70,6 +70,7 @@ extern int retroH;
 extern int retroW;
 extern unsigned int zoomed_width;
 extern unsigned int zoomed_height;
+extern int imagename_timer;
 
 //FUNCS
 extern void maincpu_mainloop_retro(void);

--- a/libretro/nukleargui/gui.i
+++ b/libretro/nukleargui/gui.i
@@ -57,8 +57,8 @@ static int gui(struct nk_context *ctx)
                 }
                 else
                 {
-                    offset.x = GUIRECT.x - retroXS_offset;
-                    offset.y = GUIRECT.y - retroYS_offset;
+                    offset.x = GUIRECT.x;// - retroXS_offset;
+                    offset.y = GUIRECT.y;// - retroYS_offset;
 #if defined(__VIC20__)
                     if (retro_get_region() == RETRO_REGION_NTSC)
                     {

--- a/libretro/nukleargui/nuklear/style.c
+++ b/libretro/nukleargui/nuklear/style.c
@@ -72,7 +72,7 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_TAB_HEADER] = nk_rgba(48, 83, 111, 255);
         nk_style_from_table(ctx, table);
     } else if (theme == THEME_C64_TRANSPARENT) {
-        table[NK_COLOR_TEXT] = nk_rgba(254, 254, 254, 255);
+        table[NK_COLOR_TEXT] = nk_rgba(250, 250, 250, 255);
         table[NK_COLOR_WINDOW] = nk_rgba(0, 0, 0, 0);
         table[NK_COLOR_HEADER] = nk_rgba(123, 127, 130, 180); // function keys
         table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 0);
@@ -102,7 +102,7 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_TAB_HEADER] = nk_rgba(48, 83, 111, 255);
         nk_style_from_table(ctx, table);
     } else if (theme == THEME_C64C_TRANSPARENT) {
-        table[NK_COLOR_TEXT] = nk_rgba(1, 1, 1, 255);
+        table[NK_COLOR_TEXT] = nk_rgba(4, 4, 4, 255);
         table[NK_COLOR_WINDOW] = nk_rgba(0, 0, 0, 0);
         table[NK_COLOR_HEADER] = nk_rgba(157, 152, 149, 180); // function keys
         table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 0);
@@ -132,7 +132,7 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_TAB_HEADER] = nk_rgba(48, 83, 111, 255);
         nk_style_from_table(ctx, table);
     } else if (theme == THEME_DARK_TRANSPARENT) {
-        table[NK_COLOR_TEXT] = nk_rgba(254, 254, 254, 255);
+        table[NK_COLOR_TEXT] = nk_rgba(250, 250, 250, 255);
         table[NK_COLOR_WINDOW] = nk_rgba(0, 0, 0, 0);
         table[NK_COLOR_HEADER] = nk_rgba(80, 80, 80, 180); // function keys
         table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 0);
@@ -162,7 +162,7 @@ set_style(struct nk_context *ctx, enum theme theme)
         table[NK_COLOR_TAB_HEADER] = nk_rgba(48, 83, 111, 255);
         nk_style_from_table(ctx, table);
     } else if (theme == THEME_LIGHT_TRANSPARENT) {
-        table[NK_COLOR_TEXT] = nk_rgba(1, 1, 1, 255);
+        table[NK_COLOR_TEXT] = nk_rgba(4, 4, 4, 255);
         table[NK_COLOR_WINDOW] = nk_rgba(0, 0, 0, 0);
         table[NK_COLOR_HEADER] = nk_rgba(180, 180, 180, 180); // function keys
         table[NK_COLOR_BORDER] = nk_rgba(0, 0, 0, 0);

--- a/libretro/nukleargui/retro/nuklear_retro_soft.h
+++ b/libretro/nukleargui/retro/nuklear_retro_soft.h
@@ -258,35 +258,34 @@ nk_retro_draw_text(RSDL_Surface *surface, short x, short y, unsigned short w, un
     int i;
     //nk_retro_fill_rect(surface, x, y, len * font->width, font->height, 0, cbg);
 
-    double dim = 0.50;
-    if (cfg.r == 1)
-        dim = 0.80;
+    double dim;
+    dim = (cfg.r == 4) ? 0.75 : 0.60;
 
-    if (dim * cbg.r > cbg.r) cbg.r = 0;
+    if (dim*cbg.r > cbg.r) cbg.r = 0;
     else cbg.r *= dim;
 
-    if (dim * cbg.g > cbg.g) cbg.g = 0;
+    if (dim*cbg.g > cbg.g) cbg.g = 0;
     else cbg.g *= dim;
 
-    if (dim * cbg.b > cbg.b) cbg.b = 0;
+    if (dim*cbg.b > cbg.b) cbg.b = 0;
     else cbg.b *= dim;
 
     for (i = 0; i < len; i++) {
         //characterRGBA(surface, x, y, text[i], cfg.r, cfg.g, cfg.b, cfg.a);
         if (pix_bytes == 2)
         {
-            if (cfg.r == 1)
-                Retro_Draw_char16(surface, x+1, y+1, text[i], 1, 1, cbg.r<<8|cbg.g<<3|cbg.b>>3, 0);
-            else if (cfg.r == 254)
-                Retro_Draw_char16(surface, x-1, y-1, text[i], 1, 1, cbg.r<<8|cbg.g<<3|cbg.b>>3, 0);
+            if (cfg.r == 4)
+                Retro_Draw_char16(surface, x+1, y+1, text[i], 1, 1, cbg.r>>3<<11|cbg.g>>2<<5|cbg.b>>3, 0);
+            else if (cfg.r == 250)
+                Retro_Draw_char16(surface, x-1, y-1, text[i], 1, 1, cbg.r>>3<<11|cbg.g>>2<<5|cbg.b>>3, 0);
 
-            Retro_Draw_char16(surface, x, y, text[i], 1, 1, cfg.r<<8|cfg.g<<3|cfg.b>>3, 0);
+            Retro_Draw_char16(surface, x, y, text[i], 1, 1, cfg.r>>3<<11|cfg.g>>2<<5|cfg.b>>3, 0);
         }
         else
         {
-            if (cfg.r == 1)
+            if (cfg.r == 4)
                 Retro_Draw_char32(surface, x+1, y+1, text[i], 1, 1, cbg.r<<16|cbg.g<<8|cbg.b, 0);
-            else if (cfg.r == 254)
+            else if (cfg.r == 250)
                 Retro_Draw_char32(surface, x-1, y-1, text[i], 1, 1, cbg.r<<16|cbg.g<<8|cbg.b, 0);
 
             Retro_Draw_char32(surface, x, y, text[i], 1, 1, cfg.a<<24|cfg.r<<16|cfg.g<<8|cfg.b, 0);

--- a/libretro/nukleargui/retro/nuklear_retro_soft.h
+++ b/libretro/nukleargui/retro/nuklear_retro_soft.h
@@ -484,7 +484,7 @@ void reset_mouse_pos()
     switch (retro_get_borders())
     {
         case 0: /* Normal borders */
-            revent.gmx = 324;
+            revent.gmx = 330;
             revent.gmy = 138;
             break;
 
@@ -498,8 +498,8 @@ void reset_mouse_pos()
     if (retro_get_region() == RETRO_REGION_NTSC)
         revent.gmy -= 12;
 #endif
-    revent.gmx -= retroXS_offset;
-    revent.gmy -= retroYS_offset;
+    //revent.gmx -= retroXS_offset;
+    //revent.gmy -= retroYS_offset;
 }
 
 static void retro_init_event()
@@ -514,7 +514,7 @@ static void retro_init_event()
     revent.margin_bottom=15;
 #else
     revent.MOUSE_PAS_X=28;
-    revent.MOUSE_PAS_Y=28;
+    revent.MOUSE_PAS_Y=27;
     revent.margin_left=10;
     revent.margin_right=10;
     revent.margin_top=5;
@@ -609,10 +609,11 @@ NK_API void nk_retro_handle_event(int *evt, int poll)
         //input_poll_cb();
 
     static long now;
-    static int lmx=0,lmy=0;
-    static int mmbL=0,mmbR=0,mmbM=0;
-    static int mouse_l,mouse_m,mouse_r=0;
-    int16_t mouse_x=0,mouse_y=0;
+    static int lmx=0, lmy=0;
+    static int mmbL=0, mmbR=0, mmbM=0;
+    static int mouse_l, mouse_m, mouse_r=0;
+    static int16_t mouse_x=0, mouse_y=0;
+    mouse_x = mouse_y = 0;
 
     // Joypad buttons
     mouse_l = input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B);
@@ -690,22 +691,23 @@ NK_API void nk_retro_handle_event(int *evt, int poll)
                 || revent.let_go_of_direction)
             {
                 revent.last_move_time = now;
-
                 revent.showpointer = 0;
-
                 revent.gmx+=mouse_x;
                 revent.gmy+=mouse_y;
 
                 // Joypad wraparound
                 // Offset changes depending on whether borders are on or off
                 if (revent.gmx < offset.x + revent.margin_left)
-                    revent.gmx = offset.x + GUI_W - (revent.margin_right * 2);
-                if (revent.gmx > offset.x + GUI_W - revent.margin_right)
-                    revent.gmx = offset.x + (revent.margin_left * 2);
+                    revent.gmx = offset.x - (revent.margin_right*2) + GUI_W;
+                else
+                if (revent.gmx > offset.x - revent.margin_right + GUI_W)
+                    revent.gmx = offset.x + (revent.margin_left*2);
+
                 if (revent.gmy < offset.y + revent.margin_top)
-                    revent.gmy = offset.y + GUI_H - (revent.margin_bottom * 2);
-                if (revent.gmy > offset.y + GUI_H - revent.margin_bottom)
-                    revent.gmy = offset.y + (revent.margin_top * 2);
+                    revent.gmy = offset.y - (revent.margin_bottom*2) + GUI_H;
+                else
+                if (revent.gmy > offset.y - revent.margin_bottom + GUI_H)
+                    revent.gmy = offset.y + (revent.margin_top*2);
             }
             revent.let_go_of_direction = 0;
         }
@@ -726,12 +728,12 @@ NK_API void nk_retro_handle_event(int *evt, int poll)
             // Mouse corners
             if (revent.gmx < offset.x)
                 revent.gmx = offset.x;
-            if (revent.gmx > zoomed_width - offset.x - 1)
-                revent.gmx = zoomed_width - offset.x - 1;
+            if (revent.gmx > zoomed_width - offset.x + (retroXS_offset*2))
+                revent.gmx = zoomed_width - offset.x + (retroXS_offset*2);
             if (revent.gmy < offset.y)
                 revent.gmy = offset.y;
-            if (revent.gmy > zoomed_height - offset.y - 3)
-                revent.gmy = zoomed_height - offset.y - 3;
+            if (revent.gmy > zoomed_height - offset.y - 2 + (retroYS_offset*2))
+                revent.gmy = zoomed_height - offset.y - 2 + (retroYS_offset*2);
         }
     }
     else

--- a/libretro/nukleargui/retro/nuklear_retro_soft.h
+++ b/libretro/nukleargui/retro/nuklear_retro_soft.h
@@ -258,23 +258,36 @@ nk_retro_draw_text(RSDL_Surface *surface, short x, short y, unsigned short w, un
     int i;
     //nk_retro_fill_rect(surface, x, y, len * font->width, font->height, 0, cbg);
 
+    double dim = 0.50;
+    if (cfg.r == 1)
+        dim = 0.80;
+
+    if (dim * cbg.r > cbg.r) cbg.r = 0;
+    else cbg.r *= dim;
+
+    if (dim * cbg.g > cbg.g) cbg.g = 0;
+    else cbg.g *= dim;
+
+    if (dim * cbg.b > cbg.b) cbg.b = 0;
+    else cbg.b *= dim;
+
     for (i = 0; i < len; i++) {
         //characterRGBA(surface, x, y, text[i], cfg.r, cfg.g, cfg.b, cfg.a);
         if (pix_bytes == 2)
         {
             if (cfg.r == 1)
-                Retro_Draw_char16(surface, x+1, y+1, text[i], 1, 1, 180<<8|180<<3|180>>3, 0);
+                Retro_Draw_char16(surface, x+1, y+1, text[i], 1, 1, cbg.r<<8|cbg.g<<3|cbg.b>>3, 0);
             else if (cfg.r == 254)
-                Retro_Draw_char16(surface, x-1, y-1, text[i], 1, 1, 40<<8|40<<3|40>>3, 0);
+                Retro_Draw_char16(surface, x-1, y-1, text[i], 1, 1, cbg.r<<8|cbg.g<<3|cbg.b>>3, 0);
 
             Retro_Draw_char16(surface, x, y, text[i], 1, 1, cfg.r<<8|cfg.g<<3|cfg.b>>3, 0);
         }
         else
         {
             if (cfg.r == 1)
-                Retro_Draw_char32(surface, x+1, y+1, text[i], 1, 1, 180<<16|180<<8|180, 0);
+                Retro_Draw_char32(surface, x+1, y+1, text[i], 1, 1, cbg.r<<16|cbg.g<<8|cbg.b, 0);
             else if (cfg.r == 254)
-                Retro_Draw_char32(surface, x-1, y-1, text[i], 1, 1, 40<<16|40<<8|40, 0);
+                Retro_Draw_char32(surface, x-1, y-1, text[i], 1, 1, cbg.r<<16|cbg.g<<8|cbg.b, 0);
 
             Retro_Draw_char32(surface, x, y, text[i], 1, 1, cfg.a<<24|cfg.r<<16|cfg.g<<8|cfg.b, 0);
         }

--- a/vice/src/arch/libretro/archdep.c
+++ b/vice/src/arch/libretro/archdep.c
@@ -410,6 +410,20 @@ int archdep_path_is_relative(const char *path)
           return 0;
     }
     return 1;
+#elif defined(WIIU)
+    if (path == NULL)
+        return 0;
+    if (*path == '/')
+        return 0;
+    // WIIU might also use "sd:" for absolute paths
+    for (int i = 0; i <= 4; i++)
+    {
+        if (path[i] == '\0')
+          return 1;
+        if (path[i] == ':')
+          return 0;
+    }
+    return 1;
 #else
     if (path == NULL)
         return 0;

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -66,6 +66,7 @@ int RETROC128COLUMNKEY=1;
 #endif
 #if defined(__VIC20__)
 int RETROVIC20MEM=0;
+int vic20mem_forced=-1;
 #endif
 int RETROUSERPORTJOY=-1;
 int RETROEXTPAL=-1;
@@ -304,7 +305,9 @@ int ui_init_finalize(void)
 #endif
 
 #if defined(__VIC20__)
-   switch (RETROVIC20MEM)
+   static unsigned int vic20mem = 0;
+   vic20mem = (vic20mem_forced > -1) ? vic20mem_forced : RETROVIC20MEM;
+   switch (vic20mem)
    {
       case 0:
          log_resources_set_int("RAMBlock0", 0);

--- a/vice/src/arch/libretro/uistatusbar.c
+++ b/vice/src/arch/libretro/uistatusbar.c
@@ -159,7 +159,7 @@ static void display_speed(void)
     }
 }
 
-static int imagename_timer = 0;
+int imagename_timer = 0;
 static int drive_enabled = 0;
 static int drive_empty = 0;
 
@@ -570,12 +570,10 @@ void uistatusbar_draw(void)
             break;
     }
 #endif
-    x -= retroXS_offset;
-    y -= retroYS_offset;
+    //x -= retroXS_offset;
+    //y -= retroYS_offset;
 
-    if (imagename_timer > 0)
-        imagename_timer--;
-    else
+    if (imagename_timer == 0)
         display_joyport();
 
     for (i = 0; i < MAX_STATUSBAR_LEN; ++i)

--- a/vice/src/arch/libretro/vsyncarch.c
+++ b/vice/src/arch/libretro/vsyncarch.c
@@ -106,7 +106,7 @@ void vsyncarch_presync(void)
     video_canvas_render(
         RCANVAS, (BYTE *)Retro_Screen,
         retroW, retroH,
-        retroXS+retroXS_offset, retroYS+retroYS_offset,
+        retroXS, retroYS,
         0, 0, //xi, yi,
         retrow*pix_bytes, 8*pix_bytes
     );

--- a/vice/src/sound.h
+++ b/vice/src/sound.h
@@ -69,14 +69,14 @@
 #endif
 
 #define SOUND_CHANNELS_MAX 2
-#define SOUND_BUFSIZE 32768
+#define SOUND_BUFSIZE 4096
 #define SOUND_SIDS_MAX 4
 
 #ifdef __OS2__
 # define SOUND_SAMPLE_BUFFER_SIZE       400
 #endif
 #ifndef SOUND_SAMPLE_BUFFER_SIZE
-# define SOUND_SAMPLE_BUFFER_SIZE       100
+# define SOUND_SAMPLE_BUFFER_SIZE       20
 #endif
 
 /* largest value in the UIs. also used by VSID as default */

--- a/vice/src/sounddrv/soundretro.c
+++ b/vice/src/sounddrv/soundretro.c
@@ -9,13 +9,13 @@
 
 #include "sound.h"
 
-extern void retro_audiocb(signed short int *sound_buffer, int sndbufsize);
+extern void retro_audio_render(signed short int *sound_buffer, int sndbufsize);
 extern int RETROSOUNDSAMPLERATE;
 
 static int retro_sound_init(const char *param, int *speed, int *fragsize, int *fragnr, int *channels)
 {
     *speed = RETROSOUNDSAMPLERATE;
-    //*fragsize = 1;
+    //*fragsize = 32;
     *fragnr = 0;
     //*channels = 1;
     //printf("speed:%d fragsize:%d fragnr:%d channels:%d\n", *speed, *fragsize, *fragnr, *channels);
@@ -25,7 +25,7 @@ static int retro_sound_init(const char *param, int *speed, int *fragsize, int *f
 static int retro_write(SWORD *pbuf, size_t nr)
 {
     //printf("pbuf:%d nr:%d\n", *pbuf, nr);
-    retro_audiocb(pbuf, nr);
+    retro_audio_render(pbuf, nr);
     return 0;
 }
 


### PR DESCRIPTION
- Changed zoom mode centering method from VICE internal `video_canvas_render `to `video_cb`
  Closes #172 
- Added filename/path based memory expansion forcing for VIC-20
  Closes #186 
  - For example `game (8k).prg` or `/8k/game.prg` will force 8KB expansion. `0k` will force none.
- Fixed WIIU cartridge path issue, hopefully
  Closes #191


- Finetuned VKBD transparency colors
- Fixed statusbar attached/ejected filename timer from progressing only when statusbar is visible
- Found some sound buffers to test adjust again, and added a placeholder for `audio_batch_cb` if/when it is worth the effort to plug in
- Removed old information from README
