### PR TITLE
New SID-engine: resid-33 (former PR 189) 

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -363,24 +363,19 @@ else
 all: $(TARGET)
 $(TARGET): $(OBJECTS)
 ifeq ($(STATIC_LINKING), 1)
-	@echo $(AR): $@
-	@$(AR) rcs $@ $(OBJECTS)
+	$(AR) rcs $@ $(OBJECTS)
 else
-	@echo $(CXX): $@
-	@$(CXX) -o $@ $(OBJECTS) $(LDFLAGS)
+	$(CXX) -o $@ $(OBJECTS) $(LDFLAGS)
 endif
 
 %.o: %.c
-	@echo $(CC): $^
-	@$(CC) $(CFLAGS) -c $^ -o $@
+	$(CC) $(CFLAGS) -c $^ -o $@
 
 %.o: %.cpp
-	@echo $(CXX): $^
-	@$(CXX) $(CXXFLAGS) -c $^ -o $@
+	$(CXX) $(CXXFLAGS) -c $^ -o $@
 
 %.o: %.cc
-	@echo $(CC): $^
-	@$(CC) $(CFLAGS) -c $^ -o $@
+	$(CC) $(CFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(OBJECTS) $(TARGET)

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -52,6 +52,7 @@ else ifeq ($(platform), crosspi)
    CFLAGS += -march=armv7-a -mfloat-abi=hard -mfpu=vfpv3 -O2 -pipe -fstack-protector 
 
    CFLAGS +=-I~/RPI/usr/include/arm-linux-gnueabihf -I/home/tech/RPI/usr/include
+   CXXFLAGS += $(CFLAGS)
  LDFLAGS += -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -L/home/tech/RPI/usr/lib
 #-I./../sources/src/include
 
@@ -111,11 +112,13 @@ else ifeq ($(platform), classic_armv8_a35)
 else ifeq ($(platform), libnx)
    include $(DEVKITPRO)/libnx/switch_rules
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
-   CFLAGS += -O3 -fomit-frame-pointer -ffast-math -I$(DEVKITPRO)/libnx/include/ -fPIE -Wl,--allow-multiple-definition
+   CFLAGS += -O3 -fomit-frame-pointer -ffast-math -I$(DEVKITPRO)/libnx/include/ -Wl,--allow-multiple-definition
    CFLAGS += -specs=$(DEVKITPRO)/libnx/switch.specs
    CFLAGS += -D__SWITCH__ -DHAVE_LIBNX -DHAVE_GETPWUID=0 -DHAVE_GETCWD=1
    CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -ffast-math -mcpu=cortex-a57+crc+fp+simd -ffunction-sections
    CFLAGS += -Ifrontend/switch -ftree-vectorize
+   CXXFLAGS += $(CFLAGS)
+   fpic = -fPIE
    STATIC_LINKING=1
 
 else ifeq ($(platform), osx)
@@ -203,6 +206,7 @@ else ifeq ($(platform), androidstc)
    CC = arm-linux-androideabi-gcc
    CXX = arm-linux-androideabi-g++
    
+   CXXFLAGS += $(CFLAGS)
    fpic = -fPIC
 # ANDROID
 else ifeq ($(platform), android)
@@ -232,6 +236,7 @@ endif
    LDFLAGS += -L$(ANDROID_NDK_ROOT)/platforms/android-19/arch-arm/usr/lib  --sysroot=$(ANDROID_NDK_ROOT)/platforms/android-19/arch-arm -march=armv7-a -mthumb -shared
    LDFLAGS += -lc -ldl -lm -landroid -llog -lsupc++ $(ANDROID_NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/thumb/libgnustl_static.a -lgcc
 
+   CXXFLAGS += $(CFLAGS)
    fpic = -fPIC
 
 # PSP
@@ -242,6 +247,7 @@ else ifeq ($(platform), psp1)
    AR = psp-ar$(EXE_EXT)
    COMMONFLAGS += -DPSP -G0 -I$(shell psp-config --pspsdk-path)/include
    CFLAGS += -std=c99
+   CXXFLAGS += -std=c99
 	STATIC_LINKING = 1
 
 # Vita

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -339,7 +339,7 @@ include Makefile.common
 
 COMMONFLAGS += -DCORE_NAME=\"$(EMUTYPE)\"
 
-OBJECTS     += $(SOURCES_CXX:.cc=.o) $(SOURCES_C:.c=.o)
+OBJECTS     += $(patsubst %.cpp,%.o,$(SOURCES_CXX:.cc=.o)) $(SOURCES_C:.c=.o)
 CXXFLAGS    += -D__LIBRETRO__ $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 CFLAGS      += -D__LIBRETRO__ $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 LDFLAGS     += -lm $(fpic)

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -350,6 +350,9 @@ CXXFLAGS    += -D__LIBRETRO__ $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 CFLAGS      += -D__LIBRETRO__ $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 LDFLAGS     += -lm $(fpic)
 
+$(info CFLAGS: $(CFLAGS))
+$(info -------)
+
 ifeq ($(platform), theos_ios)
 COMMON_FLAGS := -DIOS -DARM $(COMMON_DEFINES) $(INCFLAGS) -I$(THEOS_INCLUDE_PATH) -Wno-error
 $(LIBRARY_NAME)_CFLAGS += $(CFLAGS) $(COMMON_FLAGS)
@@ -360,19 +363,24 @@ else
 all: $(TARGET)
 $(TARGET): $(OBJECTS)
 ifeq ($(STATIC_LINKING), 1)
-	$(AR) rcs $@ $(OBJECTS)
+	@echo $(AR): $@
+	@$(AR) rcs $@ $(OBJECTS)
 else
-	$(CXX) -o $@ $(OBJECTS) $(LDFLAGS)
+	@echo $(CXX): $@
+	@$(CXX) -o $@ $(OBJECTS) $(LDFLAGS)
 endif
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $^ -o $@
+	@echo $(CC): $^
+	@$(CC) $(CFLAGS) -c $^ -o $@
 
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) -c $^ -o $@
+	@echo $(CXX): $^
+	@$(CXX) $(CXXFLAGS) -c $^ -o $@
 
 %.o: %.cc
-	$(CC) $(CFLAGS) -c $^ -o $@
+	@echo $(CC): $^
+	@$(CC) $(CFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(OBJECTS) $(TARGET)

--- a/Makefile.x128
+++ b/Makefile.x128
@@ -43,6 +43,7 @@ SOURCES_CXX += \
 		$(EMU)/resid/version.cc  \
 		$(EMU)/resid/voice.cc  \
 		$(EMU)/resid/wave.cc  \
+		$(EMU)/sid/resid-33.cc  \
 		$(EMU)/sid/resid.cc
 
 SOURCES_C += \

--- a/Makefile.x64
+++ b/Makefile.x64
@@ -42,6 +42,7 @@ SOURCES_CXX += \
 		$(EMU)/resid/version.cc \
 		$(EMU)/resid/voice.cc \
 		$(EMU)/resid/wave.cc \
+		$(EMU)/sid/resid-33.cc \
 		$(EMU)/sid/resid.cc
 				  
 SOURCES_C += \

--- a/Makefile.x64sc
+++ b/Makefile.x64sc
@@ -43,6 +43,7 @@ SOURCES_CXX += \
         $(EMU)/resid/version.cc \
         $(EMU)/resid/voice.cc \
         $(EMU)/resid/wave.cc \
+        $(EMU)/sid/resid-33.cc \
         $(EMU)/sid/resid.cc
 
 SOURCES_C += \

--- a/Makefile.x64scpu
+++ b/Makefile.x64scpu
@@ -44,6 +44,7 @@ SOURCES_CXX += \
         $(EMU)/resid/version.cc \
         $(EMU)/resid/voice.cc \
         $(EMU)/resid/wave.cc \
+        $(EMU)/sid/resid-33.cc \
         $(EMU)/sid/resid.cc
 
 SOURCES_C += \

--- a/Makefile.xcbm2
+++ b/Makefile.xcbm2
@@ -43,6 +43,7 @@ SOURCES_CXX += \
 		$(EMU)/resid/version.cc \
 		$(EMU)/resid/voice.cc \
 		$(EMU)/resid/wave.cc \
+		$(EMU)/sid/resid-33.cc \
 		$(EMU)/sid/resid.cc
 
 SOURCES_C += \

--- a/Makefile.xpet
+++ b/Makefile.xpet
@@ -43,6 +43,7 @@ SOURCES_CXX += \
 		$(EMU)/resid/version.cc \
 		$(EMU)/resid/voice.cc \
 		$(EMU)/resid/wave.cc \
+		$(EMU)/sid/resid-33.cc \
 		$(EMU)/sid/resid.cc
 
 SOURCES_C += \

--- a/Makefile.xplus4
+++ b/Makefile.xplus4
@@ -43,6 +43,7 @@ SOURCES_CXX += \
 		$(EMU)/resid/version.cc \
 		$(EMU)/resid/voice.cc \
 		$(EMU)/resid/wave.cc \
+		$(EMU)/sid/resid-33.cc \
 		$(EMU)/sid/resid.cc
 
 SOURCES_C += \

--- a/Makefile.xvic
+++ b/Makefile.xvic
@@ -45,6 +45,7 @@ SOURCES_CXX += \
 		$(EMU)/resid/version.cc \
 		$(EMU)/resid/voice.cc \
 		$(EMU)/resid/wave.cc \
+		$(EMU)/sid/resid-33.cc \
 		$(EMU)/sid/resid.cc
 
 SOURCES_C += \

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1135,6 +1135,7 @@ void retro_set_environment(retro_environment_t cb)
          {
             { "FastSID", NULL },
             { "ReSID", NULL },
+            { "ReSID-3.3", NULL },
             { NULL, NULL },
          },
          "ReSID"
@@ -2264,6 +2265,7 @@ static void update_variables(void)
       int eng=0;
 
       if (strcmp(var.value, "ReSID") == 0) { eng=1; }
+      else if (strcmp(var.value, "ReSID-3.3") == 0) { eng=6; }
 
       if (retro_ui_finalized)
          if (RETROSIDENGINE != eng)

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -92,6 +92,10 @@ extern int RETROSIDENGINE;
 extern int RETROSIDMODL;
 extern int RETRORESIDSAMPLING;
 extern int RETROSOUNDSAMPLERATE;
+extern int RETRORESIDPASSBAND;
+extern int RETRORESIDGAIN;
+extern int RETRORESIDFILTERBIAS;
+extern int RETRORESID8580FILTERBIAS;
 extern int RETROAUDIOLEAK;
 extern int RETROC64MODL;
 #if defined(__X128__)
@@ -1165,6 +1169,105 @@ void retro_set_environment(retro_environment_t cb)
             { NULL, NULL },
          },
          "Resampling"
+      },
+      {
+         "vice_resid_passband",
+         "ReSID Filter Passband",
+         "Parameters for SID Filter",
+         {
+            { "0", NULL },
+            { "10", NULL },
+            { "20", NULL },
+            { "30", NULL },
+            { "40", NULL },
+            { "50", NULL },
+            { "60", NULL },
+            { "70", NULL },
+            { "80", NULL },
+            { "90", NULL },
+            { NULL, NULL },
+         },
+         "90"
+      },
+      {
+         "vice_resid_gain",
+         "ReSID Filter Gain",
+         "Parameters for SID Filter",
+         {
+            { "90", NULL },
+            { "91", NULL },
+            { "92", NULL },
+            { "93", NULL },
+            { "94", NULL },
+            { "95", NULL },
+            { "96", NULL },
+            { "97", NULL },
+            { "98", NULL },
+            { "99", NULL },
+            { "100", NULL },
+            { NULL, NULL },
+         },
+         "97"
+      },
+      {
+         "vice_resid_filterbias",
+         "ReSID Filter Bias",
+         "Parameters for SID Filter",
+         {
+            { "-5000", NULL },
+            { "-4500", NULL },
+            { "-4000", NULL },
+            { "-3500", NULL },
+            { "-3000", NULL },
+            { "-2500", NULL },
+            { "-2000", NULL },
+            { "-1500", NULL },
+            { "-1000", NULL },
+            { "-500", NULL },
+            { "0", NULL },
+            { "500", NULL },
+            { "1000", NULL },
+            { "1500", NULL },
+            { "2000", NULL },
+            { "2500", NULL },
+            { "3000", NULL },
+            { "3500", NULL },
+            { "4000", NULL },
+            { "4500", NULL },
+            { "5000", NULL },
+            { NULL, NULL },
+         },
+         "500"
+      },
+      {
+         "vice_resid_8580filterbias",
+         "ReSID Filter 8580 Bias",
+         "Parameters for SID Filter",
+         {
+            { "-5000", NULL },
+            { "-4500", NULL },
+            { "-4000", NULL },
+            { "-3500", NULL },
+            { "-3000", NULL },
+            { "-2500", NULL },
+            { "-2000", NULL },
+            { "-1500", NULL },
+            { "-1000", NULL },
+            { "-500", NULL },
+            { "0", NULL },
+            { "500", NULL },
+            { "1000", NULL },
+            { "1500", NULL },
+            { "2000", NULL },
+            { "2500", NULL },
+            { "3000", NULL },
+            { "3500", NULL },
+            { "4000", NULL },
+            { "4500", NULL },
+            { "5000", NULL },
+            { NULL, NULL },
+         },
+         "1500"
       },
 #endif
       {
@@ -2312,6 +2415,64 @@ static void update_variables(void)
 
       RETRORESIDSAMPLING=resid;
    }
