### PR TITLE
Paddles & mouse improvements

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1714,7 +1714,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_joyport_type",
          "RetroPad Port Type",
-         "Non-joysticks will be plugged into current port only and are controlled with the left analog stick or a real mouse.",
+         "Non-joysticks will be plugged into current port only and are controlled with the left analog stick or a real mouse. Paddles will be split to 1st and 2nd RetroPort.",
          {
             { "1", "Joystick" },
             { "2", "Paddles" },

--- a/libretro/libretro-keyboard.i
+++ b/libretro/libretro-keyboard.i
@@ -1,5 +1,7 @@
 const char* keyDesc[] = {
 "---",//0,
+"MOUSE_SLOWER",//-5,
+"MOUSE_FASTER",//-6,
 "TOGGLE_VKBD",//-11,
 "TOGGLE_STATUSBAR",//-12,
 "RETROK_BACKSPACE",//8,
@@ -142,6 +144,8 @@ NULL
 
 int keyVal[] = {
 0,
+-5,
+-6,
 -11,
 -12,
 8,
@@ -284,6 +288,8 @@ int keyVal[] = {
 
 const char* keyDescHotkeys[] = {
 "---",//0,
+//"MOUSE_SLOWER",//-5,
+//"MOUSE_FASTER",//-6,
 //"TOGGLE_VKBD",//-11,
 //"TOGGLE_STATUSBAR",//-12,
 "RETROK_BACKSPACE",//8,
@@ -426,6 +432,8 @@ NULL
 
 int keyValHotkeys[] = {
 0,
+//-5,
+//-6,
 //-11,
 //-12,
 8,


### PR DESCRIPTION
- Split "Paddles" joyport type to first two RetroPads:
  - Player1 vertical axis = Player2 horizontal axis
  - Player1 2nd button = Player2 1st button
- Add speed modifier hotkeys (slower+faster) for paddles/mouse

Because "Paddles" is in fact 2 controllers in one joyport, and currently it is read like a mouse with 2 axis and 2 buttons, this is not convenient for 2 player games, like Panic Analogue, which use paddles as 2 separate entities with one axis and one button. 

