### PR TITLE
x64: Exclude vicii-clock-stretch.c

### DIFF
--- a/Makefile.x64
+++ b/Makefile.x64
@@ -499,7 +499,6 @@ SOURCES_C += \
         $(EMU)/vdrive/vdrive.c \
         $(EMU)/vicefeatures.c \
         $(EMU)/vicii/vicii-badline.c \
-        $(EMU)/vicii/vicii-clock-stretch.c \
         $(EMU)/vicii/vicii-cmdline-options.c \
         $(EMU)/vicii/vicii-color.c \
         $(EMU)/vicii/vicii-draw.c \


### PR DESCRIPTION
vicii-clock-stretch.c is not really used on x64, it's only for x128