+
+   var.key = "vice_resid_passband";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int val = atoi(var.value);
+
+      if (retro_ui_finalized)
+         if (RETRORESIDPASSBAND != val)
+         {
+            log_resources_set_int("SidResidPassband", val);
+            log_resources_set_int("SidResid8580Passband", val);
+         }
+         RETRORESIDPASSBAND=val;
+   }
+
+   var.key = "vice_resid_gain";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int val = atoi(var.value);
+
+      if (retro_ui_finalized)
+         if (RETRORESIDGAIN != val)
+         {
+            log_resources_set_int("SidResidGain", val);
+            log_resources_set_int("SidResid8580Gain", val);
+         }
+         RETRORESIDGAIN=val;
+   }
+
+   var.key = "vice_resid_filterbias";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int val = atoi(var.value);
+
+      if (retro_ui_finalized)
+         if (RETRORESIDFILTERBIAS != val)
+            log_resources_set_int("SidResidFilterBias", val);
+         RETRORESIDFILTERBIAS=val;
+   }
+
+   var.key = "vice_resid_8580filterbias";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int val = atoi(var.value);
+
+      if (retro_ui_finalized)
+         if (RETRORESID8580FILTERBIAS != val)
+            log_resources_set_int("SidResid8580FilterBias", val);
+         RETRORESID8580FILTERBIAS=val;
+   }
 #endif
 
 #if !defined(__PET__) && !defined(__CBM2__)
