### PR TITLE
Makefile: Enforce C++98-conformance, use CXXFLAGS

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -350,8 +350,9 @@ CXXFLAGS    += -D__LIBRETRO__ $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 CFLAGS      += -D__LIBRETRO__ $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 LDFLAGS     += -lm $(fpic)
 
-$(info CFLAGS: $(CFLAGS))
-$(info -------)
+# Ensure only a language version supported by all compilers is used
+CFLAGS      += -std=c99
+CXXFLAGS    += -std=c++98
 
 ifeq ($(platform), theos_ios)
 COMMON_FLAGS := -DIOS -DARM $(COMMON_DEFINES) $(INCFLAGS) -I$(THEOS_INCLUDE_PATH) -Wno-error
@@ -375,7 +376,7 @@ endif
 	$(CXX) $(CXXFLAGS) -c $^ -o $@
 
 %.o: %.cc
-	$(CC) $(CFLAGS) -c $^ -o $@
+	$(CXX) $(CXXFLAGS) -c $^ -o $@
 
 clean:
 	rm -f $(OBJECTS) $(TARGET)


### PR DESCRIPTION
Add flags to ensure source-code complies with C++98 and C99.
Also use g++ and CXXFLAGS for .cc-source as it has now been verified
CXXFLAGS is in sync with CFLAGS, but gcc and g++ will warn if the
specified -std-flag does not match the language in the source-file.

I verified all platforms use gcc/g++, with the exception of ios which uses clang/clang++ which is flag-compatible with gcc, so they all support -std - this makes sure they all use the same language-version regardless if they are old or new.