### PR TITLE
resid-fp: Fix system-header includes from cpp

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -351,7 +351,9 @@ CFLAGS      += -D__LIBRETRO__ $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 LDFLAGS     += -lm $(fpic)
 
 # Ensure only a language version supported by all compilers is used
-CFLAGS      += -std=c99
+# Do not enforce C99 as some gcc-versions appear to not handle system-headers
+# properly in that case.
+#CFLAGS      += -std=c99
 CXXFLAGS    += -std=c++98
 
 ifeq ($(platform), theos_ios)

--- a/vice/src/residfp/builders/residfp-builder/residfp/FilterModelConfig.cpp
+++ b/vice/src/residfp/builders/residfp-builder/residfp/FilterModelConfig.cpp
@@ -22,8 +22,11 @@
 
 #include "FilterModelConfig.h"
 
+#ifdef __LIBRETRO__
+#else
 #include <cmath>
 #include <cassert>
+#endif
 
 #include "Integrator.h"
 #include "OpAmp.h"

--- a/vice/src/residfp/builders/residfp-builder/residfp/FilterModelConfig8580.cpp
+++ b/vice/src/residfp/builders/residfp-builder/residfp/FilterModelConfig8580.cpp
@@ -22,7 +22,10 @@
 
 #include "FilterModelConfig8580.h"
 
+#ifdef __LIBRETRO__
+#else
 #include <cassert>
+#endif
 
 #include "Integrator8580.h"
 #include "OpAmp.h"

--- a/vice/src/residfp/builders/residfp-builder/residfp/OpAmp.cpp
+++ b/vice/src/residfp/builders/residfp-builder/residfp/OpAmp.cpp
@@ -21,7 +21,10 @@
 
 #include "OpAmp.h"
 
+#ifdef __LIBRETRO__
+#else
 #include <cmath>
+#endif
 
 #include "siddefs-fp.h"
 

--- a/vice/src/residfp/builders/residfp-builder/residfp/SID.cpp
+++ b/vice/src/residfp/builders/residfp-builder/residfp/SID.cpp
@@ -24,7 +24,10 @@
 
 #include "SID.h"
 
+#ifdef __LIBRETRO__
+#else
 #include <limits>
+#endif
 
 #include "array.h"
 #include "Filter6581.h"

--- a/vice/src/residfp/builders/residfp-builder/residfp/Spline.cpp
+++ b/vice/src/residfp/builders/residfp-builder/residfp/Spline.cpp
@@ -21,8 +21,11 @@
 
 #include "Spline.h"
 
+#ifdef __LIBRETRO__
+#else
 #include <cassert>
 #include <limits>
+#endif
 
 namespace reSIDfp
 {

--- a/vice/src/residfp/builders/residfp-builder/residfp/WaveformCalculator.cpp
+++ b/vice/src/residfp/builders/residfp-builder/residfp/WaveformCalculator.cpp
@@ -21,7 +21,10 @@
 
 #include "WaveformCalculator.h"
 
+#ifdef __LIBRETRO__
+#else
 #include <cmath>
+#endif
 
 namespace reSIDfp
 {

--- a/vice/src/residfp/builders/residfp-builder/residfp/resample/SincResampler.cpp
+++ b/vice/src/residfp/builders/residfp-builder/residfp/resample/SincResampler.cpp
@@ -22,12 +22,15 @@
 
 #include "SincResampler.h"
 
+#ifdef __LIBRETRO__
+#else
 #include <cassert>
 #include <cstring>
 #include <cmath>
 #include <iostream>
 #include <sstream>
 #include <limits>
+#endif
 
 #include "siddefs-fp.h"
 
@@ -35,8 +38,11 @@
 #  include "config.h"
 #endif
 
+#ifdef __LIBRETRO__
+#else
 #ifdef HAVE_MMINTRIN_H
 #  include <mmintrin.h>
+#endif
 #endif
 
 namespace reSIDfp

--- a/vice/src/residfp/sysincludes.h
+++ b/vice/src/residfp/sysincludes.h
@@ -8,9 +8,16 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <cstring>
+#include <iostream>
+#include <limits>
 #include <map>
 #include <memory>
+#ifdef HAVE_MMINTRIN_H
+#  include <mmintrin.h>
+#endif
 #include <stdint.h>
+#include <sstream>
 #include <string>
 #include <vector>
 #endif


### PR DESCRIPTION
Any system-header may only be included from sysincludes.h, this still
was not done in some cpp-files.