@@ -3047,6 +3208,14 @@ static void update_variables(void)
    option_display.key = "vice_sid_model";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
    option_display.key = "vice_resid_sampling";
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+   option_display.key = "vice_resid_passband";
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+   option_display.key = "vice_resid_gain";
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+   option_display.key = "vice_resid_filterbias";
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+   option_display.key = "vice_resid_8580filterbias";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 #endif
 

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -60,6 +60,10 @@ int RETROSIDENGINE=0;
 int RETROSIDMODL=0;
 int RETRORESIDSAMPLING=0;
 int RETROSOUNDSAMPLERATE=0;
+int RETRORESIDPASSBAND=0;
+int RETRORESIDGAIN=0;
+int RETRORESIDFILTERBIAS=0;
+int RETRORESID8580FILTERBIAS=0;
 int RETROAUDIOLEAK=0;
 int RETROC64MODL=0;
 #if defined(__X128__)
@@ -289,6 +293,12 @@ int ui_init_finalize(void)
    else
       sid_set_engine_model(RETROSIDENGINE, RETROSIDMODL);
    log_resources_set_int("SidResidSampling", RETRORESIDSAMPLING);
+   log_resources_set_int("SidResidPassband", RETRORESIDPASSBAND);
+   log_resources_set_int("SidResidGain", RETRORESIDGAIN);
+   log_resources_set_int("SidResidFilterBias", RETRORESIDFILTERBIAS);
+   log_resources_set_int("SidResid8580Passband", RETRORESIDPASSBAND);
+   log_resources_set_int("SidResid8580Gain", RETRORESIDGAIN);
+   log_resources_set_int("SidResid8580FilterBias", RETRORESID8580FILTERBIAS);
 #endif
 
 #if !defined(__PET__) && !defined(__CBM2__)

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -56,6 +56,7 @@
 int RETROTDE=0;
 int RETRODSE=0;
 int RETRORESET=0;
+int RETROSIDENGINE=0;
 int RETROSIDMODL=0;
 int RETRORESIDSAMPLING=0;
 int RETROSOUNDSAMPLERATE=0;
@@ -283,10 +284,10 @@ int ui_init_finalize(void)
 #endif
 
 #if !defined(__PET__) && !defined(__PLUS4__) && !defined(__VIC20__)
-   if ((RETROSIDMODL & 0xff) == 0xff)
-      resources_set_int("SidEngine", RETROSIDMODL >> 8);
+   if (RETROSIDMODL == 0xff)
+      resources_set_int("SidEngine", RETROSIDENGINE);
    else
-      sid_set_engine_model((RETROSIDMODL >> 8), (RETROSIDMODL & 0xff));
+      sid_set_engine_model(RETROSIDENGINE, RETROSIDMODL);
    log_resources_set_int("SidResidSampling", RETRORESIDSAMPLING);
 #endif
 

--- a/vice/src/resid/filter8580new.cc
+++ b/vice/src/resid/filter8580new.cc
@@ -213,8 +213,8 @@ static model_filter_init_t model_filter_init[2] = {
     9.09,
     0.80,
     26.0e-3,
-    1.0,
-    50e-6, // 10e-6,
+    1.3, // FIXME this is just a hack, k must be less than one, likely around 0.7
+    55e-6, // FIXME measure
     // FIXME: 6581 only
     0,
     0,

--- a/vice/src/sid/resid-33.cc
+++ b/vice/src/sid/resid-33.cc
@@ -1,0 +1,24 @@
+#include <math.h>
+
+/* Compile ReSID to its own namespace to avoid symbol clashes with the original one, but enable new filters
+this time. */
+#define NEW_8580_FILTER 1
+namespace RESID33
+{
+#include "resid/sid.h"
+#include "resid/dac.cc"
+#include "resid/envelope.cc"
+#include "resid/extfilt.cc"
+#include "resid/filter8580new.cc"
+#include "resid/pot.cc"
+#include "resid/sid.cc"
+#include "resid/voice.cc"
+#include "resid/wave.cc"
+}
+/* Make everything available to resid.cc, but rename the hooks-array */
+namespace reSID
+{
+	using namespace RESID33::reSID;
+}
+#define resid_hooks resid33_hooks
+#include "resid.cc"

--- a/vice/src/sid/sid-resources.c
+++ b/vice/src/sid/sid-resources.c
@@ -93,6 +93,9 @@ static int set_sid_engine(int set_engine, void *param)
         case SID_ENGINE_FASTSID:
 #ifdef HAVE_RESID
         case SID_ENGINE_RESID:
+#ifdef __LIBRETRO__
+        case SID_ENGINE_RESID33:
+#endif
 #endif
 #ifdef HAVE_CATWEASELMKIII
         case SID_ENGINE_CATWEASELMKIII:
@@ -582,6 +585,11 @@ static int sid_check_engine_model(int engine, int model)
         case SID_RESID_6581:
         case SID_RESID_8580:
         case SID_RESID_8580D:
+#ifdef __LIBRETRO__
+        case SID_RESID33_6581:
+        case SID_RESID33_8580:
+        case SID_RESID33_8580D:
+#endif
 #endif
             return 0;
 #ifdef HAVE_RESID_DTV

--- a/vice/src/sid/sid.c
+++ b/vice/src/sid/sid.c
@@ -56,6 +56,9 @@
 
 #ifdef HAVE_RESID
 #include "resid.h"
+#ifdef __LIBRETRO__
+extern sid_engine_t resid33_hooks;
+#endif
 #endif
 
 /* SID engine hooks. */
@@ -342,6 +345,11 @@ sound_t *sid_sound_machine_open(int chipno)
     if (sidengine == SID_ENGINE_RESID) {
         sid_engine = resid_hooks;
     }
+#ifdef __LIBRETRO__
+    if (sidengine == SID_ENGINE_RESID33) {
+        sid_engine = resid33_hooks;
+    }
+#endif
 #endif
 
     return sid_engine.open(siddata[chipno]);
@@ -556,6 +564,9 @@ int sid_sound_machine_cycle_based(void)
             return 0;
 #ifdef HAVE_RESID
         case SID_ENGINE_RESID:
+#ifdef __LIBRETRO__
+        case SID_ENGINE_RESID33:
+#endif
             return 1;
 #endif
 #ifdef HAVE_CATWEASELMKIII
@@ -602,6 +613,13 @@ static void set_sound_func(void)
             sid_store_func = sound_store;
             sid_dump_func = sound_dump;
         }
+#ifdef __LIBRETRO__
+        if (sid_engine_type == SID_ENGINE_RESID33) {
+            sid_read_func = sound_read;
+            sid_store_func = sound_store;
+            sid_dump_func = sound_dump;
+        }
+#endif
 #endif
 #ifdef HAVE_CATWEASELMKIII
         if (sid_engine_type == SID_ENGINE_CATWEASELMKIII) {

--- a/vice/src/sid/sid.h
+++ b/vice/src/sid/sid.h
@@ -45,6 +45,9 @@ struct sid_snapshot_state_s;
 #define SID_ENGINE_HARDSID        3
 #define SID_ENGINE_PARSID         4
 #define SID_ENGINE_SSI2001        5
+#ifdef __LIBRETRO__
+#define SID_ENGINE_RESID33        6
+#endif
 #define SID_ENGINE_DEFAULT       99
 
 #define SID_MODEL_6581           0
@@ -62,6 +65,11 @@ struct sid_snapshot_state_s;
 #define SID_RESID_6581            ((SID_ENGINE_RESID << 8) | SID_MODEL_6581)
 #define SID_RESID_8580            ((SID_ENGINE_RESID << 8) | SID_MODEL_8580)
 #define SID_RESID_8580D           ((SID_ENGINE_RESID << 8) | SID_MODEL_8580D)
+#ifdef __LIBRETRO__
+#define SID_RESID33_6581          ((SID_ENGINE_RESID33 << 8) | SID_MODEL_6581)
+#define SID_RESID33_8580          ((SID_ENGINE_RESID33 << 8) | SID_MODEL_8580)
+#define SID_RESID33_8580D         ((SID_ENGINE_RESID33 << 8) | SID_MODEL_8580D)
+#endif
 #define SID_RESID_DTVSID          ((SID_ENGINE_RESID << 8) | SID_MODEL_DTVSID)
 #define SID_CATWEASELMKIII        (SID_ENGINE_CATWEASELMKIII << 8)
 #define SID_HARDSID               (SID_ENGINE_HARDSID << 8)


### PR DESCRIPTION
This is @AnaLogiC76's work taken from https://github.com/libretro/vice-libretro/pull/189, but without resid-fp. Resid-fp has C++11 dependencies which broke buildbot compilation on many platforms.