### PR TITLE
M3U+ZIP handling, PET fixes

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -23,7 +23,10 @@ SOURCES_C  := \
 				 $(CORE_DIR)/libretro/retro_files.c \
 				 $(CORE_DIR)/libretro/retro_disk_control.c \
 				 $(CORE_DIR)/libretro/vkbd.c \
-				 $(CORE_DIR)/libretro/graph.c
+				 $(CORE_DIR)/libretro/graph.c \
+				 $(CORE_DIR)/libretro/retroglue.c \
+				 $(DEPS_DIR)/libz/unzip.c \
+				 $(DEPS_DIR)/libz/ioapi.c
 
 ifeq ($(EMUTYPE), x128)
 include $(CORE_DIR)/Makefile.x128

--- a/deps/libz/ioapi.c
+++ b/deps/libz/ioapi.c
@@ -1,0 +1,177 @@
+/* ioapi.c -- IO base function header for compress/uncompress .zip
+   files using zlib + zip or unzip API
+
+   Version 1.01e, February 12th, 2005
+
+   Copyright (C) 1998-2005 Gilles Vollant
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "zlib.h"
+#include "ioapi.h"
+
+
+
+/* I've found an old Unix (a SunOS 4.1.3_U1) without all SEEK_* defined.... */
+
+#ifndef SEEK_CUR
+#define SEEK_CUR    1
+#endif
+
+#ifndef SEEK_END
+#define SEEK_END    2
+#endif
+
+#ifndef SEEK_SET
+#define SEEK_SET    0
+#endif
+
+voidpf ZCALLBACK fopen_file_func OF((
+   voidpf opaque,
+   const char* filename,
+   int mode));
+
+uLong ZCALLBACK fread_file_func OF((
+   voidpf opaque,
+   voidpf stream,
+   void* buf,
+   uLong size));
+
+uLong ZCALLBACK fwrite_file_func OF((
+   voidpf opaque,
+   voidpf stream,
+   const void* buf,
+   uLong size));
+
+long ZCALLBACK ftell_file_func OF((
+   voidpf opaque,
+   voidpf stream));
+
+long ZCALLBACK fseek_file_func OF((
+   voidpf opaque,
+   voidpf stream,
+   uLong offset,
+   int origin));
+
+int ZCALLBACK fclose_file_func OF((
+   voidpf opaque,
+   voidpf stream));
+
+int ZCALLBACK ferror_file_func OF((
+   voidpf opaque,
+   voidpf stream));
+
+
+voidpf ZCALLBACK fopen_file_func (opaque, filename, mode)
+   voidpf opaque;
+   const char* filename;
+   int mode;
+{
+    FILE* file = NULL;
+    const char* mode_fopen = NULL;
+    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
+        mode_fopen = "rb";
+    else
+    if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
+        mode_fopen = "r+b";
+    else
+    if (mode & ZLIB_FILEFUNC_MODE_CREATE)
+        mode_fopen = "wb";
+
+    if ((filename!=NULL) && (mode_fopen != NULL))
+        file = fopen(filename, mode_fopen);
+    return file;
+}
+
+
+uLong ZCALLBACK fread_file_func (opaque, stream, buf, size)
+   voidpf opaque;
+   voidpf stream;
+   void* buf;
+   uLong size;
+{
+    uLong ret;
+    ret = (uLong)fread(buf, 1, (size_t)size, (FILE *)stream);
+    return ret;
+}
+
+
+uLong ZCALLBACK fwrite_file_func (opaque, stream, buf, size)
+   voidpf opaque;
+   voidpf stream;
+   const void* buf;
+   uLong size;
+{
+    uLong ret;
+    ret = (uLong)fwrite(buf, 1, (size_t)size, (FILE *)stream);
+    return ret;
+}
+
+long ZCALLBACK ftell_file_func (opaque, stream)
+   voidpf opaque;
+   voidpf stream;
+{
+    long ret;
+    ret = ftell((FILE *)stream);
+    return ret;
+}
+
+long ZCALLBACK fseek_file_func (opaque, stream, offset, origin)
+   voidpf opaque;
+   voidpf stream;
+   uLong offset;
+   int origin;
+{
+    int fseek_origin=0;
+    long ret;
+    switch (origin)
+    {
+    case ZLIB_FILEFUNC_SEEK_CUR :
+        fseek_origin = SEEK_CUR;
+        break;
+    case ZLIB_FILEFUNC_SEEK_END :
+        fseek_origin = SEEK_END;
+        break;
+    case ZLIB_FILEFUNC_SEEK_SET :
+        fseek_origin = SEEK_SET;
+        break;
+    default: return -1;
+    }
+    ret = 0;
+    fseek((FILE *)stream, offset, fseek_origin);
+    return ret;
+}
+
+int ZCALLBACK fclose_file_func (opaque, stream)
+   voidpf opaque;
+   voidpf stream;
+{
+    int ret;
+    ret = fclose((FILE *)stream);
+    return ret;
+}
+
+int ZCALLBACK ferror_file_func (opaque, stream)
+   voidpf opaque;
+   voidpf stream;
+{
+    int ret;
+    ret = ferror((FILE *)stream);
+    return ret;
+}
+
+void fill_fopen_filefunc (pzlib_filefunc_def)
+  zlib_filefunc_def* pzlib_filefunc_def;
+{
+    pzlib_filefunc_def->zopen_file = fopen_file_func;
+    pzlib_filefunc_def->zread_file = fread_file_func;
+    pzlib_filefunc_def->zwrite_file = fwrite_file_func;
+    pzlib_filefunc_def->ztell_file = ftell_file_func;
+    pzlib_filefunc_def->zseek_file = fseek_file_func;
+    pzlib_filefunc_def->zclose_file = fclose_file_func;
+    pzlib_filefunc_def->zerror_file = ferror_file_func;
+    pzlib_filefunc_def->opaque = NULL;
+}

--- a/deps/libz/ioapi.h
+++ b/deps/libz/ioapi.h
@@ -1,0 +1,75 @@
+/* ioapi.h -- IO base function header for compress/uncompress .zip
+   files using zlib + zip or unzip API
+
+   Version 1.01e, February 12th, 2005
+
+   Copyright (C) 1998-2005 Gilles Vollant
+*/
+
+#ifndef _ZLIBIOAPI_H
+#define _ZLIBIOAPI_H
+
+
+#define ZLIB_FILEFUNC_SEEK_CUR (1)
+#define ZLIB_FILEFUNC_SEEK_END (2)
+#define ZLIB_FILEFUNC_SEEK_SET (0)
+
+#define ZLIB_FILEFUNC_MODE_READ      (1)
+#define ZLIB_FILEFUNC_MODE_WRITE     (2)
+#define ZLIB_FILEFUNC_MODE_READWRITEFILTER (3)
+
+#define ZLIB_FILEFUNC_MODE_EXISTING (4)
+#define ZLIB_FILEFUNC_MODE_CREATE   (8)
+
+
+#ifndef ZCALLBACK
+
+#if (defined(WIN32) || defined (WINDOWS) || defined (_WINDOWS)) && defined(CALLBACK) && defined (USEWINDOWS_CALLBACK)
+#define ZCALLBACK CALLBACK
+#else
+#define ZCALLBACK
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef voidpf (ZCALLBACK *open_file_func) OF((voidpf opaque, const char* filename, int mode));
+typedef uLong  (ZCALLBACK *read_file_func) OF((voidpf opaque, voidpf stream, void* buf, uLong size));
+typedef uLong  (ZCALLBACK *write_file_func) OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
+typedef long   (ZCALLBACK *tell_file_func) OF((voidpf opaque, voidpf stream));
+typedef long   (ZCALLBACK *seek_file_func) OF((voidpf opaque, voidpf stream, uLong offset, int origin));
+typedef int    (ZCALLBACK *close_file_func) OF((voidpf opaque, voidpf stream));
+typedef int    (ZCALLBACK *testerror_file_func) OF((voidpf opaque, voidpf stream));
+
+typedef struct zlib_filefunc_def_s
+{
+    open_file_func      zopen_file;
+    read_file_func      zread_file;
+    write_file_func     zwrite_file;
+    tell_file_func      ztell_file;
+    seek_file_func      zseek_file;
+    close_file_func     zclose_file;
+    testerror_file_func zerror_file;
+    voidpf              opaque;
+} zlib_filefunc_def;
+
+
+
+void fill_fopen_filefunc OF((zlib_filefunc_def* pzlib_filefunc_def));
+
+#define ZREAD(filefunc,filestream,buf,size) ((*((filefunc).zread_file))((filefunc).opaque,filestream,buf,size))
+#define ZWRITE(filefunc,filestream,buf,size) ((*((filefunc).zwrite_file))((filefunc).opaque,filestream,buf,size))
+#define ZTELL(filefunc,filestream) ((*((filefunc).ztell_file))((filefunc).opaque,filestream))
+#define ZSEEK(filefunc,filestream,pos,mode) ((*((filefunc).zseek_file))((filefunc).opaque,filestream,pos,mode))
+#define ZCLOSE(filefunc,filestream) ((*((filefunc).zclose_file))((filefunc).opaque,filestream))
+#define ZERROR(filefunc,filestream) ((*((filefunc).zerror_file))((filefunc).opaque,filestream))
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/deps/libz/unzip.c
+++ b/deps/libz/unzip.c
@@ -1,0 +1,1599 @@
+/* unzip.c -- IO for uncompress .zip files using zlib
+   Version 1.01e, February 12th, 2005
+
+   Copyright (C) 1998-2005 Gilles Vollant
+
+   Read unzip.h for more info
+*/
+
+/* Decryption code comes from crypt.c by Info-ZIP but has been greatly reduced in terms of
+compatibility with older software. The following is from the original crypt.c. Code
+woven in by Terry Thorsen 1/2003.
+*/
+/*
+  Copyright (c) 1990-2000 Info-ZIP.  All rights reserved.
+
+  See the accompanying file LICENSE, version 2000-Apr-09 or later
+  (the contents of which are also included in zip.h) for terms of use.
+  If, for some reason, all these files are missing, the Info-ZIP license
+  also may be found at:  ftp://ftp.info-zip.org/pub/infozip/license.html
+*/
+/*
+  crypt.c (full version) by Info-ZIP.      Last revised:  [see crypt.h]
+
+  The encryption/decryption parts of this source code (as opposed to the
+  non-echoing password parts) were originally written in Europe.  The
+  whole source package can be freely distributed, including from the USA.
+  (Prior to January 2000, re-export from the US was a violation of US law.)
+ */
+
+/*
+  This encryption code is a direct transcription of the algorithm from
+  Roger Schlafly, described by Phil Katz in the file appnote.txt.  This
+  file (appnote.txt) is distributed with the PKZIP program (even in the
+  version without encryption capabilities).
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "zlib.h"
+#include "unzip.h"
+
+#ifdef STDC
+#  include <stddef.h>
+#  include <string.h>
+#  include <stdlib.h>
+#endif
+#ifdef NO_ERRNO_H
+    extern int errno;
+#else
+#   include <errno.h>
+#endif
+
+#define NOUNCRYPT
+
+#ifndef local
+#  define local static
+#endif
+/* compile with -Dlocal if your debugger can't find static symbols */
+
+
+#ifndef CASESENSITIVITYDEFAULT_NO
+#  if !defined(unix) && !defined(CASESENSITIVITYDEFAULT_YES)
+#    define CASESENSITIVITYDEFAULT_NO
+#  endif
+#endif
+
+
+#ifndef UNZ_BUFSIZE
+#define UNZ_BUFSIZE (16384)
+#endif
+
+#ifndef UNZ_MAXFILENAMEINZIP
+#define UNZ_MAXFILENAMEINZIP (256)
+#endif
+
+#ifndef ALLOC
+# define ALLOC(size) (malloc(size))
+#endif
+#ifndef TRYFREE
+# define TRYFREE(p) {if (p) free(p);}
+#endif
+
+#define SIZECENTRALDIRITEM (0x2e)
+#define SIZEZIPLOCALHEADER (0x1e)
+
+
+
+
+const char unz_copyright[] =
+   " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
+
+/* unz_file_info_interntal contain internal info about a file in zipfile*/
+typedef struct unz_file_info_internal_s
+{
+    uLong offset_curfile;/* relative offset of local header 4 bytes */
+} unz_file_info_internal;
+
+
+/* file_in_zip_read_info_s contain internal information about a file in zipfile,
+    when reading and decompress it */
+typedef struct
+{
+    char  *read_buffer;         /* internal buffer for compressed data */
+    z_stream stream;            /* zLib stream structure for inflate */
+
+    uLong pos_in_zipfile;       /* position in byte on the zipfile, for fseek*/
+    uLong stream_initialised;   /* flag set if stream structure is initialised*/
+
+    uLong offset_local_extrafield;/* offset of the local extra field */
+    uInt  size_local_extrafield;/* size of the local extra field */
+    uLong pos_local_extrafield;   /* position in the local extra field in read*/
+
+    uLong crc32;                /* crc32 of all data uncompressed */
+    uLong crc32_wait;           /* crc32 we must obtain after decompress all */
+    uLong rest_read_compressed; /* number of byte to be decompressed */
+    uLong rest_read_uncompressed;/*number of byte to be obtained after decomp*/
+    zlib_filefunc_def z_filefunc;
+    voidpf filestream;        /* io structore of the zipfile */
+    uLong compression_method;   /* compression method (0==store) */
+    uLong byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
+    int   raw;
+} file_in_zip_read_info_s;
+
+
+/* unz_s contain internal information about the zipfile
+*/
+typedef struct
+{
+    zlib_filefunc_def z_filefunc;
+    voidpf filestream;        /* io structore of the zipfile */
+    unz_global_info gi;       /* public global information */
+    uLong byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
+    uLong num_file;             /* number of the current file in the zipfile*/
+    uLong pos_in_central_dir;   /* pos of the current file in the central dir*/
+    uLong current_file_ok;      /* flag about the usability of the current file*/
+    uLong central_pos;          /* position of the beginning of the central dir*/
+
+    uLong size_central_dir;     /* size of the central directory  */
+    uLong offset_central_dir;   /* offset of start of central directory with
+                                   respect to the starting disk number */
+
+    unz_file_info cur_file_info; /* public info about the current file in zip*/
+    unz_file_info_internal cur_file_info_internal; /* private info about it*/
+    file_in_zip_read_info_s* pfile_in_zip_read; /* structure about the current
+                                        file if we are decompressing it */
+    int encrypted;
+#    ifndef NOUNCRYPT
+    unsigned long keys[3];     /* keys defining the pseudo-random sequence */
+    const unsigned long* pcrc_32_tab;
+#    endif
+} unz_s;
+
+
+#ifndef NOUNCRYPT
+#include "crypt.h"
+#endif
+
+/* ===========================================================================
+     Read a byte from a gz_stream; update next_in and avail_in. Return EOF
+   for end of file.
+   IN assertion: the stream s has been sucessfully opened for reading.
+*/
+
+
+local int unzlocal_getByte OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream,
+    int *pi));
+
+local int unzlocal_getByte(pzlib_filefunc_def,filestream,pi)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+    int *pi;
+{
+    unsigned char c;
+    int err = (int)ZREAD(*pzlib_filefunc_def,filestream,&c,1);
+    if (err==1)
+    {
+        *pi = (int)c;
+        return UNZ_OK;
+    }
+    else
+    {
+        if (ZERROR(*pzlib_filefunc_def,filestream))
+            return UNZ_ERRNO;
+        else
+            return UNZ_EOF;
+    }
+}
+
+
+/* ===========================================================================
+   Reads a long in LSB order from the given gz_stream. Sets
+*/
+local int unzlocal_getShort OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream,
+    uLong *pX));
+
+local int unzlocal_getShort (pzlib_filefunc_def,filestream,pX)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+    uLong *pX;
+{
+    uLong x ;
+    int i;
+    int err;
+
+    err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x = (uLong)i;
+
+    if (err==UNZ_OK)
+        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<8;
+
+    if (err==UNZ_OK)
+        *pX = x;
+    else
+        *pX = 0;
+    return err;
+}
+
+local int unzlocal_getLong OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream,
+    uLong *pX));
+
+local int unzlocal_getLong (pzlib_filefunc_def,filestream,pX)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+    uLong *pX;
+{
+    uLong x ;
+    int i;
+    int err;
+
+    err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x = (uLong)i;
+
+    if (err==UNZ_OK)
+        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<8;
+
+    if (err==UNZ_OK)
+        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<16;
+
+    if (err==UNZ_OK)
+        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<24;
+
+    if (err==UNZ_OK)
+        *pX = x;
+    else
+        *pX = 0;
+    return err;
+}
+
+
+/* My own strcmpi / strcasecmp */
+local int strcmpcasenosensitive_internal (fileName1,fileName2)
+    const char* fileName1;
+    const char* fileName2;
+{
+    for (;;)
+    {
+        char c1=*(fileName1++);
+        char c2=*(fileName2++);
+        if ((c1>='a') && (c1<='z'))
+            c1 -= 0x20;
+        if ((c2>='a') && (c2<='z'))
+            c2 -= 0x20;
+        if (c1=='\0')
+            return ((c2=='\0') ? 0 : -1);
+        if (c2=='\0')
+            return 1;
+        if (c1<c2)
+            return -1;
+        if (c1>c2)
+            return 1;
+    }
+}
+
+
+#ifdef  CASESENSITIVITYDEFAULT_NO
+#define CASESENSITIVITYDEFAULTVALUE 2
+#else
+#define CASESENSITIVITYDEFAULTVALUE 1
+#endif
+
+#ifndef STRCMPCASENOSENTIVEFUNCTION
+#define STRCMPCASENOSENTIVEFUNCTION strcmpcasenosensitive_internal
+#endif
+
+/*
+   Compare two filename (fileName1,fileName2).
+   If iCaseSenisivity = 1, comparision is case sensitivity (like strcmp)
+   If iCaseSenisivity = 2, comparision is not case sensitivity (like strcmpi
+                                                                or strcasecmp)
+   If iCaseSenisivity = 0, case sensitivity is defaut of your operating system
+        (like 1 on Unix, 2 on Windows)
+
+*/
+extern int ZEXPORT unzStringFileNameCompare (fileName1,fileName2,iCaseSensitivity)
+    const char* fileName1;
+    const char* fileName2;
+    int iCaseSensitivity;
+{
+    if (iCaseSensitivity==0)
+        iCaseSensitivity=CASESENSITIVITYDEFAULTVALUE;
+
+    if (iCaseSensitivity==1)
+        return strcmp(fileName1,fileName2);
+
+    return STRCMPCASENOSENTIVEFUNCTION(fileName1,fileName2);
+}
+
+#ifndef BUFREADCOMMENT
+#define BUFREADCOMMENT (0x400)
+#endif
+
+/*
+  Locate the Central directory of a zipfile (at the end, just before
+    the global comment)
+*/
+local uLong unzlocal_SearchCentralDir OF((
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream));
+
+local uLong unzlocal_SearchCentralDir(pzlib_filefunc_def,filestream)
+    const zlib_filefunc_def* pzlib_filefunc_def;
+    voidpf filestream;
+{
+    unsigned char* buf;
+    uLong uSizeFile;
+    uLong uBackRead;
+    uLong uMaxBack=0xffff; /* maximum size of global comment */
+    uLong uPosFound=0;
+
+    if (ZSEEK(*pzlib_filefunc_def,filestream,0,ZLIB_FILEFUNC_SEEK_END) != 0)
+        return 0;
+
+
+    uSizeFile = ZTELL(*pzlib_filefunc_def,filestream);
+
+    if (uMaxBack>uSizeFile)
+        uMaxBack = uSizeFile;
+
+    buf = (unsigned char*)ALLOC(BUFREADCOMMENT+4);
+    if (buf==NULL)
+        return 0;
+
+    uBackRead = 4;
+    while (uBackRead<uMaxBack)
+    {
+        uLong uReadSize,uReadPos ;
+        int i;
+        if (uBackRead+BUFREADCOMMENT>uMaxBack)
+            uBackRead = uMaxBack;
+        else
+            uBackRead+=BUFREADCOMMENT;
+        uReadPos = uSizeFile-uBackRead ;
+
+        uReadSize = ((BUFREADCOMMENT+4) < (uSizeFile-uReadPos)) ?
+                     (BUFREADCOMMENT+4) : (uSizeFile-uReadPos);
+        if (ZSEEK(*pzlib_filefunc_def,filestream,uReadPos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            break;
+
+        if (ZREAD(*pzlib_filefunc_def,filestream,buf,uReadSize)!=uReadSize)
+            break;
+
+        for (i=(int)uReadSize-3; (i--)>0;)
+            if (((*(buf+i))==0x50) && ((*(buf+i+1))==0x4b) &&
+                ((*(buf+i+2))==0x05) && ((*(buf+i+3))==0x06))
+            {
+                uPosFound = uReadPos+i;
+                break;
+            }
+
+        if (uPosFound!=0)
+            break;
+    }
+    TRYFREE(buf);
+    return uPosFound;
+}
+
+/*
+  Open a Zip file. path contain the full pathname (by example,
+     on a Windows NT computer "c:\\test\\zlib114.zip" or on an Unix computer
+     "zlib/zlib114.zip".
+     If the zipfile cannot be opened (file doesn't exist or in not valid), the
+       return value is NULL.
+     Else, the return value is a unzFile Handle, usable with other function
+       of this unzip package.
+*/
+extern unzFile ZEXPORT unzOpen2 (path, pzlib_filefunc_def)
+    const char *path;
+    zlib_filefunc_def* pzlib_filefunc_def;
+{
+    unz_s us;
+    unz_s *s;
+    uLong central_pos,uL;
+
+    uLong number_disk;          /* number of the current dist, used for
+                                   spaning ZIP, unsupported, always 0*/
+    uLong number_disk_with_CD;  /* number the the disk with central dir, used
+                                   for spaning ZIP, unsupported, always 0*/
+    uLong number_entry_CD;      /* total number of entries in
+                                   the central dir
+                                   (same than number_entry on nospan) */
+
+    int err=UNZ_OK;
+
+    if (unz_copyright[0]!=' ')
+        return NULL;
+
+    if (pzlib_filefunc_def==NULL)
+        fill_fopen_filefunc(&us.z_filefunc);
+    else
+        us.z_filefunc = *pzlib_filefunc_def;
+
+    us.filestream= (*(us.z_filefunc.zopen_file))(us.z_filefunc.opaque,
+                                                 path,
+                                                 ZLIB_FILEFUNC_MODE_READ |
+                                                 ZLIB_FILEFUNC_MODE_EXISTING);
+    if (us.filestream==NULL)
+        return NULL;
+
+    central_pos = unzlocal_SearchCentralDir(&us.z_filefunc,us.filestream);
+    if (central_pos==0)
+        err=UNZ_ERRNO;
+
+    if (ZSEEK(us.z_filefunc, us.filestream,
+                                      central_pos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        err=UNZ_ERRNO;
+
+    /* the signature, already checked */
+    if (unzlocal_getLong(&us.z_filefunc, us.filestream,&uL)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* number of this disk */
+    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&number_disk)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* number of the disk with the start of the central directory */
+    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&number_disk_with_CD)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* total number of entries in the central dir on this disk */
+    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&us.gi.number_entry)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* total number of entries in the central dir */
+    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&number_entry_CD)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if ((number_entry_CD!=us.gi.number_entry) ||
+        (number_disk_with_CD!=0) ||
+        (number_disk!=0))
+        err=UNZ_BADZIPFILE;
+
+    /* size of the central directory */
+    if (unzlocal_getLong(&us.z_filefunc, us.filestream,&us.size_central_dir)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* offset of start of central directory with respect to the
+          starting disk number */
+    if (unzlocal_getLong(&us.z_filefunc, us.filestream,&us.offset_central_dir)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    /* zipfile comment length */
+    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&us.gi.size_comment)!=UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if ((central_pos<us.offset_central_dir+us.size_central_dir) &&
+        (err==UNZ_OK))
+        err=UNZ_BADZIPFILE;
+
+    if (err!=UNZ_OK)
+    {
+        ZCLOSE(us.z_filefunc, us.filestream);
+        return NULL;
+    }
+
+    us.byte_before_the_zipfile = central_pos -
+                            (us.offset_central_dir+us.size_central_dir);
+    us.central_pos = central_pos;
+    us.pfile_in_zip_read = NULL;
+    us.encrypted = 0;
+
+
+    s=(unz_s*)ALLOC(sizeof(unz_s));
+    *s=us;
+    unzGoToFirstFile((unzFile)s);
+    return (unzFile)s;
+}
+
+
+extern unzFile ZEXPORT unzOpen (path)
+    const char *path;
+{
+    return unzOpen2(path, NULL);
+}
+
+/*
+  Close a ZipFile opened with unzipOpen.
+  If there is files inside the .Zip opened with unzipOpenCurrentFile (see later),
+    these files MUST be closed with unzipCloseCurrentFile before call unzipClose.
+  return UNZ_OK if there is no problem. */
+extern int ZEXPORT unzClose (file)
+    unzFile file;
+{
+    unz_s* s;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+
+    if (s->pfile_in_zip_read!=NULL)
+        unzCloseCurrentFile(file);
+
+    ZCLOSE(s->z_filefunc, s->filestream);
+    TRYFREE(s);
+    return UNZ_OK;
+}
+
+
+/*
+  Write info about the ZipFile in the *pglobal_info structure.
+  No preparation of the structure is needed
+  return UNZ_OK if there is no problem. */
+extern int ZEXPORT unzGetGlobalInfo (file,pglobal_info)
+    unzFile file;
+    unz_global_info *pglobal_info;
+{
+    unz_s* s;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    *pglobal_info=s->gi;
+    return UNZ_OK;
+}
+
+
+/*
+   Translate date/time from Dos format to tm_unz (readable more easilty)
+*/
+local void unzlocal_DosDateToTmuDate (ulDosDate, ptm)
+    uLong ulDosDate;
+    tm_unz* ptm;
+{
+    uLong uDate;
+    uDate = (uLong)(ulDosDate>>16);
+    ptm->tm_mday = (uInt)(uDate&0x1f) ;
+    ptm->tm_mon =  (uInt)((((uDate)&0x1E0)/0x20)-1) ;
+    ptm->tm_year = (uInt)(((uDate&0x0FE00)/0x0200)+1980) ;
+
+    ptm->tm_hour = (uInt) ((ulDosDate &0xF800)/0x800);
+    ptm->tm_min =  (uInt) ((ulDosDate&0x7E0)/0x20) ;
+    ptm->tm_sec =  (uInt) (2*(ulDosDate&0x1f)) ;
+}
+
+/*
+  Get Info about the current file in the zipfile, with internal only info
+*/
+local int unzlocal_GetCurrentFileInfoInternal OF((unzFile file,
+                                                  unz_file_info *pfile_info,
+                                                  unz_file_info_internal
+                                                  *pfile_info_internal,
+                                                  char *szFileName,
+                                                  uLong fileNameBufferSize,
+                                                  void *extraField,
+                                                  uLong extraFieldBufferSize,
+                                                  char *szComment,
+                                                  uLong commentBufferSize));
+
+local int unzlocal_GetCurrentFileInfoInternal (file,
+                                              pfile_info,
+                                              pfile_info_internal,
+                                              szFileName, fileNameBufferSize,
+                                              extraField, extraFieldBufferSize,
+                                              szComment,  commentBufferSize)
+    unzFile file;
+    unz_file_info *pfile_info;
+    unz_file_info_internal *pfile_info_internal;
+    char *szFileName;
+    uLong fileNameBufferSize;
+    void *extraField;
+    uLong extraFieldBufferSize;
+    char *szComment;
+    uLong commentBufferSize;
+{
+    unz_s* s;
+    unz_file_info file_info;
+    unz_file_info_internal file_info_internal;
+    int err=UNZ_OK;
+    uLong uMagic;
+    long lSeek=0;
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    if (ZSEEK(s->z_filefunc, s->filestream,
+              s->pos_in_central_dir+s->byte_before_the_zipfile,
+              ZLIB_FILEFUNC_SEEK_SET)!=0)
+        err=UNZ_ERRNO;
+
+
+    /* we check the magic */
+    if (err==UNZ_OK)
+        if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
+            err=UNZ_ERRNO;
+        else if (uMagic!=0x02014b50)
+            err=UNZ_BADZIPFILE;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.version) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.version_needed) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.flag) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.compression_method) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.dosDate) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    unzlocal_DosDateToTmuDate(file_info.dosDate,&file_info.tmu_date);
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.crc) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.compressed_size) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.uncompressed_size) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.size_filename) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.size_file_extra) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.size_file_comment) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.disk_num_start) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.internal_fa) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.external_fa) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info_internal.offset_curfile) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    lSeek+=file_info.size_filename;
+    if ((err==UNZ_OK) && (szFileName!=NULL))
+    {
+        uLong uSizeRead ;
+        if (file_info.size_filename<fileNameBufferSize)
+        {
+            *(szFileName+file_info.size_filename)='\0';
+            uSizeRead = file_info.size_filename;
+        }
+        else
+            uSizeRead = fileNameBufferSize;
+
+        if ((file_info.size_filename>0) && (fileNameBufferSize>0))
+            if (ZREAD(s->z_filefunc, s->filestream,szFileName,uSizeRead)!=uSizeRead)
+                err=UNZ_ERRNO;
+        lSeek -= uSizeRead;
+    }
+
+
+    if ((err==UNZ_OK) && (extraField!=NULL))
+    {
+        uLong uSizeRead ;
+        if (file_info.size_file_extra<extraFieldBufferSize)
+            uSizeRead = file_info.size_file_extra;
+        else
+            uSizeRead = extraFieldBufferSize;
+
+        if (lSeek!=0)
+            if (ZSEEK(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
+                lSeek=0;
+            else
+                err=UNZ_ERRNO;
+        if ((file_info.size_file_extra>0) && (extraFieldBufferSize>0))
+            if (ZREAD(s->z_filefunc, s->filestream,extraField,uSizeRead)!=uSizeRead)
+                err=UNZ_ERRNO;
+        lSeek += file_info.size_file_extra - uSizeRead;
+    }
+    else
+        lSeek+=file_info.size_file_extra;
+
+
+    if ((err==UNZ_OK) && (szComment!=NULL))
+    {
+        uLong uSizeRead ;
+        if (file_info.size_file_comment<commentBufferSize)
+        {
+            *(szComment+file_info.size_file_comment)='\0';
+            uSizeRead = file_info.size_file_comment;
+        }
+        else
+            uSizeRead = commentBufferSize;
+
+        if (lSeek!=0)
+            if (ZSEEK(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
+                lSeek=0;
+            else
+                err=UNZ_ERRNO;
+        if ((file_info.size_file_comment>0) && (commentBufferSize>0))
+            if (ZREAD(s->z_filefunc, s->filestream,szComment,uSizeRead)!=uSizeRead)
+                err=UNZ_ERRNO;
+        lSeek+=file_info.size_file_comment - uSizeRead;
+    }
+    else
+        lSeek+=file_info.size_file_comment;
+
+    if ((err==UNZ_OK) && (pfile_info!=NULL))
+        *pfile_info=file_info;
+
+    if ((err==UNZ_OK) && (pfile_info_internal!=NULL))
+        *pfile_info_internal=file_info_internal;
+
+    return err;
+}
+
+
+
+/*
+  Write info about the ZipFile in the *pglobal_info structure.
+  No preparation of the structure is needed
+  return UNZ_OK if there is no problem.
+*/
+extern int ZEXPORT unzGetCurrentFileInfo (file,
+                                          pfile_info,
+                                          szFileName, fileNameBufferSize,
+                                          extraField, extraFieldBufferSize,
+                                          szComment,  commentBufferSize)
+    unzFile file;
+    unz_file_info *pfile_info;
+    char *szFileName;
+    uLong fileNameBufferSize;
+    void *extraField;
+    uLong extraFieldBufferSize;
+    char *szComment;
+    uLong commentBufferSize;
+{
+    return unzlocal_GetCurrentFileInfoInternal(file,pfile_info,NULL,
+                                                szFileName,fileNameBufferSize,
+                                                extraField,extraFieldBufferSize,
+                                                szComment,commentBufferSize);
+}
+
+/*
+  Set the current file of the zipfile to the first file.
+  return UNZ_OK if there is no problem
+*/
+extern int ZEXPORT unzGoToFirstFile (file)
+    unzFile file;
+{
+    int err=UNZ_OK;
+    unz_s* s;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    s->pos_in_central_dir=s->offset_central_dir;
+    s->num_file=0;
+    err=unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                             &s->cur_file_info_internal,
+                                             NULL,0,NULL,0,NULL,0);
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
+}
+
+/*
+  Set the current file of the zipfile to the next file.
+  return UNZ_OK if there is no problem
+  return UNZ_END_OF_LIST_OF_FILE if the actual file was the latest.
+*/
+extern int ZEXPORT unzGoToNextFile (file)
+    unzFile file;
+{
+    unz_s* s;
+    int err;
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
+    if (s->gi.number_entry != 0xffff)    /* 2^16 files overflow hack */
+      if (s->num_file+1==s->gi.number_entry)
+        return UNZ_END_OF_LIST_OF_FILE;
+
+    s->pos_in_central_dir += SIZECENTRALDIRITEM + s->cur_file_info.size_filename +
+            s->cur_file_info.size_file_extra + s->cur_file_info.size_file_comment ;
+    s->num_file++;
+    err = unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                               &s->cur_file_info_internal,
+                                               NULL,0,NULL,0,NULL,0);
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
+}
+
+
+/*
+  Try locate the file szFileName in the zipfile.
+  For the iCaseSensitivity signification, see unzipStringFileNameCompare
+
+  return value :
+  UNZ_OK if the file is found. It becomes the current file.
+  UNZ_END_OF_LIST_OF_FILE if the file is not found
+*/
+extern int ZEXPORT unzLocateFile (file, szFileName, iCaseSensitivity)
+    unzFile file;
+    const char *szFileName;
+    int iCaseSensitivity;
+{
+    unz_s* s;
+    int err;
+
+    /* We remember the 'current' position in the file so that we can jump
+     * back there if we fail.
+     */
+    unz_file_info cur_file_infoSaved;
+    unz_file_info_internal cur_file_info_internalSaved;
+    uLong num_fileSaved;
+    uLong pos_in_central_dirSaved;
+
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+
+    if (strlen(szFileName)>=UNZ_MAXFILENAMEINZIP)
+        return UNZ_PARAMERROR;
+
+    s=(unz_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
+
+    /* Save the current state */
+    num_fileSaved = s->num_file;
+    pos_in_central_dirSaved = s->pos_in_central_dir;
+    cur_file_infoSaved = s->cur_file_info;
+    cur_file_info_internalSaved = s->cur_file_info_internal;
+
+    err = unzGoToFirstFile(file);
+
+    while (err == UNZ_OK)
+    {
+        char szCurrentFileName[UNZ_MAXFILENAMEINZIP+1];
+        err = unzGetCurrentFileInfo(file,NULL,
+                                    szCurrentFileName,sizeof(szCurrentFileName)-1,
+                                    NULL,0,NULL,0);
+        if (err == UNZ_OK)
+        {
+            if (unzStringFileNameCompare(szCurrentFileName,
+                                            szFileName,iCaseSensitivity)==0)
+                return UNZ_OK;
+            err = unzGoToNextFile(file);
+        }
+    }
+
+    /* We failed, so restore the state of the 'current file' to where we
+     * were.
+     */
+    s->num_file = num_fileSaved ;
+    s->pos_in_central_dir = pos_in_central_dirSaved ;
+    s->cur_file_info = cur_file_infoSaved;
+    s->cur_file_info_internal = cur_file_info_internalSaved;
+    return err;
+}
+
+
+/*
+///////////////////////////////////////////
+// Contributed by Ryan Haksi (mailto://cryogen@infoserve.net)
+// I need random access
+//
+// Further optimization could be realized by adding an ability
+// to cache the directory in memory. The goal being a single
+// comprehensive file read to put the file I need in a memory.
+*/
+
+/*
+typedef struct unz_file_pos_s
+{
+    uLong pos_in_zip_directory;   // offset in file
+    uLong num_of_file;            // # of file
+} unz_file_pos;
+*/
+
+extern int ZEXPORT unzGetFilePos(file, file_pos)
+    unzFile file;
+    unz_file_pos* file_pos;
+{
+    unz_s* s;
+
+    if (file==NULL || file_pos==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
+
+    file_pos->pos_in_zip_directory  = s->pos_in_central_dir;
+    file_pos->num_of_file           = s->num_file;
+
+    return UNZ_OK;
+}
+
+extern int ZEXPORT unzGoToFilePos(file, file_pos)
+    unzFile file;
+    unz_file_pos* file_pos;
+{
+    unz_s* s;
+    int err;
+
+    if (file==NULL || file_pos==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+
+    /* jump to the right spot */
+    s->pos_in_central_dir = file_pos->pos_in_zip_directory;
+    s->num_file           = file_pos->num_of_file;
+
+    /* set the current file */
+    err = unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                               &s->cur_file_info_internal,
+                                               NULL,0,NULL,0,NULL,0);
+    /* return results */
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
+}
+
+/*
+// Unzip Helper Functions - should be here?
+///////////////////////////////////////////
+*/
+
+/*
+  Read the local header of the current zipfile
+  Check the coherency of the local header and info in the end of central
+        directory about this file
+  store in *piSizeVar the size of extra info in local header
+        (filename and size of extra field data)
+*/
+local int unzlocal_CheckCurrentFileCoherencyHeader (s,piSizeVar,
+                                                    poffset_local_extrafield,
+                                                    psize_local_extrafield)
+    unz_s* s;
+    uInt* piSizeVar;
+    uLong *poffset_local_extrafield;
+    uInt  *psize_local_extrafield;
+{
+    uLong uMagic,uData,uFlags;
+    uLong size_filename;
+    uLong size_extra_field;
+    int err=UNZ_OK;
+
+    *piSizeVar = 0;
+    *poffset_local_extrafield = 0;
+    *psize_local_extrafield = 0;
+
+    if (ZSEEK(s->z_filefunc, s->filestream,s->cur_file_info_internal.offset_curfile +
+                                s->byte_before_the_zipfile,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        return UNZ_ERRNO;
+
+
+    if (err==UNZ_OK)
+        if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
+            err=UNZ_ERRNO;
+        else if (uMagic!=0x04034b50)
+            err=UNZ_BADZIPFILE;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uData) != UNZ_OK)
+        err=UNZ_ERRNO;
+/*
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.wVersion))
+        err=UNZ_BADZIPFILE;
+*/
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uFlags) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uData) != UNZ_OK)
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.compression_method))
+        err=UNZ_BADZIPFILE;
+
+    if ((err==UNZ_OK) && (s->cur_file_info.compression_method!=0) &&
+                         (s->cur_file_info.compression_method!=Z_DEFLATED))
+        err=UNZ_BADZIPFILE;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* date/time */
+        err=UNZ_ERRNO;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* crc */
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.crc) &&
+                              ((uFlags & 8)==0))
+        err=UNZ_BADZIPFILE;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* size compr */
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.compressed_size) &&
+                              ((uFlags & 8)==0))
+        err=UNZ_BADZIPFILE;
+
+    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* size uncompr */
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.uncompressed_size) &&
+                              ((uFlags & 8)==0))
+        err=UNZ_BADZIPFILE;
+
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&size_filename) != UNZ_OK)
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (size_filename!=s->cur_file_info.size_filename))
+        err=UNZ_BADZIPFILE;
+
+    *piSizeVar += (uInt)size_filename;
+
+    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&size_extra_field) != UNZ_OK)
+        err=UNZ_ERRNO;
+    *poffset_local_extrafield= s->cur_file_info_internal.offset_curfile +
+                                    SIZEZIPLOCALHEADER + size_filename;
+    *psize_local_extrafield = (uInt)size_extra_field;
+
+    *piSizeVar += (uInt)size_extra_field;
+
+    return err;
+}
+
+/*
+  Open for reading data the current file in the zipfile.
+  If there is no error and the file is opened, the return value is UNZ_OK.
+*/
+extern int ZEXPORT unzOpenCurrentFile3 (file, method, level, raw, password)
+    unzFile file;
+    int* method;
+    int* level;
+    int raw;
+    const char* password;
+{
+    int err=UNZ_OK;
+    uInt iSizeVar;
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    uLong offset_local_extrafield;  /* offset of the local extra field */
+    uInt  size_local_extrafield;    /* size of the local extra field */
+#    ifndef NOUNCRYPT
+    char source[12];
+#    else
+    if (password != NULL)
+        return UNZ_PARAMERROR;
+#    endif
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_PARAMERROR;
+
+    if (s->pfile_in_zip_read != NULL)
+        unzCloseCurrentFile(file);
+
+    if (unzlocal_CheckCurrentFileCoherencyHeader(s,&iSizeVar,
+                &offset_local_extrafield,&size_local_extrafield)!=UNZ_OK)
+        return UNZ_BADZIPFILE;
+
+    pfile_in_zip_read_info = (file_in_zip_read_info_s*)
+                                        ALLOC(sizeof(file_in_zip_read_info_s));
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_INTERNALERROR;
+
+    pfile_in_zip_read_info->read_buffer=(char*)ALLOC(UNZ_BUFSIZE);
+    pfile_in_zip_read_info->offset_local_extrafield = offset_local_extrafield;
+    pfile_in_zip_read_info->size_local_extrafield = size_local_extrafield;
+    pfile_in_zip_read_info->pos_local_extrafield=0;
+    pfile_in_zip_read_info->raw=raw;
+
+    if (pfile_in_zip_read_info->read_buffer==NULL)
+    {
+        TRYFREE(pfile_in_zip_read_info);
+        return UNZ_INTERNALERROR;
+    }
+
+    pfile_in_zip_read_info->stream_initialised=0;
+
+    if (method!=NULL)
+        *method = (int)s->cur_file_info.compression_method;
+
+    if (level!=NULL)
+    {
+        *level = 6;
+        switch (s->cur_file_info.flag & 0x06)
+        {
+          case 6 : *level = 1; break;
+          case 4 : *level = 2; break;
+          case 2 : *level = 9; break;
+        }
+    }
+
+    if ((s->cur_file_info.compression_method!=0) &&
+        (s->cur_file_info.compression_method!=Z_DEFLATED))
+        err=UNZ_BADZIPFILE;
+
+    pfile_in_zip_read_info->crc32_wait=s->cur_file_info.crc;
+    pfile_in_zip_read_info->crc32=0;
+    pfile_in_zip_read_info->compression_method =
+            s->cur_file_info.compression_method;
+    pfile_in_zip_read_info->filestream=s->filestream;
+    pfile_in_zip_read_info->z_filefunc=s->z_filefunc;
+    pfile_in_zip_read_info->byte_before_the_zipfile=s->byte_before_the_zipfile;
+
+    pfile_in_zip_read_info->stream.total_out = 0;
+
+    if ((s->cur_file_info.compression_method==Z_DEFLATED) &&
+        (!raw))
+    {
+      pfile_in_zip_read_info->stream.zalloc = (alloc_func)0;
+      pfile_in_zip_read_info->stream.zfree = (free_func)0;
+      pfile_in_zip_read_info->stream.opaque = (voidpf)0;
+      pfile_in_zip_read_info->stream.next_in = (voidpf)0;
+      pfile_in_zip_read_info->stream.avail_in = 0;
+
+      err=inflateInit2(&pfile_in_zip_read_info->stream, -MAX_WBITS);
+      if (err == Z_OK)
+        pfile_in_zip_read_info->stream_initialised=1;
+      else
+      {
+        TRYFREE(pfile_in_zip_read_info);
+        return err;
+      }
+        /* windowBits is passed < 0 to tell that there is no zlib header.
+         * Note that in this case inflate *requires* an extra "dummy" byte
+         * after the compressed stream in order to complete decompression and
+         * return Z_STREAM_END.
+         * In unzip, i don't wait absolutely Z_STREAM_END because I known the
+         * size of both compressed and uncompressed data
+         */
+    }
+    pfile_in_zip_read_info->rest_read_compressed =
+            s->cur_file_info.compressed_size ;
+    pfile_in_zip_read_info->rest_read_uncompressed =
+            s->cur_file_info.uncompressed_size ;
+
+
+    pfile_in_zip_read_info->pos_in_zipfile =
+            s->cur_file_info_internal.offset_curfile + SIZEZIPLOCALHEADER +
+              iSizeVar;
+
+    pfile_in_zip_read_info->stream.avail_in = (uInt)0;
+
+    s->pfile_in_zip_read = pfile_in_zip_read_info;
+
+#    ifndef NOUNCRYPT
+    if (password != NULL)
+    {
+        int i;
+        s->pcrc_32_tab = get_crc_table();
+        init_keys(password,s->keys,s->pcrc_32_tab);
+        if (ZSEEK(s->z_filefunc, s->filestream,
+                  s->pfile_in_zip_read->pos_in_zipfile +
+                     s->pfile_in_zip_read->byte_before_the_zipfile,
+                  SEEK_SET)!=0)
+            return UNZ_INTERNALERROR;
+        if(ZREAD(s->z_filefunc, s->filestream,source, 12)<12)
+            return UNZ_INTERNALERROR;
+
+        for (i = 0; i<12; i++)
+            zdecode(s->keys,s->pcrc_32_tab,source[i]);
+
+        s->pfile_in_zip_read->pos_in_zipfile+=12;
+        s->encrypted=1;
+    }
+#    endif
+
+
+    return UNZ_OK;
+}
+
+extern int ZEXPORT unzOpenCurrentFile (file)
+    unzFile file;
+{
+    return unzOpenCurrentFile3(file, NULL, NULL, 0, NULL);
+}
+
+extern int ZEXPORT unzOpenCurrentFilePassword (file, password)
+    unzFile file;
+    const char* password;
+{
+    return unzOpenCurrentFile3(file, NULL, NULL, 0, password);
+}
+
+extern int ZEXPORT unzOpenCurrentFile2 (file,method,level,raw)
+    unzFile file;
+    int* method;
+    int* level;
+    int raw;
+{
+    return unzOpenCurrentFile3(file, method, level, raw, NULL);
+}
+
+/*
+  Read bytes from the current file.
+  buf contain buffer where data must be copied
+  len the size of buf.
+
+  return the number of byte copied if somes bytes are copied
+  return 0 if the end of file was reached
+  return <0 with error code if there is an error
+    (UNZ_ERRNO for IO error, or zLib error for uncompress error)
+*/
+extern int ZEXPORT unzReadCurrentFile  (file, buf, len)
+    unzFile file;
+    voidp buf;
+    unsigned len;
+{
+    int err=UNZ_OK;
+    uInt iRead = 0;
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
+
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
+
+
+    if ((pfile_in_zip_read_info->read_buffer == NULL))
+        return UNZ_END_OF_LIST_OF_FILE;
+    if (len==0)
+        return 0;
+
+    pfile_in_zip_read_info->stream.next_out = (Bytef*)buf;
+
+    pfile_in_zip_read_info->stream.avail_out = (uInt)len;
+
+    if ((len>pfile_in_zip_read_info->rest_read_uncompressed) &&
+        (!(pfile_in_zip_read_info->raw)))
+        pfile_in_zip_read_info->stream.avail_out =
+            (uInt)pfile_in_zip_read_info->rest_read_uncompressed;
+
+    if ((len>pfile_in_zip_read_info->rest_read_compressed+
+           pfile_in_zip_read_info->stream.avail_in) &&
+         (pfile_in_zip_read_info->raw))
+        pfile_in_zip_read_info->stream.avail_out =
+            (uInt)pfile_in_zip_read_info->rest_read_compressed+
+            pfile_in_zip_read_info->stream.avail_in;
+
+    while (pfile_in_zip_read_info->stream.avail_out>0)
+    {
+        if ((pfile_in_zip_read_info->stream.avail_in==0) &&
+            (pfile_in_zip_read_info->rest_read_compressed>0))
+        {
+            uInt uReadThis = UNZ_BUFSIZE;
+            if (pfile_in_zip_read_info->rest_read_compressed<uReadThis)
+                uReadThis = (uInt)pfile_in_zip_read_info->rest_read_compressed;
+            if (uReadThis == 0)
+                return UNZ_EOF;
+            if (ZSEEK(pfile_in_zip_read_info->z_filefunc,
+                      pfile_in_zip_read_info->filestream,
+                      pfile_in_zip_read_info->pos_in_zipfile +
+                         pfile_in_zip_read_info->byte_before_the_zipfile,
+                         ZLIB_FILEFUNC_SEEK_SET)!=0)
+                return UNZ_ERRNO;
+            if (ZREAD(pfile_in_zip_read_info->z_filefunc,
+                      pfile_in_zip_read_info->filestream,
+                      pfile_in_zip_read_info->read_buffer,
+                      uReadThis)!=uReadThis)
+                return UNZ_ERRNO;
+
+
+#            ifndef NOUNCRYPT
+            if(s->encrypted)
+            {
+                uInt i;
+                for(i=0;i<uReadThis;i++)
+                  pfile_in_zip_read_info->read_buffer[i] =
+                      zdecode(s->keys,s->pcrc_32_tab,
+                              pfile_in_zip_read_info->read_buffer[i]);
+            }
+#            endif
+
+
+            pfile_in_zip_read_info->pos_in_zipfile += uReadThis;
+
+            pfile_in_zip_read_info->rest_read_compressed-=uReadThis;
+
+            pfile_in_zip_read_info->stream.next_in =
+                (Bytef*)pfile_in_zip_read_info->read_buffer;
+            pfile_in_zip_read_info->stream.avail_in = (uInt)uReadThis;
+        }
+
+        if ((pfile_in_zip_read_info->compression_method==0) || (pfile_in_zip_read_info->raw))
+        {
+            uInt uDoCopy,i ;
+
+            if ((pfile_in_zip_read_info->stream.avail_in == 0) &&
+                (pfile_in_zip_read_info->rest_read_compressed == 0))
+                return (iRead==0) ? UNZ_EOF : iRead;
+
+            if (pfile_in_zip_read_info->stream.avail_out <
+                            pfile_in_zip_read_info->stream.avail_in)
+                uDoCopy = pfile_in_zip_read_info->stream.avail_out ;
+            else
+                uDoCopy = pfile_in_zip_read_info->stream.avail_in ;
+
+            for (i=0;i<uDoCopy;i++)
+                *(pfile_in_zip_read_info->stream.next_out+i) =
+                        *(pfile_in_zip_read_info->stream.next_in+i);
+
+            pfile_in_zip_read_info->crc32 = crc32(pfile_in_zip_read_info->crc32,
+                                pfile_in_zip_read_info->stream.next_out,
+                                uDoCopy);
+            pfile_in_zip_read_info->rest_read_uncompressed-=uDoCopy;
+            pfile_in_zip_read_info->stream.avail_in -= uDoCopy;
+            pfile_in_zip_read_info->stream.avail_out -= uDoCopy;
+            pfile_in_zip_read_info->stream.next_out += uDoCopy;
+            pfile_in_zip_read_info->stream.next_in += uDoCopy;
+            pfile_in_zip_read_info->stream.total_out += uDoCopy;
+            iRead += uDoCopy;
+        }
+        else
+        {
+            uLong uTotalOutBefore,uTotalOutAfter;
+            const Bytef *bufBefore;
+            uLong uOutThis;
+            int flush=Z_SYNC_FLUSH;
+
+            uTotalOutBefore = pfile_in_zip_read_info->stream.total_out;
+            bufBefore = pfile_in_zip_read_info->stream.next_out;
+
+            /*
+            if ((pfile_in_zip_read_info->rest_read_uncompressed ==
+                     pfile_in_zip_read_info->stream.avail_out) &&
+                (pfile_in_zip_read_info->rest_read_compressed == 0))
+                flush = Z_FINISH;
+            */
+            err=inflate(&pfile_in_zip_read_info->stream,flush);
+
+            if ((err>=0) && (pfile_in_zip_read_info->stream.msg!=NULL))
+              err = Z_DATA_ERROR;
+
+            uTotalOutAfter = pfile_in_zip_read_info->stream.total_out;
+            uOutThis = uTotalOutAfter-uTotalOutBefore;
+
+            pfile_in_zip_read_info->crc32 =
+                crc32(pfile_in_zip_read_info->crc32,bufBefore,
+                        (uInt)(uOutThis));
+
+            pfile_in_zip_read_info->rest_read_uncompressed -=
+                uOutThis;
+
+            iRead += (uInt)(uTotalOutAfter - uTotalOutBefore);
+
+            if (err==Z_STREAM_END)
+                return (iRead==0) ? UNZ_EOF : iRead;
+            if (err!=Z_OK)
+                break;
+        }
+    }
+
+    if (err==Z_OK)
+        return iRead;
+    return err;
+}
+
+
+/*
+  Give the current position in uncompressed data
+*/
+extern z_off_t ZEXPORT unztell (file)
+    unzFile file;
+{
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
+
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
+
+    return (z_off_t)pfile_in_zip_read_info->stream.total_out;
+}
+
+
+/*
+  return 1 if the end of file was reached, 0 elsewhere
+*/
+extern int ZEXPORT unzeof (file)
+    unzFile file;
+{
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
+
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
+
+    if (pfile_in_zip_read_info->rest_read_uncompressed == 0)
+        return 1;
+    else
+        return 0;
+}
+
+
+
+/*
+  Read extra field from the current file (opened by unzOpenCurrentFile)
+  This is the local-header version of the extra field (sometimes, there is
+    more info in the local-header version than in the central-header)
+
+  if buf==NULL, it return the size of the local extra field that can be read
+
+  if buf!=NULL, len is the size of the buffer, the extra header is copied in
+    buf.
+  the return value is the number of bytes copied in buf, or (if <0)
+    the error code
+*/
+extern int ZEXPORT unzGetLocalExtrafield (file,buf,len)
+    unzFile file;
+    voidp buf;
+    unsigned len;
+{
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    uInt read_now;
+    uLong size_to_read;
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
+
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
+
+    size_to_read = (pfile_in_zip_read_info->size_local_extrafield -
+                pfile_in_zip_read_info->pos_local_extrafield);
+
+    if (buf==NULL)
+        return (int)size_to_read;
+
+    if (len>size_to_read)
+        read_now = (uInt)size_to_read;
+    else
+        read_now = (uInt)len ;
+
+    if (read_now==0)
+        return 0;
+
+    if (ZSEEK(pfile_in_zip_read_info->z_filefunc,
+              pfile_in_zip_read_info->filestream,
+              pfile_in_zip_read_info->offset_local_extrafield +
+              pfile_in_zip_read_info->pos_local_extrafield,
+              ZLIB_FILEFUNC_SEEK_SET)!=0)
+        return UNZ_ERRNO;
+
+    if (ZREAD(pfile_in_zip_read_info->z_filefunc,
+              pfile_in_zip_read_info->filestream,
+              buf,read_now)!=read_now)
+        return UNZ_ERRNO;
+
+    return (int)read_now;
+}
+
+/*
+  Close the file in zip opened with unzipOpenCurrentFile
+  Return UNZ_CRCERROR if all the file was read but the CRC is not good
+*/
+extern int ZEXPORT unzCloseCurrentFile (file)
+    unzFile file;
+{
+    int err=UNZ_OK;
+
+    unz_s* s;
+    file_in_zip_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
+
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
+
+
+    if ((pfile_in_zip_read_info->rest_read_uncompressed == 0) &&
+        (!pfile_in_zip_read_info->raw))
+    {
+        if (pfile_in_zip_read_info->crc32 != pfile_in_zip_read_info->crc32_wait)
+            err=UNZ_CRCERROR;
+    }
+
+
+    TRYFREE(pfile_in_zip_read_info->read_buffer);
+    pfile_in_zip_read_info->read_buffer = NULL;
+    if (pfile_in_zip_read_info->stream_initialised)
+        inflateEnd(&pfile_in_zip_read_info->stream);
+
+    pfile_in_zip_read_info->stream_initialised = 0;
+    TRYFREE(pfile_in_zip_read_info);
+
+    s->pfile_in_zip_read=NULL;
+
+    return err;
+}
+
+
+/*
+  Get the global comment string of the ZipFile, in the szComment buffer.
+  uSizeBuf is the size of the szComment buffer.
+  return the number of byte copied or an error code <0
+*/
+extern int ZEXPORT unzGetGlobalComment (file, szComment, uSizeBuf)
+    unzFile file;
+    char *szComment;
+    uLong uSizeBuf;
+{
+    int err=UNZ_OK;
+    unz_s* s;
+    uLong uReadThis ;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+
+    uReadThis = uSizeBuf;
+    if (uReadThis>s->gi.size_comment)
+        uReadThis = s->gi.size_comment;
+
+    if (ZSEEK(s->z_filefunc,s->filestream,s->central_pos+22,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        return UNZ_ERRNO;
+
+    if (uReadThis>0)
+    {
+      *szComment='\0';
+      if (ZREAD(s->z_filefunc,s->filestream,szComment,uReadThis)!=uReadThis)
+        return UNZ_ERRNO;
+    }
+
+    if ((szComment != NULL) && (uSizeBuf > s->gi.size_comment))
+        *(szComment+s->gi.size_comment)='\0';
+    return (int)uReadThis;
+}
+
+/* Additions by RX '2004 */
+extern uLong ZEXPORT unzGetOffset (file)
+    unzFile file;
+{
+    unz_s* s;
+
+    if (file==NULL)
+          return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+    if (!s->current_file_ok)
+      return 0;
+    if (s->gi.number_entry != 0 && s->gi.number_entry != 0xffff)
+      if (s->num_file==s->gi.number_entry)
+         return 0;
+    return s->pos_in_central_dir;
+}
+
+extern int ZEXPORT unzSetOffset (file, pos)
+        unzFile file;
+        uLong pos;
+{
+    unz_s* s;
+    int err;
+
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz_s*)file;
+
+    s->pos_in_central_dir = pos;
+    s->num_file = s->gi.number_entry;      /* hack */
+    err = unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                              &s->cur_file_info_internal,
+                                              NULL,0,NULL,0,NULL,0);
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
+}

--- a/deps/libz/unzip.h
+++ b/deps/libz/unzip.h
@@ -1,0 +1,354 @@
+/* unzip.h -- IO for uncompress .zip files using zlib
+   Version 1.01e, February 12th, 2005
+
+   Copyright (C) 1998-2005 Gilles Vollant
+
+   This unzip package allow extract file from .ZIP file, compatible with PKZip 2.04g
+     WinZip, InfoZip tools and compatible.
+
+   Multi volume ZipFile (span) are not supported.
+   Encryption compatible with pkzip 2.04g only supported
+   Old compressions used by old PKZip 1.x are not supported
+
+
+   I WAIT FEEDBACK at mail info@winimage.com
+   Visit also http://www.winimage.com/zLibDll/unzip.htm for evolution
+
+   Condition of use and distribution are the same than zlib :
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+
+*/
+
+/* for more info about .ZIP format, see
+      http://www.info-zip.org/pub/infozip/doc/appnote-981119-iz.zip
+      http://www.info-zip.org/pub/infozip/doc/
+   PkWare has also a specification at :
+      ftp://ftp.pkware.com/probdesc.zip
+*/
+
+#ifndef _unz_H
+#define _unz_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef _ZLIB_H
+#include "zlib.h"
+#endif
+
+#ifndef _ZLIBIOAPI_H
+#include "ioapi.h"
+#endif
+
+#if defined(STRICTUNZIP) || defined(STRICTZIPUNZIP)
+/* like the STRICT of WIN32, we define a pointer that cannot be converted
+    from (void*) without cast */
+typedef struct TagunzFile__ { int unused; } unzFile__;
+typedef unzFile__ *unzFile;
+#else
+typedef voidp unzFile;
+#endif
+
+
+#define UNZ_OK                          (0)
+#define UNZ_END_OF_LIST_OF_FILE         (-100)
+#define UNZ_ERRNO                       (Z_ERRNO)
+#define UNZ_EOF                         (0)
+#define UNZ_PARAMERROR                  (-102)
+#define UNZ_BADZIPFILE                  (-103)
+#define UNZ_INTERNALERROR               (-104)
+#define UNZ_CRCERROR                    (-105)
+
+/* tm_unz contain date/time info */
+typedef struct tm_unz_s
+{
+    uInt tm_sec;            /* seconds after the minute - [0,59] */
+    uInt tm_min;            /* minutes after the hour - [0,59] */
+    uInt tm_hour;           /* hours since midnight - [0,23] */
+    uInt tm_mday;           /* day of the month - [1,31] */
+    uInt tm_mon;            /* months since January - [0,11] */
+    uInt tm_year;           /* years - [1980..2044] */
+} tm_unz;
+
+/* unz_global_info structure contain global data about the ZIPfile
+   These data comes from the end of central dir */
+typedef struct unz_global_info_s
+{
+    uLong number_entry;         /* total number of entries in
+                       the central dir on this disk */
+    uLong size_comment;         /* size of the global comment of the zipfile */
+} unz_global_info;
+
+
+/* unz_file_info contain information about a file in the zipfile */
+typedef struct unz_file_info_s
+{
+    uLong version;              /* version made by                 2 bytes */
+    uLong version_needed;       /* version needed to extract       2 bytes */
+    uLong flag;                 /* general purpose bit flag        2 bytes */
+    uLong compression_method;   /* compression method              2 bytes */
+    uLong dosDate;              /* last mod file date in Dos fmt   4 bytes */
+    uLong crc;                  /* crc-32                          4 bytes */
+    uLong compressed_size;      /* compressed size                 4 bytes */
+    uLong uncompressed_size;    /* uncompressed size               4 bytes */
+    uLong size_filename;        /* filename length                 2 bytes */
+    uLong size_file_extra;      /* extra field length              2 bytes */
+    uLong size_file_comment;    /* file comment length             2 bytes */
+
+    uLong disk_num_start;       /* disk number start               2 bytes */
+    uLong internal_fa;          /* internal file attributes        2 bytes */
+    uLong external_fa;          /* external file attributes        4 bytes */
+
+    tm_unz tmu_date;
+} unz_file_info;
+
+extern int ZEXPORT unzStringFileNameCompare OF ((const char* fileName1,
+                                                 const char* fileName2,
+                                                 int iCaseSensitivity));
+/*
+   Compare two filename (fileName1,fileName2).
+   If iCaseSenisivity = 1, comparision is case sensitivity (like strcmp)
+   If iCaseSenisivity = 2, comparision is not case sensitivity (like strcmpi
+                                or strcasecmp)
+   If iCaseSenisivity = 0, case sensitivity is defaut of your operating system
+    (like 1 on Unix, 2 on Windows)
+*/
+
+
+extern unzFile ZEXPORT unzOpen OF((const char *path));
+/*
+  Open a Zip file. path contain the full pathname (by example,
+     on a Windows XP computer "c:\\zlib\\zlib113.zip" or on an Unix computer
+     "zlib/zlib113.zip".
+     If the zipfile cannot be opened (file don't exist or in not valid), the
+       return value is NULL.
+     Else, the return value is a unzFile Handle, usable with other function
+       of this unzip package.
+*/
+
+extern unzFile ZEXPORT unzOpen2 OF((const char *path,
+                                    zlib_filefunc_def* pzlib_filefunc_def));
+/*
+   Open a Zip file, like unzOpen, but provide a set of file low level API
+      for read/write the zip file (see ioapi.h)
+*/
+
+extern int ZEXPORT unzClose OF((unzFile file));
+/*
+  Close a ZipFile opened with unzipOpen.
+  If there is files inside the .Zip opened with unzOpenCurrentFile (see later),
+    these files MUST be closed with unzipCloseCurrentFile before call unzipClose.
+  return UNZ_OK if there is no problem. */
+
+extern int ZEXPORT unzGetGlobalInfo OF((unzFile file,
+                                        unz_global_info *pglobal_info));
+/*
+  Write info about the ZipFile in the *pglobal_info structure.
+  No preparation of the structure is needed
+  return UNZ_OK if there is no problem. */
+
+
+extern int ZEXPORT unzGetGlobalComment OF((unzFile file,
+                                           char *szComment,
+                                           uLong uSizeBuf));
+/*
+  Get the global comment string of the ZipFile, in the szComment buffer.
+  uSizeBuf is the size of the szComment buffer.
+  return the number of byte copied or an error code <0
+*/
+
+
+/***************************************************************************/
+/* Unzip package allow you browse the directory of the zipfile */
+
+extern int ZEXPORT unzGoToFirstFile OF((unzFile file));
+/*
+  Set the current file of the zipfile to the first file.
+  return UNZ_OK if there is no problem
+*/
+
+extern int ZEXPORT unzGoToNextFile OF((unzFile file));
+/*
+  Set the current file of the zipfile to the next file.
+  return UNZ_OK if there is no problem
+  return UNZ_END_OF_LIST_OF_FILE if the actual file was the latest.
+*/
+
+extern int ZEXPORT unzLocateFile OF((unzFile file,
+                     const char *szFileName,
+                     int iCaseSensitivity));
+/*
+  Try locate the file szFileName in the zipfile.
+  For the iCaseSensitivity signification, see unzStringFileNameCompare
+
+  return value :
+  UNZ_OK if the file is found. It becomes the current file.
+  UNZ_END_OF_LIST_OF_FILE if the file is not found
+*/
+
+
+/* ****************************************** */
+/* Ryan supplied functions */
+/* unz_file_info contain information about a file in the zipfile */
+typedef struct unz_file_pos_s
+{
+    uLong pos_in_zip_directory;   /* offset in zip file directory */
+    uLong num_of_file;            /* # of file */
+} unz_file_pos;
+
+extern int ZEXPORT unzGetFilePos(
+    unzFile file,
+    unz_file_pos* file_pos);
+
+extern int ZEXPORT unzGoToFilePos(
+    unzFile file,
+    unz_file_pos* file_pos);
+
+/* ****************************************** */
+
+extern int ZEXPORT unzGetCurrentFileInfo OF((unzFile file,
+                         unz_file_info *pfile_info,
+                         char *szFileName,
+                         uLong fileNameBufferSize,
+                         void *extraField,
+                         uLong extraFieldBufferSize,
+                         char *szComment,
+                         uLong commentBufferSize));
+/*
+  Get Info about the current file
+  if pfile_info!=NULL, the *pfile_info structure will contain somes info about
+        the current file
+  if szFileName!=NULL, the filemane string will be copied in szFileName
+            (fileNameBufferSize is the size of the buffer)
+  if extraField!=NULL, the extra field information will be copied in extraField
+            (extraFieldBufferSize is the size of the buffer).
+            This is the Central-header version of the extra field
+  if szComment!=NULL, the comment string of the file will be copied in szComment
+            (commentBufferSize is the size of the buffer)
+*/
+
+/***************************************************************************/
+/* for reading the content of the current zipfile, you can open it, read data
+   from it, and close it (you can close it before reading all the file)
+   */
+
+extern int ZEXPORT unzOpenCurrentFile OF((unzFile file));
+/*
+  Open for reading data the current file in the zipfile.
+  If there is no error, the return value is UNZ_OK.
+*/
+
+extern int ZEXPORT unzOpenCurrentFilePassword OF((unzFile file,
+                                                  const char* password));
+/*
+  Open for reading data the current file in the zipfile.
+  password is a crypting password
+  If there is no error, the return value is UNZ_OK.
+*/
+
+extern int ZEXPORT unzOpenCurrentFile2 OF((unzFile file,
+                                           int* method,
+                                           int* level,
+                                           int raw));
+/*
+  Same than unzOpenCurrentFile, but open for read raw the file (not uncompress)
+    if raw==1
+  *method will receive method of compression, *level will receive level of
+     compression
+  note : you can set level parameter as NULL (if you did not want known level,
+         but you CANNOT set method parameter as NULL
+*/
+
+extern int ZEXPORT unzOpenCurrentFile3 OF((unzFile file,
+                                           int* method,
+                                           int* level,
+                                           int raw,
+                                           const char* password));
+/*
+  Same than unzOpenCurrentFile, but open for read raw the file (not uncompress)
+    if raw==1
+  *method will receive method of compression, *level will receive level of
+     compression
+  note : you can set level parameter as NULL (if you did not want known level,
+         but you CANNOT set method parameter as NULL
+*/
+
+
+extern int ZEXPORT unzCloseCurrentFile OF((unzFile file));
+/*
+  Close the file in zip opened with unzOpenCurrentFile
+  Return UNZ_CRCERROR if all the file was read but the CRC is not good
+*/
+
+extern int ZEXPORT unzReadCurrentFile OF((unzFile file,
+                      voidp buf,
+                      unsigned len));
+/*
+  Read bytes from the current file (opened by unzOpenCurrentFile)
+  buf contain buffer where data must be copied
+  len the size of buf.
+
+  return the number of byte copied if somes bytes are copied
+  return 0 if the end of file was reached
+  return <0 with error code if there is an error
+    (UNZ_ERRNO for IO error, or zLib error for uncompress error)
+*/
+
+extern z_off_t ZEXPORT unztell OF((unzFile file));
+/*
+  Give the current position in uncompressed data
+*/
+
+extern int ZEXPORT unzeof OF((unzFile file));
+/*
+  return 1 if the end of file was reached, 0 elsewhere
+*/
+
+extern int ZEXPORT unzGetLocalExtrafield OF((unzFile file,
+                                             voidp buf,
+                                             unsigned len));
+/*
+  Read extra field from the current file (opened by unzOpenCurrentFile)
+  This is the local-header version of the extra field (sometimes, there is
+    more info in the local-header version than in the central-header)
+
+  if buf==NULL, it return the size of the local extra field
+
+  if buf!=NULL, len is the size of the buffer, the extra header is copied in
+    buf.
+  the return value is the number of bytes copied in buf, or (if <0)
+    the error code
+*/
+
+/***************************************************************************/
+
+/* Get the current file offset */
+extern uLong ZEXPORT unzGetOffset (unzFile file);
+
+/* Set the current file offset */
+extern int ZEXPORT unzSetOffset (unzFile file, uLong pos);
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _unz_H */

--- a/deps/libz/zlib.h
+++ b/deps/libz/zlib.h
@@ -1,0 +1,1744 @@
+/* zlib.h -- interface of the 'zlib' general purpose compression library
+  version 1.2.7, May 2nd, 2012
+
+  Copyright (C) 1995-2012 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu
+
+
+  The data format used by the zlib library is described by RFCs (Request for
+  Comments) 1950 to 1952 in the files http://tools.ietf.org/html/rfc1950
+  (zlib format), rfc1951 (deflate format) and rfc1952 (gzip format).
+*/
+
+#ifndef ZLIB_H
+#define ZLIB_H
+
+#include "zconf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ZLIB_VERSION "1.2.7"
+#define ZLIB_VERNUM 0x1270
+#define ZLIB_VER_MAJOR 1
+#define ZLIB_VER_MINOR 2
+#define ZLIB_VER_REVISION 7
+#define ZLIB_VER_SUBREVISION 0
+
+/*
+    The 'zlib' compression library provides in-memory compression and
+  decompression functions, including integrity checks of the uncompressed data.
+  This version of the library supports only one compression method (deflation)
+  but other algorithms will be added later and will have the same stream
+  interface.
+
+    Compression can be done in a single step if the buffers are large enough,
+  or can be done by repeated calls of the compression function.  In the latter
+  case, the application must provide more input and/or consume the output
+  (providing more output space) before each call.
+
+    The compressed data format used by default by the in-memory functions is
+  the zlib format, which is a zlib wrapper documented in RFC 1950, wrapped
+  around a deflate stream, which is itself documented in RFC 1951.
+
+    The library also supports reading and writing files in gzip (.gz) format
+  with an interface similar to that of stdio using the functions that start
+  with "gz".  The gzip format is different from the zlib format.  gzip is a
+  gzip wrapper, documented in RFC 1952, wrapped around a deflate stream.
+
+    This library can optionally read and write gzip streams in memory as well.
+
+    The zlib format was designed to be compact and fast for use in memory
+  and on communications channels.  The gzip format was designed for single-
+  file compression on file systems, has a larger header than zlib to maintain
+  directory information, and uses a different, slower check method than zlib.
+
+    The library does not install any signal handler.  The decoder checks
+  the consistency of the compressed data, so the library should never crash
+  even in case of corrupted input.
+*/
+
+typedef voidpf (*alloc_func) OF((voidpf opaque, uInt items, uInt size));
+typedef void   (*free_func)  OF((voidpf opaque, voidpf address));
+
+struct internal_state;
+
+typedef struct z_stream_s {
+    z_const Bytef *next_in;     /* next input byte */
+    uInt     avail_in;  /* number of bytes available at next_in */
+    uLong    total_in;  /* total number of input bytes read so far */
+
+    Bytef    *next_out; /* next output byte should be put there */
+    uInt     avail_out; /* remaining free space at next_out */
+    uLong    total_out; /* total number of bytes output so far */
+
+    z_const char *msg;  /* last error message, NULL if no error */
+    struct internal_state FAR *state; /* not visible by applications */
+
+    alloc_func zalloc;  /* used to allocate the internal state */
+    free_func  zfree;   /* used to free the internal state */
+    voidpf     opaque;  /* private data object passed to zalloc and zfree */
+
+    int     data_type;  /* best guess about the data type: binary or text */
+    uLong   adler;      /* adler32 value of the uncompressed data */
+    uLong   reserved;   /* reserved for future use */
+} z_stream;
+
+typedef z_stream FAR *z_streamp;
+
+/*
+     gzip header information passed to and from zlib routines.  See RFC 1952
+  for more details on the meanings of these fields.
+*/
+typedef struct gz_header_s {
+    int     text;       /* true if compressed data believed to be text */
+    uLong   time;       /* modification time */
+    int     xflags;     /* extra flags (not used when writing a gzip file) */
+    int     os;         /* operating system */
+    Bytef   *extra;     /* pointer to extra field or Z_NULL if none */
+    uInt    extra_len;  /* extra field length (valid if extra != Z_NULL) */
+    uInt    extra_max;  /* space at extra (only when reading header) */
+    Bytef   *name;      /* pointer to zero-terminated file name or Z_NULL */
+    uInt    name_max;   /* space at name (only when reading header) */
+    Bytef   *comment;   /* pointer to zero-terminated comment or Z_NULL */
+    uInt    comm_max;   /* space at comment (only when reading header) */
+    int     hcrc;       /* true if there was or will be a header crc */
+    int     done;       /* true when done reading gzip header (not used
+                           when writing a gzip file) */
+} gz_header;
+
+typedef gz_header FAR *gz_headerp;
+
+/*
+     The application must update next_in and avail_in when avail_in has dropped
+   to zero.  It must update next_out and avail_out when avail_out has dropped
+   to zero.  The application must initialize zalloc, zfree and opaque before
+   calling the init function.  All other fields are set by the compression
+   library and must not be updated by the application.
+
+     The opaque value provided by the application will be passed as the first
+   parameter for calls of zalloc and zfree.  This can be useful for custom
+   memory management.  The compression library attaches no meaning to the
+   opaque value.
+
+     zalloc must return Z_NULL if there is not enough memory for the object.
+   If zlib is used in a multi-threaded application, zalloc and zfree must be
+   thread safe.
+
+     On 16-bit systems, the functions zalloc and zfree must be able to allocate
+   exactly 65536 bytes, but will not be required to allocate more than this if
+   the symbol MAXSEG_64K is defined (see zconf.h).  WARNING: On MSDOS, pointers
+   returned by zalloc for objects of exactly 65536 bytes *must* have their
+   offset normalized to zero.  The default allocation function provided by this
+   library ensures this (see zutil.c).  To reduce memory requirements and avoid
+   any allocation of 64K objects, at the expense of compression ratio, compile
+   the library with -DMAX_WBITS=14 (see zconf.h).
+
+     The fields total_in and total_out can be used for statistics or progress
+   reports.  After compression, total_in holds the total size of the
+   uncompressed data and may be saved for use in the decompressor (particularly
+   if the decompressor wants to decompress everything in a single step).
+*/
+
+                        /* constants */
+
+#define Z_NO_FLUSH      0
+#define Z_PARTIAL_FLUSH 1
+#define Z_SYNC_FLUSH    2
+#define Z_FULL_FLUSH    3
+#define Z_FINISH        4
+#define Z_BLOCK         5
+#define Z_TREES         6
+/* Allowed flush values; see deflate() and inflate() below for details */
+
+#define Z_OK            0
+#define Z_STREAM_END    1
+#define Z_NEED_DICT     2
+#define Z_ERRNO        (-1)
+#define Z_STREAM_ERROR (-2)
+#define Z_DATA_ERROR   (-3)
+#define Z_MEM_ERROR    (-4)
+#define Z_BUF_ERROR    (-5)
+#define Z_VERSION_ERROR (-6)
+/* Return codes for the compression/decompression functions. Negative values
+ * are errors, positive values are used for special but normal events.
+ */
+
+#define Z_NO_COMPRESSION         0
+#define Z_BEST_SPEED             1
+#define Z_BEST_COMPRESSION       9
+#define Z_DEFAULT_COMPRESSION  (-1)
+/* compression levels */
+
+#define Z_FILTERED            1
+#define Z_HUFFMAN_ONLY        2
+#define Z_RLE                 3
+#define Z_FIXED               4
+#define Z_DEFAULT_STRATEGY    0
+/* compression strategy; see deflateInit2() below for details */
+
+#define Z_BINARY   0
+#define Z_TEXT     1
+#define Z_ASCII    Z_TEXT   /* for compatibility with 1.2.2 and earlier */
+#define Z_UNKNOWN  2
+/* Possible values of the data_type field (though see inflate()) */
+
+#define Z_DEFLATED   8
+/* The deflate compression method (the only one supported in this version) */
+
+#define Z_NULL  0  /* for initializing zalloc, zfree, opaque */
+
+#define zlib_version zlibVersion()
+/* for compatibility with versions < 1.0.2 */
+
+
+                        /* basic functions */
+
+ZEXTERN const char * ZEXPORT zlibVersion OF((void));
+/* The application can compare zlibVersion and ZLIB_VERSION for consistency.
+   If the first character differs, the library code actually used is not
+   compatible with the zlib.h header file used by the application.  This check
+   is automatically made by deflateInit and inflateInit.
+ */
+
+/*
+ZEXTERN int ZEXPORT deflateInit OF((z_streamp strm, int level));
+
+     Initializes the internal stream state for compression.  The fields
+   zalloc, zfree and opaque must be initialized before by the caller.  If
+   zalloc and zfree are set to Z_NULL, deflateInit updates them to use default
+   allocation functions.
+
+     The compression level must be Z_DEFAULT_COMPRESSION, or between 0 and 9:
+   1 gives best speed, 9 gives best compression, 0 gives no compression at all
+   (the input data is simply copied a block at a time).  Z_DEFAULT_COMPRESSION
+   requests a default compromise between speed and compression (currently
+   equivalent to level 6).
+
+     deflateInit returns Z_OK if success, Z_MEM_ERROR if there was not enough
+   memory, Z_STREAM_ERROR if level is not a valid compression level, or
+   Z_VERSION_ERROR if the zlib library version (zlib_version) is incompatible
+   with the version assumed by the caller (ZLIB_VERSION).  msg is set to null
+   if there is no error message.  deflateInit does not perform any compression:
+   this will be done by deflate().
+*/
+
+
+ZEXTERN int ZEXPORT deflate OF((z_streamp strm, int flush));
+/*
+    deflate compresses as much data as possible, and stops when the input
+  buffer becomes empty or the output buffer becomes full.  It may introduce
+  some output latency (reading input without producing any output) except when
+  forced to flush.
+
+    The detailed semantics are as follows.  deflate performs one or both of the
+  following actions:
+
+  - Compress more input starting at next_in and update next_in and avail_in
+    accordingly.  If not all input can be processed (because there is not
+    enough room in the output buffer), next_in and avail_in are updated and
+    processing will resume at this point for the next call of deflate().
+
+  - Provide more output starting at next_out and update next_out and avail_out
+    accordingly.  This action is forced if the parameter flush is non zero.
+    Forcing flush frequently degrades the compression ratio, so this parameter
+    should be set only when necessary (in interactive applications).  Some
+    output may be provided even if flush is not set.
+
+    Before the call of deflate(), the application should ensure that at least
+  one of the actions is possible, by providing more input and/or consuming more
+  output, and updating avail_in or avail_out accordingly; avail_out should
+  never be zero before the call.  The application can consume the compressed
+  output when it wants, for example when the output buffer is full (avail_out
+  == 0), or after each call of deflate().  If deflate returns Z_OK and with
+  zero avail_out, it must be called again after making room in the output
+  buffer because there might be more output pending.
+
+    Normally the parameter flush is set to Z_NO_FLUSH, which allows deflate to
+  decide how much data to accumulate before producing output, in order to
+  maximize compression.
+
+    If the parameter flush is set to Z_SYNC_FLUSH, all pending output is
+  flushed to the output buffer and the output is aligned on a byte boundary, so
+  that the decompressor can get all input data available so far.  (In
+  particular avail_in is zero after the call if enough output space has been
+  provided before the call.) Flushing may degrade compression for some
+  compression algorithms and so it should be used only when necessary.  This
+  completes the current deflate block and follows it with an empty stored block
+  that is three bits plus filler bits to the next byte, followed by four bytes
+  (00 00 ff ff).
+
+    If flush is set to Z_PARTIAL_FLUSH, all pending output is flushed to the
+  output buffer, but the output is not aligned to a byte boundary.  All of the
+  input data so far will be available to the decompressor, as for Z_SYNC_FLUSH.
+  This completes the current deflate block and follows it with an empty fixed
+  codes block that is 10 bits long.  This assures that enough bytes are output
+  in order for the decompressor to finish the block before the empty fixed code
+  block.
+
+    If flush is set to Z_BLOCK, a deflate block is completed and emitted, as
+  for Z_SYNC_FLUSH, but the output is not aligned on a byte boundary, and up to
+  seven bits of the current block are held to be written as the next byte after
+  the next deflate block is completed.  In this case, the decompressor may not
+  be provided enough bits at this point in order to complete decompression of
+  the data provided so far to the compressor.  It may need to wait for the next
+  block to be emitted.  This is for advanced applications that need to control
+  the emission of deflate blocks.
+
+    If flush is set to Z_FULL_FLUSH, all output is flushed as with
+  Z_SYNC_FLUSH, and the compression state is reset so that decompression can
+  restart from this point if previous compressed data has been damaged or if
+  random access is desired.  Using Z_FULL_FLUSH too often can seriously degrade
+  compression.
+
+    If deflate returns with avail_out == 0, this function must be called again
+  with the same value of the flush parameter and more output space (updated
+  avail_out), until the flush is complete (deflate returns with non-zero
+  avail_out).  In the case of a Z_FULL_FLUSH or Z_SYNC_FLUSH, make sure that
+  avail_out is greater than six to avoid repeated flush markers due to
+  avail_out == 0 on return.
+
+    If the parameter flush is set to Z_FINISH, pending input is processed,
+  pending output is flushed and deflate returns with Z_STREAM_END if there was
+  enough output space; if deflate returns with Z_OK, this function must be
+  called again with Z_FINISH and more output space (updated avail_out) but no
+  more input data, until it returns with Z_STREAM_END or an error.  After
+  deflate has returned Z_STREAM_END, the only possible operations on the stream
+  are deflateReset or deflateEnd.
+
+    Z_FINISH can be used immediately after deflateInit if all the compression
+  is to be done in a single step.  In this case, avail_out must be at least the
+  value returned by deflateBound (see below).  Then deflate is guaranteed to
+  return Z_STREAM_END.  If not enough output space is provided, deflate will
+  not return Z_STREAM_END, and it must be called again as described above.
+
+    deflate() sets strm->adler to the adler32 checksum of all input read
+  so far (that is, total_in bytes).
+
+    deflate() may update strm->data_type if it can make a good guess about
+  the input data type (Z_BINARY or Z_TEXT).  In doubt, the data is considered
+  binary.  This field is only for information purposes and does not affect the
+  compression algorithm in any manner.
+
+    deflate() returns Z_OK if some progress has been made (more input
+  processed or more output produced), Z_STREAM_END if all input has been
+  consumed and all output has been produced (only when flush is set to
+  Z_FINISH), Z_STREAM_ERROR if the stream state was inconsistent (for example
+  if next_in or next_out was Z_NULL), Z_BUF_ERROR if no progress is possible
+  (for example avail_in or avail_out was zero).  Note that Z_BUF_ERROR is not
+  fatal, and deflate() can be called again with more input and more output
+  space to continue compressing.
+*/
+
+
+ZEXTERN int ZEXPORT deflateEnd OF((z_streamp strm));
+/*
+     All dynamically allocated data structures for this stream are freed.
+   This function discards any unprocessed input and does not flush any pending
+   output.
+
+     deflateEnd returns Z_OK if success, Z_STREAM_ERROR if the
+   stream state was inconsistent, Z_DATA_ERROR if the stream was freed
+   prematurely (some input or output was discarded).  In the error case, msg
+   may be set but then points to a static string (which must not be
+   deallocated).
+*/
+
+
+/*
+ZEXTERN int ZEXPORT inflateInit OF((z_streamp strm));
+
+     Initializes the internal stream state for decompression.  The fields
+   next_in, avail_in, zalloc, zfree and opaque must be initialized before by
+   the caller.  If next_in is not Z_NULL and avail_in is large enough (the
+   exact value depends on the compression method), inflateInit determines the
+   compression method from the zlib header and allocates all data structures
+   accordingly; otherwise the allocation will be deferred to the first call of
+   inflate.  If zalloc and zfree are set to Z_NULL, inflateInit updates them to
+   use default allocation functions.
+
+     inflateInit returns Z_OK if success, Z_MEM_ERROR if there was not enough
+   memory, Z_VERSION_ERROR if the zlib library version is incompatible with the
+   version assumed by the caller, or Z_STREAM_ERROR if the parameters are
+   invalid, such as a null pointer to the structure.  msg is set to null if
+   there is no error message.  inflateInit does not perform any decompression
+   apart from possibly reading the zlib header if present: actual decompression
+   will be done by inflate().  (So next_in and avail_in may be modified, but
+   next_out and avail_out are unused and unchanged.) The current implementation
+   of inflateInit() does not process any header information -- that is deferred
+   until inflate() is called.
+*/
+
+
+ZEXTERN int ZEXPORT inflate OF((z_streamp strm, int flush));
+/*
+    inflate decompresses as much data as possible, and stops when the input
+  buffer becomes empty or the output buffer becomes full.  It may introduce
+  some output latency (reading input without producing any output) except when
+  forced to flush.
+
+  The detailed semantics are as follows.  inflate performs one or both of the
+  following actions:
+
+  - Decompress more input starting at next_in and update next_in and avail_in
+    accordingly.  If not all input can be processed (because there is not
+    enough room in the output buffer), next_in is updated and processing will
+    resume at this point for the next call of inflate().
+
+  - Provide more output starting at next_out and update next_out and avail_out
+    accordingly.  inflate() provides as much output as possible, until there is
+    no more input data or no more space in the output buffer (see below about
+    the flush parameter).
+
+    Before the call of inflate(), the application should ensure that at least
+  one of the actions is possible, by providing more input and/or consuming more
+  output, and updating the next_* and avail_* values accordingly.  The
+  application can consume the uncompressed output when it wants, for example
+  when the output buffer is full (avail_out == 0), or after each call of
+  inflate().  If inflate returns Z_OK and with zero avail_out, it must be
+  called again after making room in the output buffer because there might be
+  more output pending.
+
+    The flush parameter of inflate() can be Z_NO_FLUSH, Z_SYNC_FLUSH, Z_FINISH,
+  Z_BLOCK, or Z_TREES.  Z_SYNC_FLUSH requests that inflate() flush as much
+  output as possible to the output buffer.  Z_BLOCK requests that inflate()
+  stop if and when it gets to the next deflate block boundary.  When decoding
+  the zlib or gzip format, this will cause inflate() to return immediately
+  after the header and before the first block.  When doing a raw inflate,
+  inflate() will go ahead and process the first block, and will return when it
+  gets to the end of that block, or when it runs out of data.
+
+    The Z_BLOCK option assists in appending to or combining deflate streams.
+  Also to assist in this, on return inflate() will set strm->data_type to the
+  number of unused bits in the last byte taken from strm->next_in, plus 64 if
+  inflate() is currently decoding the last block in the deflate stream, plus
+  128 if inflate() returned immediately after decoding an end-of-block code or
+  decoding the complete header up to just before the first byte of the deflate
+  stream.  The end-of-block will not be indicated until all of the uncompressed
+  data from that block has been written to strm->next_out.  The number of
+  unused bits may in general be greater than seven, except when bit 7 of
+  data_type is set, in which case the number of unused bits will be less than
+  eight.  data_type is set as noted here every time inflate() returns for all
+  flush options, and so can be used to determine the amount of currently
+  consumed input in bits.
+
+    The Z_TREES option behaves as Z_BLOCK does, but it also returns when the
+  end of each deflate block header is reached, before any actual data in that
+  block is decoded.  This allows the caller to determine the length of the
+  deflate block header for later use in random access within a deflate block.
+  256 is added to the value of strm->data_type when inflate() returns
+  immediately after reaching the end of the deflate block header.
+
+    inflate() should normally be called until it returns Z_STREAM_END or an
+  error.  However if all decompression is to be performed in a single step (a
+  single call of inflate), the parameter flush should be set to Z_FINISH.  In
+  this case all pending input is processed and all pending output is flushed;
+  avail_out must be large enough to hold all of the uncompressed data for the
+  operation to complete.  (The size of the uncompressed data may have been
+  saved by the compressor for this purpose.) The use of Z_FINISH is not
+  required to perform an inflation in one step.  However it may be used to
+  inform inflate that a faster approach can be used for the single inflate()
+  call.  Z_FINISH also informs inflate to not maintain a sliding window if the
+  stream completes, which reduces inflate's memory footprint.  If the stream
+  does not complete, either because not all of the stream is provided or not
+  enough output space is provided, then a sliding window will be allocated and
+  inflate() can be called again to continue the operation as if Z_NO_FLUSH had
+  been used.
+
+     In this implementation, inflate() always flushes as much output as
+  possible to the output buffer, and always uses the faster approach on the
+  first call.  So the effects of the flush parameter in this implementation are
+  on the return value of inflate() as noted below, when inflate() returns early
+  when Z_BLOCK or Z_TREES is used, and when inflate() avoids the allocation of
+  memory for a sliding window when Z_FINISH is used.
+
+     If a preset dictionary is needed after this call (see inflateSetDictionary
+  below), inflate sets strm->adler to the Adler-32 checksum of the dictionary
+  chosen by the compressor and returns Z_NEED_DICT; otherwise it sets
+  strm->adler to the Adler-32 checksum of all output produced so far (that is,
+  total_out bytes) and returns Z_OK, Z_STREAM_END or an error code as described
+  below.  At the end of the stream, inflate() checks that its computed adler32
+  checksum is equal to that saved by the compressor and returns Z_STREAM_END
+  only if the checksum is correct.
+
+    inflate() can decompress and check either zlib-wrapped or gzip-wrapped
+  deflate data.  The header type is detected automatically, if requested when
+  initializing with inflateInit2().  Any information contained in the gzip
+  header is not retained, so applications that need that information should
+  instead use raw inflate, see inflateInit2() below, or inflateBack() and
+  perform their own processing of the gzip header and trailer.  When processing
+  gzip-wrapped deflate data, strm->adler32 is set to the CRC-32 of the output
+  producted so far.  The CRC-32 is checked against the gzip trailer.
+
+    inflate() returns Z_OK if some progress has been made (more input processed
+  or more output produced), Z_STREAM_END if the end of the compressed data has
+  been reached and all uncompressed output has been produced, Z_NEED_DICT if a
+  preset dictionary is needed at this point, Z_DATA_ERROR if the input data was
+  corrupted (input stream not conforming to the zlib format or incorrect check
+  value), Z_STREAM_ERROR if the stream structure was inconsistent (for example
+  next_in or next_out was Z_NULL), Z_MEM_ERROR if there was not enough memory,
+  Z_BUF_ERROR if no progress is possible or if there was not enough room in the
+  output buffer when Z_FINISH is used.  Note that Z_BUF_ERROR is not fatal, and
+  inflate() can be called again with more input and more output space to
+  continue decompressing.  If Z_DATA_ERROR is returned, the application may
+  then call inflateSync() to look for a good compression block if a partial
+  recovery of the data is desired.
+*/
+
+
+ZEXTERN int ZEXPORT inflateEnd OF((z_streamp strm));
+/*
+     All dynamically allocated data structures for this stream are freed.
+   This function discards any unprocessed input and does not flush any pending
+   output.
+
+     inflateEnd returns Z_OK if success, Z_STREAM_ERROR if the stream state
+   was inconsistent.  In the error case, msg may be set but then points to a
+   static string (which must not be deallocated).
+*/
+
+
+                        /* Advanced functions */
+
+/*
+    The following functions are needed only in some special applications.
+*/
+
+/*
+ZEXTERN int ZEXPORT deflateInit2 OF((z_streamp strm,
+                                     int  level,
+                                     int  method,
+                                     int  windowBits,
+                                     int  memLevel,
+                                     int  strategy));
+
+     This is another version of deflateInit with more compression options.  The
+   fields next_in, zalloc, zfree and opaque must be initialized before by the
+   caller.
+
+     The method parameter is the compression method.  It must be Z_DEFLATED in
+   this version of the library.
+
+     The windowBits parameter is the base two logarithm of the window size
+   (the size of the history buffer).  It should be in the range 8..15 for this
+   version of the library.  Larger values of this parameter result in better
+   compression at the expense of memory usage.  The default value is 15 if
+   deflateInit is used instead.
+
+     windowBits can also be -8..-15 for raw deflate.  In this case, -windowBits
+   determines the window size.  deflate() will then generate raw deflate data
+   with no zlib header or trailer, and will not compute an adler32 check value.
+
+     windowBits can also be greater than 15 for optional gzip encoding.  Add
+   16 to windowBits to write a simple gzip header and trailer around the
+   compressed data instead of a zlib wrapper.  The gzip header will have no
+   file name, no extra data, no comment, no modification time (set to zero), no
+   header crc, and the operating system will be set to 255 (unknown).  If a
+   gzip stream is being written, strm->adler is a crc32 instead of an adler32.
+
+     The memLevel parameter specifies how much memory should be allocated
+   for the internal compression state.  memLevel=1 uses minimum memory but is
+   slow and reduces compression ratio; memLevel=9 uses maximum memory for
+   optimal speed.  The default value is 8.  See zconf.h for total memory usage
+   as a function of windowBits and memLevel.
+
+     The strategy parameter is used to tune the compression algorithm.  Use the
+   value Z_DEFAULT_STRATEGY for normal data, Z_FILTERED for data produced by a
+   filter (or predictor), Z_HUFFMAN_ONLY to force Huffman encoding only (no
+   string match), or Z_RLE to limit match distances to one (run-length
+   encoding).  Filtered data consists mostly of small values with a somewhat
+   random distribution.  In this case, the compression algorithm is tuned to
+   compress them better.  The effect of Z_FILTERED is to force more Huffman
+   coding and less string matching; it is somewhat intermediate between
+   Z_DEFAULT_STRATEGY and Z_HUFFMAN_ONLY.  Z_RLE is designed to be almost as
+   fast as Z_HUFFMAN_ONLY, but give better compression for PNG image data.  The
+   strategy parameter only affects the compression ratio but not the
+   correctness of the compressed output even if it is not set appropriately.
+   Z_FIXED prevents the use of dynamic Huffman codes, allowing for a simpler
+   decoder for special applications.
+
+     deflateInit2 returns Z_OK if success, Z_MEM_ERROR if there was not enough
+   memory, Z_STREAM_ERROR if any parameter is invalid (such as an invalid
+   method), or Z_VERSION_ERROR if the zlib library version (zlib_version) is
+   incompatible with the version assumed by the caller (ZLIB_VERSION).  msg is
+   set to null if there is no error message.  deflateInit2 does not perform any
+   compression: this will be done by deflate().
+*/
+
+ZEXTERN int ZEXPORT deflateSetDictionary OF((z_streamp strm,
+                                             const Bytef *dictionary,
+                                             uInt  dictLength));
+/*
+     Initializes the compression dictionary from the given byte sequence
+   without producing any compressed output.  When using the zlib format, this
+   function must be called immediately after deflateInit, deflateInit2 or
+   deflateReset, and before any call of deflate.  When doing raw deflate, this
+   function must be called either before any call of deflate, or immediately
+   after the completion of a deflate block, i.e. after all input has been
+   consumed and all output has been delivered when using any of the flush
+   options Z_BLOCK, Z_PARTIAL_FLUSH, Z_SYNC_FLUSH, or Z_FULL_FLUSH.  The
+   compressor and decompressor must use exactly the same dictionary (see
+   inflateSetDictionary).
+
+     The dictionary should consist of strings (byte sequences) that are likely
+   to be encountered later in the data to be compressed, with the most commonly
+   used strings preferably put towards the end of the dictionary.  Using a
+   dictionary is most useful when the data to be compressed is short and can be
+   predicted with good accuracy; the data can then be compressed better than
+   with the default empty dictionary.
+
+     Depending on the size of the compression data structures selected by
+   deflateInit or deflateInit2, a part of the dictionary may in effect be
+   discarded, for example if the dictionary is larger than the window size
+   provided in deflateInit or deflateInit2.  Thus the strings most likely to be
+   useful should be put at the end of the dictionary, not at the front.  In
+   addition, the current implementation of deflate will use at most the window
+   size minus 262 bytes of the provided dictionary.
+
+     Upon return of this function, strm->adler is set to the adler32 value
+   of the dictionary; the decompressor may later use this value to determine
+   which dictionary has been used by the compressor.  (The adler32 value
+   applies to the whole dictionary even if only a subset of the dictionary is
+   actually used by the compressor.) If a raw deflate was requested, then the
+   adler32 value is not computed and strm->adler is not set.
+
+     deflateSetDictionary returns Z_OK if success, or Z_STREAM_ERROR if a
+   parameter is invalid (e.g.  dictionary being Z_NULL) or the stream state is
+   inconsistent (for example if deflate has already been called for this stream
+   or if not at a block boundary for raw deflate).  deflateSetDictionary does
+   not perform any compression: this will be done by deflate().
+*/
+
+ZEXTERN int ZEXPORT deflateCopy OF((z_streamp dest,
+                                    z_streamp source));
+/*
+     Sets the destination stream as a complete copy of the source stream.
+
+     This function can be useful when several compression strategies will be
+   tried, for example when there are several ways of pre-processing the input
+   data with a filter.  The streams that will be discarded should then be freed
+   by calling deflateEnd.  Note that deflateCopy duplicates the internal
+   compression state which can be quite large, so this strategy is slow and can
+   consume lots of memory.
+
+     deflateCopy returns Z_OK if success, Z_MEM_ERROR if there was not
+   enough memory, Z_STREAM_ERROR if the source stream state was inconsistent
+   (such as zalloc being Z_NULL).  msg is left unchanged in both source and
+   destination.
+*/
+
+ZEXTERN int ZEXPORT deflateReset OF((z_streamp strm));
+/*
+     This function is equivalent to deflateEnd followed by deflateInit,
+   but does not free and reallocate all the internal compression state.  The
+   stream will keep the same compression level and any other attributes that
+   may have been set by deflateInit2.
+
+     deflateReset returns Z_OK if success, or Z_STREAM_ERROR if the source
+   stream state was inconsistent (such as zalloc or state being Z_NULL).
+*/
+
+ZEXTERN int ZEXPORT deflateParams OF((z_streamp strm,
+                                      int level,
+                                      int strategy));
+/*
+     Dynamically update the compression level and compression strategy.  The
+   interpretation of level and strategy is as in deflateInit2.  This can be
+   used to switch between compression and straight copy of the input data, or
+   to switch to a different kind of input data requiring a different strategy.
+   If the compression level is changed, the input available so far is
+   compressed with the old level (and may be flushed); the new level will take
+   effect only at the next call of deflate().
+
+     Before the call of deflateParams, the stream state must be set as for
+   a call of deflate(), since the currently available input may have to be
+   compressed and flushed.  In particular, strm->avail_out must be non-zero.
+
+     deflateParams returns Z_OK if success, Z_STREAM_ERROR if the source
+   stream state was inconsistent or if a parameter was invalid, Z_BUF_ERROR if
+   strm->avail_out was zero.
+*/
+
+ZEXTERN int ZEXPORT deflateTune OF((z_streamp strm,
+                                    int good_length,
+                                    int max_lazy,
+                                    int nice_length,
+                                    int max_chain));
+/*
+     Fine tune deflate's internal compression parameters.  This should only be
+   used by someone who understands the algorithm used by zlib's deflate for
+   searching for the best matching string, and even then only by the most
+   fanatic optimizer trying to squeeze out the last compressed bit for their
+   specific input data.  Read the deflate.c source code for the meaning of the
+   max_lazy, good_length, nice_length, and max_chain parameters.
+
+     deflateTune() can be called after deflateInit() or deflateInit2(), and
+   returns Z_OK on success, or Z_STREAM_ERROR for an invalid deflate stream.
+ */
+
+ZEXTERN uLong ZEXPORT deflateBound OF((z_streamp strm,
+                                       uLong sourceLen));
+/*
+     deflateBound() returns an upper bound on the compressed size after
+   deflation of sourceLen bytes.  It must be called after deflateInit() or
+   deflateInit2(), and after deflateSetHeader(), if used.  This would be used
+   to allocate an output buffer for deflation in a single pass, and so would be
+   called before deflate().  If that first deflate() call is provided the
+   sourceLen input bytes, an output buffer allocated to the size returned by
+   deflateBound(), and the flush value Z_FINISH, then deflate() is guaranteed
+   to return Z_STREAM_END.  Note that it is possible for the compressed size to
+   be larger than the value returned by deflateBound() if flush options other
+   than Z_FINISH or Z_NO_FLUSH are used.
+*/
+
+ZEXTERN int ZEXPORT deflatePending OF((z_streamp strm,
+                                       unsigned *pending,
+                                       int *bits));
+/*
+     deflatePending() returns the number of bytes and bits of output that have
+   been generated, but not yet provided in the available output.  The bytes not
+   provided would be due to the available output space having being consumed.
+   The number of bits of output not provided are between 0 and 7, where they
+   await more bits to join them in order to fill out a full byte.  If pending
+   or bits are Z_NULL, then those values are not set.
+
+     deflatePending returns Z_OK if success, or Z_STREAM_ERROR if the source
+   stream state was inconsistent.
+ */
+
+ZEXTERN int ZEXPORT deflatePrime OF((z_streamp strm,
+                                     int bits,
+                                     int value));
+/*
+     deflatePrime() inserts bits in the deflate output stream.  The intent
+   is that this function is used to start off the deflate output with the bits
+   leftover from a previous deflate stream when appending to it.  As such, this
+   function can only be used for raw deflate, and must be used before the first
+   deflate() call after a deflateInit2() or deflateReset().  bits must be less
+   than or equal to 16, and that many of the least significant bits of value
+   will be inserted in the output.
+
+     deflatePrime returns Z_OK if success, Z_BUF_ERROR if there was not enough
+   room in the internal buffer to insert the bits, or Z_STREAM_ERROR if the
+   source stream state was inconsistent.
+*/
+
+ZEXTERN int ZEXPORT deflateSetHeader OF((z_streamp strm,
+                                         gz_headerp head));
+/*
+     deflateSetHeader() provides gzip header information for when a gzip
+   stream is requested by deflateInit2().  deflateSetHeader() may be called
+   after deflateInit2() or deflateReset() and before the first call of
+   deflate().  The text, time, os, extra field, name, and comment information
+   in the provided gz_header structure are written to the gzip header (xflag is
+   ignored -- the extra flags are set according to the compression level).  The
+   caller must assure that, if not Z_NULL, name and comment are terminated with
+   a zero byte, and that if extra is not Z_NULL, that extra_len bytes are
+   available there.  If hcrc is true, a gzip header crc is included.  Note that
+   the current versions of the command-line version of gzip (up through version
+   1.3.x) do not support header crc's, and will report that it is a "multi-part
+   gzip file" and give up.
+
+     If deflateSetHeader is not used, the default gzip header has text false,
+   the time set to zero, and os set to 255, with no extra, name, or comment
+   fields.  The gzip header is returned to the default state by deflateReset().
+
+     deflateSetHeader returns Z_OK if success, or Z_STREAM_ERROR if the source
+   stream state was inconsistent.
+*/
+
+/*
+ZEXTERN int ZEXPORT inflateInit2 OF((z_streamp strm,
+                                     int  windowBits));
+
+     This is another version of inflateInit with an extra parameter.  The
+   fields next_in, avail_in, zalloc, zfree and opaque must be initialized
+   before by the caller.
+
+     The windowBits parameter is the base two logarithm of the maximum window
+   size (the size of the history buffer).  It should be in the range 8..15 for
+   this version of the library.  The default value is 15 if inflateInit is used
+   instead.  windowBits must be greater than or equal to the windowBits value
+   provided to deflateInit2() while compressing, or it must be equal to 15 if
+   deflateInit2() was not used.  If a compressed stream with a larger window
+   size is given as input, inflate() will return with the error code
+   Z_DATA_ERROR instead of trying to allocate a larger window.
+
+     windowBits can also be zero to request that inflate use the window size in
+   the zlib header of the compressed stream.
+
+     windowBits can also be -8..-15 for raw inflate.  In this case, -windowBits
+   determines the window size.  inflate() will then process raw deflate data,
+   not looking for a zlib or gzip header, not generating a check value, and not
+   looking for any check values for comparison at the end of the stream.  This
+   is for use with other formats that use the deflate compressed data format
+   such as zip.  Those formats provide their own check values.  If a custom
+   format is developed using the raw deflate format for compressed data, it is
+   recommended that a check value such as an adler32 or a crc32 be applied to
+   the uncompressed data as is done in the zlib, gzip, and zip formats.  For
+   most applications, the zlib format should be used as is.  Note that comments
+   above on the use in deflateInit2() applies to the magnitude of windowBits.
+
+     windowBits can also be greater than 15 for optional gzip decoding.  Add
+   32 to windowBits to enable zlib and gzip decoding with automatic header
+   detection, or add 16 to decode only the gzip format (the zlib format will
+   return a Z_DATA_ERROR).  If a gzip stream is being decoded, strm->adler is a
+   crc32 instead of an adler32.
+
+     inflateInit2 returns Z_OK if success, Z_MEM_ERROR if there was not enough
+   memory, Z_VERSION_ERROR if the zlib library version is incompatible with the
+   version assumed by the caller, or Z_STREAM_ERROR if the parameters are
+   invalid, such as a null pointer to the structure.  msg is set to null if
+   there is no error message.  inflateInit2 does not perform any decompression
+   apart from possibly reading the zlib header if present: actual decompression
+   will be done by inflate().  (So next_in and avail_in may be modified, but
+   next_out and avail_out are unused and unchanged.) The current implementation
+   of inflateInit2() does not process any header information -- that is
+   deferred until inflate() is called.
+*/
+
+ZEXTERN int ZEXPORT inflateSetDictionary OF((z_streamp strm,
+                                             const Bytef *dictionary,
+                                             uInt  dictLength));
+/*
+     Initializes the decompression dictionary from the given uncompressed byte
+   sequence.  This function must be called immediately after a call of inflate,
+   if that call returned Z_NEED_DICT.  The dictionary chosen by the compressor
+   can be determined from the adler32 value returned by that call of inflate.
+   The compressor and decompressor must use exactly the same dictionary (see
+   deflateSetDictionary).  For raw inflate, this function can be called at any
+   time to set the dictionary.  If the provided dictionary is smaller than the
+   window and there is already data in the window, then the provided dictionary
+   will amend what's there.  The application must insure that the dictionary
+   that was used for compression is provided.
+
+     inflateSetDictionary returns Z_OK if success, Z_STREAM_ERROR if a
+   parameter is invalid (e.g.  dictionary being Z_NULL) or the stream state is
+   inconsistent, Z_DATA_ERROR if the given dictionary doesn't match the
+   expected one (incorrect adler32 value).  inflateSetDictionary does not
+   perform any decompression: this will be done by subsequent calls of
+   inflate().
+*/
+
+ZEXTERN int ZEXPORT inflateSync OF((z_streamp strm));
+/*
+     Skips invalid compressed data until a possible full flush point (see above
+   for the description of deflate with Z_FULL_FLUSH) can be found, or until all
+   available input is skipped.  No output is provided.
+
+     inflateSync searches for a 00 00 FF FF pattern in the compressed data.
+   All full flush points have this pattern, but not all occurences of this
+   pattern are full flush points.
+
+     inflateSync returns Z_OK if a possible full flush point has been found,
+   Z_BUF_ERROR if no more input was provided, Z_DATA_ERROR if no flush point
+   has been found, or Z_STREAM_ERROR if the stream structure was inconsistent.
+   In the success case, the application may save the current current value of
+   total_in which indicates where valid compressed data was found.  In the
+   error case, the application may repeatedly call inflateSync, providing more
+   input each time, until success or end of the input data.
+*/
+
+ZEXTERN int ZEXPORT inflateCopy OF((z_streamp dest,
+                                    z_streamp source));
+/*
+     Sets the destination stream as a complete copy of the source stream.
+
+     This function can be useful when randomly accessing a large stream.  The
+   first pass through the stream can periodically record the inflate state,
+   allowing restarting inflate at those points when randomly accessing the
+   stream.
+
+     inflateCopy returns Z_OK if success, Z_MEM_ERROR if there was not
+   enough memory, Z_STREAM_ERROR if the source stream state was inconsistent
+   (such as zalloc being Z_NULL).  msg is left unchanged in both source and
+   destination.
+*/
+
+ZEXTERN int ZEXPORT inflateReset OF((z_streamp strm));
+/*
+     This function is equivalent to inflateEnd followed by inflateInit,
+   but does not free and reallocate all the internal decompression state.  The
+   stream will keep attributes that may have been set by inflateInit2.
+
+     inflateReset returns Z_OK if success, or Z_STREAM_ERROR if the source
+   stream state was inconsistent (such as zalloc or state being Z_NULL).
+*/
+
+ZEXTERN int ZEXPORT inflateReset2 OF((z_streamp strm,
+                                      int windowBits));
+/*
+     This function is the same as inflateReset, but it also permits changing
+   the wrap and window size requests.  The windowBits parameter is interpreted
+   the same as it is for inflateInit2.
+
+     inflateReset2 returns Z_OK if success, or Z_STREAM_ERROR if the source
+   stream state was inconsistent (such as zalloc or state being Z_NULL), or if
+   the windowBits parameter is invalid.
+*/
+
+ZEXTERN int ZEXPORT inflatePrime OF((z_streamp strm,
+                                     int bits,
+                                     int value));
+/*
+     This function inserts bits in the inflate input stream.  The intent is
+   that this function is used to start inflating at a bit position in the
+   middle of a byte.  The provided bits will be used before any bytes are used
+   from next_in.  This function should only be used with raw inflate, and
+   should be used before the first inflate() call after inflateInit2() or
+   inflateReset().  bits must be less than or equal to 16, and that many of the
+   least significant bits of value will be inserted in the input.
+
+     If bits is negative, then the input stream bit buffer is emptied.  Then
+   inflatePrime() can be called again to put bits in the buffer.  This is used
+   to clear out bits leftover after feeding inflate a block description prior
+   to feeding inflate codes.
+
+     inflatePrime returns Z_OK if success, or Z_STREAM_ERROR if the source
+   stream state was inconsistent.
+*/
+
+ZEXTERN long ZEXPORT inflateMark OF((z_streamp strm));
+/*
+     This function returns two values, one in the lower 16 bits of the return
+   value, and the other in the remaining upper bits, obtained by shifting the
+   return value down 16 bits.  If the upper value is -1 and the lower value is
+   zero, then inflate() is currently decoding information outside of a block.
+   If the upper value is -1 and the lower value is non-zero, then inflate is in
+   the middle of a stored block, with the lower value equaling the number of
+   bytes from the input remaining to copy.  If the upper value is not -1, then
+   it is the number of bits back from the current bit position in the input of
+   the code (literal or length/distance pair) currently being processed.  In
+   that case the lower value is the number of bytes already emitted for that
+   code.
+
+     A code is being processed if inflate is waiting for more input to complete
+   decoding of the code, or if it has completed decoding but is waiting for
+   more output space to write the literal or match data.
+
+     inflateMark() is used to mark locations in the input data for random
+   access, which may be at bit positions, and to note those cases where the
+   output of a code may span boundaries of random access blocks.  The current
+   location in the input stream can be determined from avail_in and data_type
+   as noted in the description for the Z_BLOCK flush parameter for inflate.
+
+     inflateMark returns the value noted above or -1 << 16 if the provided
+   source stream state was inconsistent.
+*/
+
+ZEXTERN int ZEXPORT inflateGetHeader OF((z_streamp strm,
+                                         gz_headerp head));
+/*
+     inflateGetHeader() requests that gzip header information be stored in the
+   provided gz_header structure.  inflateGetHeader() may be called after
+   inflateInit2() or inflateReset(), and before the first call of inflate().
+   As inflate() processes the gzip stream, head->done is zero until the header
+   is completed, at which time head->done is set to one.  If a zlib stream is
+   being decoded, then head->done is set to -1 to indicate that there will be
+   no gzip header information forthcoming.  Note that Z_BLOCK or Z_TREES can be
+   used to force inflate() to return immediately after header processing is
+   complete and before any actual data is decompressed.
+
+     The text, time, xflags, and os fields are filled in with the gzip header
+   contents.  hcrc is set to true if there is a header CRC.  (The header CRC
+   was valid if done is set to one.) If extra is not Z_NULL, then extra_max
+   contains the maximum number of bytes to write to extra.  Once done is true,
+   extra_len contains the actual extra field length, and extra contains the
+   extra field, or that field truncated if extra_max is less than extra_len.
+   If name is not Z_NULL, then up to name_max characters are written there,
+   terminated with a zero unless the length is greater than name_max.  If
+   comment is not Z_NULL, then up to comm_max characters are written there,
+   terminated with a zero unless the length is greater than comm_max.  When any
+   of extra, name, or comment are not Z_NULL and the respective field is not
+   present in the header, then that field is set to Z_NULL to signal its
+   absence.  This allows the use of deflateSetHeader() with the returned
+   structure to duplicate the header.  However if those fields are set to
+   allocated memory, then the application will need to save those pointers
+   elsewhere so that they can be eventually freed.
+
+     If inflateGetHeader is not used, then the header information is simply
+   discarded.  The header is always checked for validity, including the header
+   CRC if present.  inflateReset() will reset the process to discard the header
+   information.  The application would need to call inflateGetHeader() again to
+   retrieve the header from the next gzip stream.
+
+     inflateGetHeader returns Z_OK if success, or Z_STREAM_ERROR if the source
+   stream state was inconsistent.
+*/
+
+/*
+ZEXTERN int ZEXPORT inflateBackInit OF((z_streamp strm, int windowBits,
+                                        unsigned char FAR *window));
+
+     Initialize the internal stream state for decompression using inflateBack()
+   calls.  The fields zalloc, zfree and opaque in strm must be initialized
+   before the call.  If zalloc and zfree are Z_NULL, then the default library-
+   derived memory allocation routines are used.  windowBits is the base two
+   logarithm of the window size, in the range 8..15.  window is a caller
+   supplied buffer of that size.  Except for special applications where it is
+   assured that deflate was used with small window sizes, windowBits must be 15
+   and a 32K byte window must be supplied to be able to decompress general
+   deflate streams.
+
+     See inflateBack() for the usage of these routines.
+
+     inflateBackInit will return Z_OK on success, Z_STREAM_ERROR if any of
+   the parameters are invalid, Z_MEM_ERROR if the internal state could not be
+   allocated, or Z_VERSION_ERROR if the version of the library does not match
+   the version of the header file.
+*/
+
+typedef unsigned (*in_func) OF((void FAR *, unsigned char FAR * FAR *));
+typedef int (*out_func) OF((void FAR *, unsigned char FAR *, unsigned));
+
+ZEXTERN int ZEXPORT inflateBack OF((z_streamp strm,
+                                    in_func in, void FAR *in_desc,
+                                    out_func out, void FAR *out_desc));
+/*
+     inflateBack() does a raw inflate with a single call using a call-back
+   interface for input and output.  This is more efficient than inflate() for
+   file i/o applications in that it avoids copying between the output and the
+   sliding window by simply making the window itself the output buffer.  This
+   function trusts the application to not change the output buffer passed by
+   the output function, at least until inflateBack() returns.
+
+     inflateBackInit() must be called first to allocate the internal state
+   and to initialize the state with the user-provided window buffer.
+   inflateBack() may then be used multiple times to inflate a complete, raw
+   deflate stream with each call.  inflateBackEnd() is then called to free the
+   allocated state.
+
+     A raw deflate stream is one with no zlib or gzip header or trailer.
+   This routine would normally be used in a utility that reads zip or gzip
+   files and writes out uncompressed files.  The utility would decode the
+   header and process the trailer on its own, hence this routine expects only
+   the raw deflate stream to decompress.  This is different from the normal
+   behavior of inflate(), which expects either a zlib or gzip header and
+   trailer around the deflate stream.
+
+     inflateBack() uses two subroutines supplied by the caller that are then
+   called by inflateBack() for input and output.  inflateBack() calls those
+   routines until it reads a complete deflate stream and writes out all of the
+   uncompressed data, or until it encounters an error.  The function's
+   parameters and return types are defined above in the in_func and out_func
+   typedefs.  inflateBack() will call in(in_desc, &buf) which should return the
+   number of bytes of provided input, and a pointer to that input in buf.  If
+   there is no input available, in() must return zero--buf is ignored in that
+   case--and inflateBack() will return a buffer error.  inflateBack() will call
+   out(out_desc, buf, len) to write the uncompressed data buf[0..len-1].  out()
+   should return zero on success, or non-zero on failure.  If out() returns
+   non-zero, inflateBack() will return with an error.  Neither in() nor out()
+   are permitted to change the contents of the window provided to
+   inflateBackInit(), which is also the buffer that out() uses to write from.
+   The length written by out() will be at most the window size.  Any non-zero
+   amount of input may be provided by in().
+
+     For convenience, inflateBack() can be provided input on the first call by
+   setting strm->next_in and strm->avail_in.  If that input is exhausted, then
+   in() will be called.  Therefore strm->next_in must be initialized before
+   calling inflateBack().  If strm->next_in is Z_NULL, then in() will be called
+   immediately for input.  If strm->next_in is not Z_NULL, then strm->avail_in
+   must also be initialized, and then if strm->avail_in is not zero, input will
+   initially be taken from strm->next_in[0 ..  strm->avail_in - 1].
+
+     The in_desc and out_desc parameters of inflateBack() is passed as the
+   first parameter of in() and out() respectively when they are called.  These
+   descriptors can be optionally used to pass any information that the caller-
+   supplied in() and out() functions need to do their job.
+
+     On return, inflateBack() will set strm->next_in and strm->avail_in to
+   pass back any unused input that was provided by the last in() call.  The
+   return values of inflateBack() can be Z_STREAM_END on success, Z_BUF_ERROR
+   if in() or out() returned an error, Z_DATA_ERROR if there was a format error
+   in the deflate stream (in which case strm->msg is set to indicate the nature
+   of the error), or Z_STREAM_ERROR if the stream was not properly initialized.
+   In the case of Z_BUF_ERROR, an input or output error can be distinguished
+   using strm->next_in which will be Z_NULL only if in() returned an error.  If
+   strm->next_in is not Z_NULL, then the Z_BUF_ERROR was due to out() returning
+   non-zero.  (in() will always be called before out(), so strm->next_in is
+   assured to be defined if out() returns non-zero.) Note that inflateBack()
+   cannot return Z_OK.
+*/
+
+ZEXTERN int ZEXPORT inflateBackEnd OF((z_streamp strm));
+/*
+     All memory allocated by inflateBackInit() is freed.
+
+     inflateBackEnd() returns Z_OK on success, or Z_STREAM_ERROR if the stream
+   state was inconsistent.
+*/
+
+ZEXTERN uLong ZEXPORT zlibCompileFlags OF((void));
+/* Return flags indicating compile-time options.
+
+    Type sizes, two bits each, 00 = 16 bits, 01 = 32, 10 = 64, 11 = other:
+     1.0: size of uInt
+     3.2: size of uLong
+     5.4: size of voidpf (pointer)
+     7.6: size of z_off_t
+
+    Compiler, assembler, and debug options:
+     8: DEBUG
+     9: ASMV or ASMINF -- use ASM code
+     10: ZLIB_WINAPI -- exported functions use the WINAPI calling convention
+     11: 0 (reserved)
+
+    One-time table building (smaller code, but not thread-safe if true):
+     12: BUILDFIXED -- build static block decoding tables when needed
+     13: DYNAMIC_CRC_TABLE -- build CRC calculation tables when needed
+     14,15: 0 (reserved)
+
+    Library content (indicates missing functionality):
+     16: NO_GZCOMPRESS -- gz* functions cannot compress (to avoid linking
+                          deflate code when not needed)
+     17: NO_GZIP -- deflate can't write gzip streams, and inflate can't detect
+                    and decode gzip streams (to avoid linking crc code)
+     18-19: 0 (reserved)
+
+    Operation variations (changes in library functionality):
+     20: PKZIP_BUG_WORKAROUND -- slightly more permissive inflate
+     21: FASTEST -- deflate algorithm with only one, lowest compression level
+     22,23: 0 (reserved)
+
+    The sprintf variant used by gzprintf (zero is best):
+     24: 0 = vs*, 1 = s* -- 1 means limited to 20 arguments after the format
+     25: 0 = *nprintf, 1 = *printf -- 1 means gzprintf() not secure!
+     26: 0 = returns value, 1 = void -- 1 means inferred string length returned
+
+    Remainder:
+     27-31: 0 (reserved)
+ */
+
+#ifndef Z_SOLO
+
+                        /* utility functions */
+
+/*
+     The following utility functions are implemented on top of the basic
+   stream-oriented functions.  To simplify the interface, some default options
+   are assumed (compression level and memory usage, standard memory allocation
+   functions).  The source code of these utility functions can be modified if
+   you need special options.
+*/
+
+ZEXTERN int ZEXPORT compress OF((Bytef *dest,   uLongf *destLen,
+                                 const Bytef *source, uLong sourceLen));
+/*
+     Compresses the source buffer into the destination buffer.  sourceLen is
+   the byte length of the source buffer.  Upon entry, destLen is the total size
+   of the destination buffer, which must be at least the value returned by
+   compressBound(sourceLen).  Upon exit, destLen is the actual size of the
+   compressed buffer.
+
+     compress returns Z_OK if success, Z_MEM_ERROR if there was not
+   enough memory, Z_BUF_ERROR if there was not enough room in the output
+   buffer.
+*/
+
+ZEXTERN int ZEXPORT compress2 OF((Bytef *dest,   uLongf *destLen,
+                                  const Bytef *source, uLong sourceLen,
+                                  int level));
+/*
+     Compresses the source buffer into the destination buffer.  The level
+   parameter has the same meaning as in deflateInit.  sourceLen is the byte
+   length of the source buffer.  Upon entry, destLen is the total size of the
+   destination buffer, which must be at least the value returned by
+   compressBound(sourceLen).  Upon exit, destLen is the actual size of the
+   compressed buffer.
+
+     compress2 returns Z_OK if success, Z_MEM_ERROR if there was not enough
+   memory, Z_BUF_ERROR if there was not enough room in the output buffer,
+   Z_STREAM_ERROR if the level parameter is invalid.
+*/
+
+ZEXTERN uLong ZEXPORT compressBound OF((uLong sourceLen));
+/*
+     compressBound() returns an upper bound on the compressed size after
+   compress() or compress2() on sourceLen bytes.  It would be used before a
+   compress() or compress2() call to allocate the destination buffer.
+*/
+
+ZEXTERN int ZEXPORT uncompress OF((Bytef *dest,   uLongf *destLen,
+                                   const Bytef *source, uLong sourceLen));
+/*
+     Decompresses the source buffer into the destination buffer.  sourceLen is
+   the byte length of the source buffer.  Upon entry, destLen is the total size
+   of the destination buffer, which must be large enough to hold the entire
+   uncompressed data.  (The size of the uncompressed data must have been saved
+   previously by the compressor and transmitted to the decompressor by some
+   mechanism outside the scope of this compression library.) Upon exit, destLen
+   is the actual size of the uncompressed buffer.
+
+     uncompress returns Z_OK if success, Z_MEM_ERROR if there was not
+   enough memory, Z_BUF_ERROR if there was not enough room in the output
+   buffer, or Z_DATA_ERROR if the input data was corrupted or incomplete.  In
+   the case where there is not enough room, uncompress() will fill the output
+   buffer with the uncompressed data up to that point.
+*/
+
+                        /* gzip file access functions */
+
+/*
+     This library supports reading and writing files in gzip (.gz) format with
+   an interface similar to that of stdio, using the functions that start with
+   "gz".  The gzip format is different from the zlib format.  gzip is a gzip
+   wrapper, documented in RFC 1952, wrapped around a deflate stream.
+*/
+
+typedef struct gzFile_s *gzFile;    /* semi-opaque gzip file descriptor */
+
+/*
+ZEXTERN gzFile ZEXPORT gzopen OF((const char *path, const char *mode));
+
+     Opens a gzip (.gz) file for reading or writing.  The mode parameter is as
+   in fopen ("rb" or "wb") but can also include a compression level ("wb9") or
+   a strategy: 'f' for filtered data as in "wb6f", 'h' for Huffman-only
+   compression as in "wb1h", 'R' for run-length encoding as in "wb1R", or 'F'
+   for fixed code compression as in "wb9F".  (See the description of
+   deflateInit2 for more information about the strategy parameter.)  'T' will
+   request transparent writing or appending with no compression and not using
+   the gzip format.
+
+     "a" can be used instead of "w" to request that the gzip stream that will
+   be written be appended to the file.  "+" will result in an error, since
+   reading and writing to the same gzip file is not supported.  The addition of
+   "x" when writing will create the file exclusively, which fails if the file
+   already exists.  On systems that support it, the addition of "e" when
+   reading or writing will set the flag to close the file on an execve() call.
+
+     These functions, as well as gzip, will read and decode a sequence of gzip
+   streams in a file.  The append function of gzopen() can be used to create
+   such a file.  (Also see gzflush() for another way to do this.)  When
+   appending, gzopen does not test whether the file begins with a gzip stream,
+   nor does it look for the end of the gzip streams to begin appending.  gzopen
+   will simply append a gzip stream to the existing file.
+
+     gzopen can be used to read a file which is not in gzip format; in this
+   case gzread will directly read from the file without decompression.  When
+   reading, this will be detected automatically by looking for the magic two-
+   byte gzip header.
+
+     gzopen returns NULL if the file could not be opened, if there was
+   insufficient memory to allocate the gzFile state, or if an invalid mode was
+   specified (an 'r', 'w', or 'a' was not provided, or '+' was provided).
+   errno can be checked to determine if the reason gzopen failed was that the
+   file could not be opened.
+*/
+
+ZEXTERN gzFile ZEXPORT gzdopen OF((int fd, const char *mode));
+/*
+     gzdopen associates a gzFile with the file descriptor fd.  File descriptors
+   are obtained from calls like open, dup, creat, pipe or fileno (if the file
+   has been previously opened with fopen).  The mode parameter is as in gzopen.
+
+     The next call of gzclose on the returned gzFile will also close the file
+   descriptor fd, just like fclose(fdopen(fd, mode)) closes the file descriptor
+   fd.  If you want to keep fd open, use fd = dup(fd_keep); gz = gzdopen(fd,
+   mode);.  The duplicated descriptor should be saved to avoid a leak, since
+   gzdopen does not close fd if it fails.  If you are using fileno() to get the
+   file descriptor from a FILE *, then you will have to use dup() to avoid
+   double-close()ing the file descriptor.  Both gzclose() and fclose() will
+   close the associated file descriptor, so they need to have different file
+   descriptors.
+
+     gzdopen returns NULL if there was insufficient memory to allocate the
+   gzFile state, if an invalid mode was specified (an 'r', 'w', or 'a' was not
+   provided, or '+' was provided), or if fd is -1.  The file descriptor is not
+   used until the next gz* read, write, seek, or close operation, so gzdopen
+   will not detect if fd is invalid (unless fd is -1).
+*/
+
+ZEXTERN int ZEXPORT gzbuffer OF((gzFile file, unsigned size));
+/*
+     Set the internal buffer size used by this library's functions.  The
+   default buffer size is 8192 bytes.  This function must be called after
+   gzopen() or gzdopen(), and before any other calls that read or write the
+   file.  The buffer memory allocation is always deferred to the first read or
+   write.  Two buffers are allocated, either both of the specified size when
+   writing, or one of the specified size and the other twice that size when
+   reading.  A larger buffer size of, for example, 64K or 128K bytes will
+   noticeably increase the speed of decompression (reading).
+
+     The new buffer size also affects the maximum length for gzprintf().
+
+     gzbuffer() returns 0 on success, or -1 on failure, such as being called
+   too late.
+*/
+
+ZEXTERN int ZEXPORT gzsetparams OF((gzFile file, int level, int strategy));
+/*
+     Dynamically update the compression level or strategy.  See the description
+   of deflateInit2 for the meaning of these parameters.
+
+     gzsetparams returns Z_OK if success, or Z_STREAM_ERROR if the file was not
+   opened for writing.
+*/
+
+ZEXTERN int ZEXPORT gzread OF((gzFile file, voidp buf, unsigned len));
+/*
+     Reads the given number of uncompressed bytes from the compressed file.  If
+   the input file is not in gzip format, gzread copies the given number of
+   bytes into the buffer directly from the file.
+
+     After reaching the end of a gzip stream in the input, gzread will continue
+   to read, looking for another gzip stream.  Any number of gzip streams may be
+   concatenated in the input file, and will all be decompressed by gzread().
+   If something other than a gzip stream is encountered after a gzip stream,
+   that remaining trailing garbage is ignored (and no error is returned).
+
+     gzread can be used to read a gzip file that is being concurrently written.
+   Upon reaching the end of the input, gzread will return with the available
+   data.  If the error code returned by gzerror is Z_OK or Z_BUF_ERROR, then
+   gzclearerr can be used to clear the end of file indicator in order to permit
+   gzread to be tried again.  Z_OK indicates that a gzip stream was completed
+   on the last gzread.  Z_BUF_ERROR indicates that the input file ended in the
+   middle of a gzip stream.  Note that gzread does not return -1 in the event
+   of an incomplete gzip stream.  This error is deferred until gzclose(), which
+   will return Z_BUF_ERROR if the last gzread ended in the middle of a gzip
+   stream.  Alternatively, gzerror can be used before gzclose to detect this
+   case.
+
+     gzread returns the number of uncompressed bytes actually read, less than
+   len for end of file, or -1 for error.
+*/
+
+ZEXTERN int ZEXPORT gzwrite OF((gzFile file,
+                                voidpc buf, unsigned len));
+/*
+     Writes the given number of uncompressed bytes into the compressed file.
+   gzwrite returns the number of uncompressed bytes written or 0 in case of
+   error.
+*/
+
+ZEXTERN int ZEXPORTVA gzprintf Z_ARG((gzFile file, const char *format, ...));
+/*
+     Converts, formats, and writes the arguments to the compressed file under
+   control of the format string, as in fprintf.  gzprintf returns the number of
+   uncompressed bytes actually written, or 0 in case of error.  The number of
+   uncompressed bytes written is limited to 8191, or one less than the buffer
+   size given to gzbuffer().  The caller should assure that this limit is not
+   exceeded.  If it is exceeded, then gzprintf() will return an error (0) with
+   nothing written.  In this case, there may also be a buffer overflow with
+   unpredictable consequences, which is possible only if zlib was compiled with
+   the insecure functions sprintf() or vsprintf() because the secure snprintf()
+   or vsnprintf() functions were not available.  This can be determined using
+   zlibCompileFlags().
+*/
+
+ZEXTERN int ZEXPORT gzputs OF((gzFile file, const char *s));
+/*
+     Writes the given null-terminated string to the compressed file, excluding
+   the terminating null character.
+
+     gzputs returns the number of characters written, or -1 in case of error.
+*/
+
+ZEXTERN char * ZEXPORT gzgets OF((gzFile file, char *buf, int len));
+/*
+     Reads bytes from the compressed file until len-1 characters are read, or a
+   newline character is read and transferred to buf, or an end-of-file
+   condition is encountered.  If any characters are read or if len == 1, the
+   string is terminated with a null character.  If no characters are read due
+   to an end-of-file or len < 1, then the buffer is left untouched.
+
+     gzgets returns buf which is a null-terminated string, or it returns NULL
+   for end-of-file or in case of error.  If there was an error, the contents at
+   buf are indeterminate.
+*/
+
+ZEXTERN int ZEXPORT gzputc OF((gzFile file, int c));
+/*
+     Writes c, converted to an unsigned char, into the compressed file.  gzputc
+   returns the value that was written, or -1 in case of error.
+*/
+
+ZEXTERN int ZEXPORT gzgetc OF((gzFile file));
+/*
+     Reads one byte from the compressed file.  gzgetc returns this byte or -1
+   in case of end of file or error.  This is implemented as a macro for speed.
+   As such, it does not do all of the checking the other functions do.  I.e.
+   it does not check to see if file is NULL, nor whether the structure file
+   points to has been clobbered or not.
+*/
+
+ZEXTERN int ZEXPORT gzungetc OF((int c, gzFile file));
+/*
+     Push one character back onto the stream to be read as the first character
+   on the next read.  At least one character of push-back is allowed.
+   gzungetc() returns the character pushed, or -1 on failure.  gzungetc() will
+   fail if c is -1, and may fail if a character has been pushed but not read
+   yet.  If gzungetc is used immediately after gzopen or gzdopen, at least the
+   output buffer size of pushed characters is allowed.  (See gzbuffer above.)
+   The pushed character will be discarded if the stream is repositioned with
+   gzseek() or gzrewind().
+*/
+
+ZEXTERN int ZEXPORT gzflush OF((gzFile file, int flush));
+/*
+     Flushes all pending output into the compressed file.  The parameter flush
+   is as in the deflate() function.  The return value is the zlib error number
+   (see function gzerror below).  gzflush is only permitted when writing.
+
+     If the flush parameter is Z_FINISH, the remaining data is written and the
+   gzip stream is completed in the output.  If gzwrite() is called again, a new
+   gzip stream will be started in the output.  gzread() is able to read such
+   concatented gzip streams.
+
+     gzflush should be called only when strictly necessary because it will
+   degrade compression if called too often.
+*/
+
+/*
+ZEXTERN z_off_t ZEXPORT gzseek OF((gzFile file,
+                                   z_off_t offset, int whence));
+
+     Sets the starting position for the next gzread or gzwrite on the given
+   compressed file.  The offset represents a number of bytes in the
+   uncompressed data stream.  The whence parameter is defined as in lseek(2);
+   the value SEEK_END is not supported.
+
+     If the file is opened for reading, this function is emulated but can be
+   extremely slow.  If the file is opened for writing, only forward seeks are
+   supported; gzseek then compresses a sequence of zeroes up to the new
+   starting position.
+
+     gzseek returns the resulting offset location as measured in bytes from
+   the beginning of the uncompressed stream, or -1 in case of error, in
+   particular if the file is opened for writing and the new starting position
+   would be before the current position.
+*/
+
+ZEXTERN int ZEXPORT    gzrewind OF((gzFile file));
+/*
+     Rewinds the given file. This function is supported only for reading.
+
+     gzrewind(file) is equivalent to (int)gzseek(file, 0L, SEEK_SET)
+*/
+
+/*
+ZEXTERN z_off_t ZEXPORT    gztell OF((gzFile file));
+
+     Returns the starting position for the next gzread or gzwrite on the given
+   compressed file.  This position represents a number of bytes in the
+   uncompressed data stream, and is zero when starting, even if appending or
+   reading a gzip stream from the middle of a file using gzdopen().
+
+     gztell(file) is equivalent to gzseek(file, 0L, SEEK_CUR)
+*/
+
+/*
+ZEXTERN z_off_t ZEXPORT gzoffset OF((gzFile file));
+
+     Returns the current offset in the file being read or written.  This offset
+   includes the count of bytes that precede the gzip stream, for example when
+   appending or when using gzdopen() for reading.  When reading, the offset
+   does not include as yet unused buffered input.  This information can be used
+   for a progress indicator.  On error, gzoffset() returns -1.
+*/
+
+ZEXTERN int ZEXPORT gzeof OF((gzFile file));
+/*
+     Returns true (1) if the end-of-file indicator has been set while reading,
+   false (0) otherwise.  Note that the end-of-file indicator is set only if the
+   read tried to go past the end of the input, but came up short.  Therefore,
+   just like feof(), gzeof() may return false even if there is no more data to
+   read, in the event that the last read request was for the exact number of
+   bytes remaining in the input file.  This will happen if the input file size
+   is an exact multiple of the buffer size.
+
+     If gzeof() returns true, then the read functions will return no more data,
+   unless the end-of-file indicator is reset by gzclearerr() and the input file
+   has grown since the previous end of file was detected.
+*/
+
+ZEXTERN int ZEXPORT gzdirect OF((gzFile file));
+/*
+     Returns true (1) if file is being copied directly while reading, or false
+   (0) if file is a gzip stream being decompressed.
+
+     If the input file is empty, gzdirect() will return true, since the input
+   does not contain a gzip stream.
+
+     If gzdirect() is used immediately after gzopen() or gzdopen() it will
+   cause buffers to be allocated to allow reading the file to determine if it
+   is a gzip file.  Therefore if gzbuffer() is used, it should be called before
+   gzdirect().
+
+     When writing, gzdirect() returns true (1) if transparent writing was
+   requested ("wT" for the gzopen() mode), or false (0) otherwise.  (Note:
+   gzdirect() is not needed when writing.  Transparent writing must be
+   explicitly requested, so the application already knows the answer.  When
+   linking statically, using gzdirect() will include all of the zlib code for
+   gzip file reading and decompression, which may not be desired.)
+*/
+
+ZEXTERN int ZEXPORT    gzclose OF((gzFile file));
+/*
+     Flushes all pending output if necessary, closes the compressed file and
+   deallocates the (de)compression state.  Note that once file is closed, you
+   cannot call gzerror with file, since its structures have been deallocated.
+   gzclose must not be called more than once on the same file, just as free
+   must not be called more than once on the same allocation.
+
+     gzclose will return Z_STREAM_ERROR if file is not valid, Z_ERRNO on a
+   file operation error, Z_MEM_ERROR if out of memory, Z_BUF_ERROR if the
+   last read ended in the middle of a gzip stream, or Z_OK on success.
+*/
+
+ZEXTERN int ZEXPORT gzclose_r OF((gzFile file));
+ZEXTERN int ZEXPORT gzclose_w OF((gzFile file));
+/*
+     Same as gzclose(), but gzclose_r() is only for use when reading, and
+   gzclose_w() is only for use when writing or appending.  The advantage to
+   using these instead of gzclose() is that they avoid linking in zlib
+   compression or decompression code that is not used when only reading or only
+   writing respectively.  If gzclose() is used, then both compression and
+   decompression code will be included the application when linking to a static
+   zlib library.
+*/
+
+ZEXTERN const char * ZEXPORT gzerror OF((gzFile file, int *errnum));
+/*
+     Returns the error message for the last error which occurred on the given
+   compressed file.  errnum is set to zlib error number.  If an error occurred
+   in the file system and not in the compression library, errnum is set to
+   Z_ERRNO and the application may consult errno to get the exact error code.
+
+     The application must not modify the returned string.  Future calls to
+   this function may invalidate the previously returned string.  If file is
+   closed, then the string previously returned by gzerror will no longer be
+   available.
+
+     gzerror() should be used to distinguish errors from end-of-file for those
+   functions above that do not distinguish those cases in their return values.
+*/
+
+ZEXTERN void ZEXPORT gzclearerr OF((gzFile file));
+/*
+     Clears the error and end-of-file flags for file.  This is analogous to the
+   clearerr() function in stdio.  This is useful for continuing to read a gzip
+   file that is being written concurrently.
+*/
+
+#endif /* !Z_SOLO */
+
+                        /* checksum functions */
+
+/*
+     These functions are not related to compression but are exported
+   anyway because they might be useful in applications using the compression
+   library.
+*/
+
+ZEXTERN uLong ZEXPORT adler32 OF((uLong adler, const Bytef *buf, uInt len));
+/*
+     Update a running Adler-32 checksum with the bytes buf[0..len-1] and
+   return the updated checksum.  If buf is Z_NULL, this function returns the
+   required initial value for the checksum.
+
+     An Adler-32 checksum is almost as reliable as a CRC32 but can be computed
+   much faster.
+
+   Usage example:
+
+     uLong adler = adler32(0L, Z_NULL, 0);
+
+     while (read_buffer(buffer, length) != EOF) {
+       adler = adler32(adler, buffer, length);
+     }
+     if (adler != original_adler) error();
+*/
+
+/*
+ZEXTERN uLong ZEXPORT adler32_combine OF((uLong adler1, uLong adler2,
+                                          z_off_t len2));
+
+     Combine two Adler-32 checksums into one.  For two sequences of bytes, seq1
+   and seq2 with lengths len1 and len2, Adler-32 checksums were calculated for
+   each, adler1 and adler2.  adler32_combine() returns the Adler-32 checksum of
+   seq1 and seq2 concatenated, requiring only adler1, adler2, and len2.  Note
+   that the z_off_t type (like off_t) is a signed integer.  If len2 is
+   negative, the result has no meaning or utility.
+*/
+
+ZEXTERN uLong ZEXPORT crc32   OF((uLong crc, const Bytef *buf, uInt len));
+/*
+     Update a running CRC-32 with the bytes buf[0..len-1] and return the
+   updated CRC-32.  If buf is Z_NULL, this function returns the required
+   initial value for the crc.  Pre- and post-conditioning (one's complement) is
+   performed within this function so it shouldn't be done by the application.
+
+   Usage example:
+
+     uLong crc = crc32(0L, Z_NULL, 0);
+
+     while (read_buffer(buffer, length) != EOF) {
+       crc = crc32(crc, buffer, length);
+     }
+     if (crc != original_crc) error();
+*/
+
+/*
+ZEXTERN uLong ZEXPORT crc32_combine OF((uLong crc1, uLong crc2, z_off_t len2));
+
+     Combine two CRC-32 check values into one.  For two sequences of bytes,
+   seq1 and seq2 with lengths len1 and len2, CRC-32 check values were
+   calculated for each, crc1 and crc2.  crc32_combine() returns the CRC-32
+   check value of seq1 and seq2 concatenated, requiring only crc1, crc2, and
+   len2.
+*/
+
+
+                        /* various hacks, don't look :) */
+
+/* deflateInit and inflateInit are macros to allow checking the zlib version
+ * and the compiler's view of z_stream:
+ */
+ZEXTERN int ZEXPORT deflateInit_ OF((z_streamp strm, int level,
+                                     const char *version, int stream_size));
+ZEXTERN int ZEXPORT inflateInit_ OF((z_streamp strm,
+                                     const char *version, int stream_size));
+ZEXTERN int ZEXPORT deflateInit2_ OF((z_streamp strm, int  level, int  method,
+                                      int windowBits, int memLevel,
+                                      int strategy, const char *version,
+                                      int stream_size));
+ZEXTERN int ZEXPORT inflateInit2_ OF((z_streamp strm, int  windowBits,
+                                      const char *version, int stream_size));
+ZEXTERN int ZEXPORT inflateBackInit_ OF((z_streamp strm, int windowBits,
+                                         unsigned char FAR *window,
+                                         const char *version,
+                                         int stream_size));
+#define deflateInit(strm, level) \
+        deflateInit_((strm), (level), ZLIB_VERSION, (int)sizeof(z_stream))
+#define inflateInit(strm) \
+        inflateInit_((strm), ZLIB_VERSION, (int)sizeof(z_stream))
+#define deflateInit2(strm, level, method, windowBits, memLevel, strategy) \
+        deflateInit2_((strm),(level),(method),(windowBits),(memLevel),\
+                      (strategy), ZLIB_VERSION, (int)sizeof(z_stream))
+#define inflateInit2(strm, windowBits) \
+        inflateInit2_((strm), (windowBits), ZLIB_VERSION, \
+                      (int)sizeof(z_stream))
+#define inflateBackInit(strm, windowBits, window) \
+        inflateBackInit_((strm), (windowBits), (window), \
+                      ZLIB_VERSION, (int)sizeof(z_stream))
+
+#ifndef Z_SOLO
+
+/* gzgetc() macro and its supporting function and exposed data structure.  Note
+ * that the real internal state is much larger than the exposed structure.
+ * This abbreviated structure exposes just enough for the gzgetc() macro.  The
+ * user should not mess with these exposed elements, since their names or
+ * behavior could change in the future, perhaps even capriciously.  They can
+ * only be used by the gzgetc() macro.  You have been warned.
+ */
+struct gzFile_s {
+    unsigned have;
+    unsigned char *next;
+    z_off64_t pos;
+};
+ZEXTERN int ZEXPORT gzgetc_ OF((gzFile file));  /* backward compatibility */
+#ifdef Z_PREFIX_SET
+#  undef z_gzgetc
+#  define z_gzgetc(g) \
+          ((g)->have ? ((g)->have--, (g)->pos++, *((g)->next)++) : gzgetc(g))
+#else
+#  define gzgetc(g) \
+          ((g)->have ? ((g)->have--, (g)->pos++, *((g)->next)++) : gzgetc(g))
+#endif
+
+/* provide 64-bit offset functions if _LARGEFILE64_SOURCE defined, and/or
+ * change the regular functions to 64 bits if _FILE_OFFSET_BITS is 64 (if
+ * both are true, the application gets the *64 functions, and the regular
+ * functions are changed to 64 bits) -- in case these are set on systems
+ * without large file support, _LFS64_LARGEFILE must also be true
+ */
+#ifdef Z_LARGE64
+   ZEXTERN gzFile ZEXPORT gzopen64 OF((const char *, const char *));
+   ZEXTERN z_off64_t ZEXPORT gzseek64 OF((gzFile, z_off64_t, int));
+   ZEXTERN z_off64_t ZEXPORT gztell64 OF((gzFile));
+   ZEXTERN z_off64_t ZEXPORT gzoffset64 OF((gzFile));
+   ZEXTERN uLong ZEXPORT adler32_combine64 OF((uLong, uLong, z_off64_t));
+   ZEXTERN uLong ZEXPORT crc32_combine64 OF((uLong, uLong, z_off64_t));
+#endif
+
+#if !defined(ZLIB_INTERNAL) && defined(Z_WANT64)
+#  ifdef Z_PREFIX_SET
+#    define z_gzopen z_gzopen64
+#    define z_gzseek z_gzseek64
+#    define z_gztell z_gztell64
+#    define z_gzoffset z_gzoffset64
+#    define z_adler32_combine z_adler32_combine64
+#    define z_crc32_combine z_crc32_combine64
+#  else
+#    define gzopen gzopen64
+#    define gzseek gzseek64
+#    define gztell gztell64
+#    define gzoffset gzoffset64
+#    define adler32_combine adler32_combine64
+#    define crc32_combine crc32_combine64
+#  endif
+#  ifndef Z_LARGE64
+     ZEXTERN gzFile ZEXPORT gzopen64 OF((const char *, const char *));
+     ZEXTERN z_off_t ZEXPORT gzseek64 OF((gzFile, z_off_t, int));
+     ZEXTERN z_off_t ZEXPORT gztell64 OF((gzFile));
+     ZEXTERN z_off_t ZEXPORT gzoffset64 OF((gzFile));
+     ZEXTERN uLong ZEXPORT adler32_combine64 OF((uLong, uLong, z_off_t));
+     ZEXTERN uLong ZEXPORT crc32_combine64 OF((uLong, uLong, z_off_t));
+#  endif
+#else
+   ZEXTERN gzFile ZEXPORT gzopen OF((const char *, const char *));
+   ZEXTERN z_off_t ZEXPORT gzseek OF((gzFile, z_off_t, int));
+   ZEXTERN z_off_t ZEXPORT gztell OF((gzFile));
+   ZEXTERN z_off_t ZEXPORT gzoffset OF((gzFile));
+   ZEXTERN uLong ZEXPORT adler32_combine OF((uLong, uLong, z_off_t));
+   ZEXTERN uLong ZEXPORT crc32_combine OF((uLong, uLong, z_off_t));
+#endif
+
+#else /* Z_SOLO */
+
+   ZEXTERN uLong ZEXPORT adler32_combine OF((uLong, uLong, z_off_t));
+   ZEXTERN uLong ZEXPORT crc32_combine OF((uLong, uLong, z_off_t));
+
+#endif /* !Z_SOLO */
+
+/* hack for buggy compilers */
+#if !defined(ZUTIL_H) && !defined(NO_DUMMY_DECL)
+    struct internal_state {int dummy;};
+#endif
+
+/* undocumented functions */
+ZEXTERN const char   * ZEXPORT zError           OF((int));
+ZEXTERN int            ZEXPORT inflateSyncPoint OF((z_streamp));
+ZEXTERN const z_crc_t FAR * ZEXPORT get_crc_table    OF((void));
+ZEXTERN int            ZEXPORT inflateUndermine OF((z_streamp, int));
+ZEXTERN int            ZEXPORT inflateResetKeep OF((z_streamp));
+ZEXTERN int            ZEXPORT deflateResetKeep OF((z_streamp));
+#if defined(_WIN32) && !defined(Z_SOLO)
+ZEXTERN gzFile         ZEXPORT gzopen_w OF((const wchar_t *path,
+                                            const char *mode));
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZLIB_H */

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2020 The RetroArch team
+/* Copyright  (C) 2010-2019 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (file_path.c).
@@ -32,6 +32,8 @@
 #include <file/file_path.h>
 #include <retro_assert.h>
 #include <string/stdstring.h>
+#define VFS_FRONTEND
+#include <vfs/vfs_implementation.h>
 
 /* TODO: There are probably some unnecessary things on this huge include list now but I'm too afraid to touch it */
 #ifdef __APPLE__
@@ -111,6 +113,137 @@
 #endif
 
 #endif
+
+static retro_vfs_stat_t path_stat_cb   = NULL;
+static retro_vfs_mkdir_t path_mkdir_cb = NULL;
+
+void path_vfs_init(const struct retro_vfs_interface_info* vfs_info)
+{
+   const struct retro_vfs_interface* 
+      vfs_iface           = vfs_info->iface;
+
+   path_stat_cb           = NULL;
+   path_mkdir_cb          = NULL;
+
+   if (vfs_info->required_interface_version < PATH_REQUIRED_VFS_VERSION || !vfs_iface)
+      return;
+
+   path_stat_cb           = vfs_iface->stat;
+   path_mkdir_cb          = vfs_iface->mkdir;
+}
+
+#define path_stat_internal(path, size) ((path_stat_cb != NULL) ? path_stat_cb((path), (size)) : retro_vfs_stat_impl((path), (size)))
+
+#define path_mkdir_norecurse(dir) ((path_mkdir_cb != NULL) ? path_mkdir_cb((dir)) : retro_vfs_mkdir_impl((dir)))
+
+int path_stat(const char *path)
+{
+   return path_stat_internal(path, NULL);
+}
+
+/**
+ * path_is_directory:
+ * @path               : path
+ *
+ * Checks if path is a directory.
+ *
+ * Returns: true (1) if path is a directory, otherwise false (0).
+ */
+bool path_is_directory(const char *path)
+{
+   return (path_stat_internal(path, NULL) & RETRO_VFS_STAT_IS_DIRECTORY) != 0;
+}
+
+bool path_is_character_special(const char *path)
+{
+   return (path_stat_internal(path, NULL) & RETRO_VFS_STAT_IS_CHARACTER_SPECIAL) != 0;
+}
+
+bool path_is_valid(const char *path)
+{
+   return (path_stat_internal(path, NULL) & RETRO_VFS_STAT_IS_VALID) != 0;
+}
+
+int32_t path_get_size(const char *path)
+{
+   int32_t filesize = 0;
+   if (path_stat_internal(path, &filesize) != 0)
+      return filesize;
+
+   return -1;
+}
+
+/**
+ * path_mkdir:
+ * @dir                : directory
+ *
+ * Create directory on filesystem.
+ *
+ * Returns: true (1) if directory could be created, otherwise false (0).
+ **/
+bool path_mkdir(const char *dir)
+{
+   bool         sret  = false;
+   bool norecurse     = false;
+   char     *basedir  = NULL;
+
+   if (!(dir && *dir))
+      return false;
+
+   /* Use heap. Real chance of stack 
+    * overflow if we recurse too hard. */
+   basedir            = strdup(dir);
+
+   if (!basedir)
+	   return false;
+
+   path_parent_dir(basedir);
+
+   if (!*basedir || !strcmp(basedir, dir))
+   {
+      free(basedir);
+      return false;
+   }
+
+#if defined(GEKKO)
+   {
+      size_t len = strlen(basedir);
+
+      /* path_parent_dir() keeps the trailing slash.
+       * On Wii, mkdir() fails if the path has a
+       * trailing slash...
+       * We must therefore remove it. */
+      if (len > 0)
+         if (basedir[len - 1] == '/')
+            basedir[len - 1] = '\0';
+   }
+#endif
+
+   if (path_is_directory(basedir))
+      norecurse = true;
+   else
+   {
+      sret      = path_mkdir(basedir);
+
+      if (sret)
+         norecurse = true;
+   }
+
+   free(basedir);
+
+   if (norecurse)
+   {
+      int ret = path_mkdir_norecurse(dir);
+
+      /* Don't treat this as an error. */
+      if (ret == -2 && path_is_directory(dir))
+         return true;
+
+      return (ret == 0);
+   }
+
+   return sret;
+}
 
 /**
  * path_get_archive_delim:
@@ -260,11 +393,11 @@ void fill_pathname(char *out_path, const char *in_path,
  * present in 'in_path', it will be ignored.
  *
  */
-size_t fill_pathname_noext(char *out_path, const char *in_path,
+void fill_pathname_noext(char *out_path, const char *in_path,
       const char *replace, size_t size)
 {
    strlcpy(out_path, in_path, size);
-   return strlcat(out_path, replace, size);
+   strlcat(out_path, replace, size);
 }
 
 char *find_last_slash(const char *str)
@@ -302,8 +435,12 @@ void fill_pathname_slash(char *path, size_t size)
    /* Try to preserve slash type. */
    if (last_slash != (path + path_len - 1))
    {
-      path[path_len]   = last_slash[0];
-      path[path_len+1] = '\0';
+      char join_str[2];
+
+      join_str[0] = '\0';
+
+      strlcpy(join_str, last_slash, sizeof(join_str));
+      strlcat(path, join_str, size);
    }
 }
 
@@ -324,7 +461,7 @@ void fill_pathname_slash(char *path, size_t size)
  * E.g..: in_dir = "/tmp/some_dir", in_basename = "/some_content/foo.c",
  * replace = ".asm" => in_dir = "/tmp/some_dir/foo.c.asm"
  **/
-size_t fill_pathname_dir(char *in_dir, const char *in_basename,
+void fill_pathname_dir(char *in_dir, const char *in_basename,
       const char *replace, size_t size)
 {
    const char *base = NULL;
@@ -332,7 +469,7 @@ size_t fill_pathname_dir(char *in_dir, const char *in_basename,
    fill_pathname_slash(in_dir, size);
    base = path_basename(in_basename);
    strlcat(in_dir, base, size);
-   return strlcat(in_dir, replace, size);
+   strlcat(in_dir, replace, size);
 }
 
 /**
@@ -343,14 +480,14 @@ size_t fill_pathname_dir(char *in_dir, const char *in_basename,
  *
  * Copies basename of @in_path into @out_path.
  **/
-size_t fill_pathname_base(char *out, const char *in_path, size_t size)
+void fill_pathname_base(char *out, const char *in_path, size_t size)
 {
    const char     *ptr = path_basename(in_path);
 
    if (!ptr)
       ptr = in_path;
 
-   return strlcpy(out, ptr, size);
+   strlcpy(out, ptr, size);
 }
 
 void fill_pathname_base_noext(char *out,
@@ -360,12 +497,12 @@ void fill_pathname_base_noext(char *out,
    path_remove_extension(out);
 }
 
-size_t fill_pathname_base_ext(char *out,
+void fill_pathname_base_ext(char *out,
       const char *in_path, const char *ext,
       size_t size)
 {
    fill_pathname_base_noext(out, in_path, size);
-   return strlcat(out, ext, size);
+   strlcat(out, ext, size);
 }
 
 /**
@@ -460,7 +597,7 @@ void fill_pathname_parent_dir(char *out_dir,
  * E.g.:
  * out_filename = "RetroArch-{month}{day}-{Hours}{Minutes}.{@ext}"
  **/
-size_t fill_dated_filename(char *out_filename,
+void fill_dated_filename(char *out_filename,
       const char *ext, size_t size)
 {
    time_t       cur_time = time(NULL);
@@ -468,7 +605,7 @@ size_t fill_dated_filename(char *out_filename,
 
    strftime(out_filename, size,
          "RetroArch-%m%d-%H%M%S", tm_);
-   return strlcat(out_filename, ext, size);
+   strlcat(out_filename, ext, size);
 }
 
 /**
@@ -722,9 +859,13 @@ char *path_resolve_realpath(char *buf, size_t size, bool resolve_symlinks)
          t++;
       }
       else if (next - p == 1 && p[0] == '.')
+      {
          p += 2;
+      }
       else if (next - p == 0)
+      {
          p += 1;
+      }
       else
       {
          /* fail when truncating */
@@ -761,7 +902,7 @@ end:
  *
  * E.g. path /a/b/e/f.cg with base /a/b/c/d/ turns into ../../e/f.cg
  **/
-size_t path_relative_to(char *out,
+void path_relative_to(char *out,
       const char *path, const char *base, size_t size)
 {
    size_t i;
@@ -772,7 +913,10 @@ size_t path_relative_to(char *out,
    if (strlen(path) >= 2 && strlen(base) >= 2
          && path[1] == ':' && base[1] == ':'
          && path[0] != base[0])
-      return strlcpy(out, path, size);
+   {
+      strlcpy(out, path, size);
+      return;
+   }
 #endif
 
    /* Trim common beginning */
@@ -786,8 +930,7 @@ size_t path_relative_to(char *out,
    for (i = 0; trimmed_base[i]; i++)
       if (trimmed_base[i] == path_default_slash_c())
          strlcat(out, ".." path_default_slash(), size);
-
-   return strlcat(out, trimmed_path, size);
+   strlcat(out, trimmed_path, size);
 }
 
 /**
@@ -827,7 +970,7 @@ void fill_pathname_resolve_relative(char *out_path,
  * Makes sure not to get  two consecutive slashes
  * between directory and path.
  **/
-size_t fill_pathname_join(char *out_path,
+void fill_pathname_join(char *out_path,
       const char *dir, const char *path, size_t size)
 {
    if (out_path != dir)
@@ -836,10 +979,10 @@ size_t fill_pathname_join(char *out_path,
    if (*out_path)
       fill_pathname_slash(out_path, size);
 
-   return strlcat(out_path, path, size);
+   strlcat(out_path, path, size);
 }
 
-size_t fill_pathname_join_special_ext(char *out_path,
+void fill_pathname_join_special_ext(char *out_path,
       const char *dir,  const char *path,
       const char *last, const char *ext,
       size_t size)
@@ -849,25 +992,25 @@ size_t fill_pathname_join_special_ext(char *out_path,
       fill_pathname_slash(out_path, size);
 
    strlcat(out_path, last, size);
-   return strlcat(out_path, ext, size);
+   strlcat(out_path, ext, size);
 }
 
-size_t fill_pathname_join_concat_noext(char *out_path,
+void fill_pathname_join_concat_noext(char *out_path,
       const char *dir, const char *path,
       const char *concat,
       size_t size)
 {
    fill_pathname_noext(out_path, dir, path, size);
-   return strlcat(out_path, concat, size);
+   strlcat(out_path, concat, size);
 }
 
-size_t fill_pathname_join_concat(char *out_path,
+void fill_pathname_join_concat(char *out_path,
       const char *dir, const char *path,
       const char *concat,
       size_t size)
 {
    fill_pathname_join(out_path, dir, path, size);
-   return strlcat(out_path, concat, size);
+   strlcat(out_path, concat, size);
 }
 
 void fill_pathname_join_noext(char *out_path,
@@ -888,7 +1031,7 @@ void fill_pathname_join_noext(char *out_path,
  * Joins a directory (@dir) and path (@path) together
  * using the given delimiter (@delim).
  **/
-size_t fill_pathname_join_delim(char *out_path, const char *dir,
+void fill_pathname_join_delim(char *out_path, const char *dir,
       const char *path, const char delim, size_t size)
 {
    size_t copied;
@@ -902,16 +1045,15 @@ size_t fill_pathname_join_delim(char *out_path, const char *dir,
    out_path[copied+1] = '\0';
 
    if (path)
-      copied = strlcat(out_path, path, size);
-   return copied;
+      strlcat(out_path, path, size);
 }
 
-size_t fill_pathname_join_delim_concat(char *out_path, const char *dir,
+void fill_pathname_join_delim_concat(char *out_path, const char *dir,
       const char *path, const char delim, const char *concat,
       size_t size)
 {
    fill_pathname_join_delim(out_path, dir, path, delim, size);
-   return strlcat(out_path, concat, size);
+   strlcat(out_path, concat, size);
 }
 
 /**
@@ -929,7 +1071,7 @@ size_t fill_pathname_join_delim_concat(char *out_path, const char *dir,
  * E.g.: "/path/to/game.img" -> game.img
  *       "/path/to/myarchive.7z#folder/to/game.img" -> game.img
  */
-size_t fill_short_pathname_representation(char* out_rep,
+void fill_short_pathname_representation(char* out_rep,
       const char *in_path, size_t size)
 {
    char path_short[PATH_MAX_LENGTH];
@@ -939,7 +1081,7 @@ size_t fill_short_pathname_representation(char* out_rep,
    fill_pathname(path_short, path_basename(in_path), "",
             sizeof(path_short));
 
-   return strlcpy(out_rep, path_short, size);
+   strlcpy(out_rep, path_short, size);
 }
 
 void fill_short_pathname_representation_noext(char* out_rep,
@@ -1157,24 +1299,20 @@ void fill_pathname_application_path(char *s, size_t len)
       CFStringRef bundle_path = CFURLCopyPath(bundle_url);
       CFStringGetCString(bundle_path, s, len, kCFStringEncodingUTF8);
 #ifdef HAVE_COCOATOUCH
-      {
-         /* This needs to be done so that the path becomes 
-          * /private/var/... and this
-          * is used consistently throughout for the iOS bundle path */
-         char resolved_bundle_dir_buf[PATH_MAX_LENGTH] = {0};
-         if (realpath(s, resolved_bundle_dir_buf))
-         {
-            strlcpy(s, resolved_bundle_dir_buf, len - 1);
-            strlcat(s, "/", len);
-         }
-      }
+       // This needs to be done so that the path becomes /private/var/... and this
+       // is used consistently throughout for the iOS bundle path
+       char resolved_bundle_dir_buf[PATH_MAX_LENGTH] = {0};
+       if (realpath(s, resolved_bundle_dir_buf))
+       {
+           strlcpy(s,resolved_bundle_dir_buf, len);
+           strlcat(s,"/",len);
+       }
 #endif
 
       CFRelease(bundle_path);
       CFRelease(bundle_url);
 #ifndef HAVE_COCOATOUCH
-      /* Not sure what this does but it breaks 
-       * stuff for iOS, so skipping */
+      // Not sure what this does but it breaks stuff for iOS so skipping
       retro_assert(strlcat(s, "nobin", len) < len);
 #endif
       return;
@@ -1249,8 +1387,8 @@ void fill_pathname_home_dir(char *s, size_t len)
 
 bool is_path_accessible_using_standard_io(const char *path)
 {
-   bool result                = true;
 #ifdef __WINRT__
+   bool result;
    size_t         path_sizeof = PATH_MAX_LENGTH * sizeof(char);
    char *relative_path_abbrev = (char*)malloc(path_sizeof);
    fill_pathname_abbreviate_special(relative_path_abbrev, path, path_sizeof);
@@ -1258,6 +1396,8 @@ bool is_path_accessible_using_standard_io(const char *path)
    result = strlen(relative_path_abbrev) >= 2 && (relative_path_abbrev[0] == ':' || relative_path_abbrev[0] == '~') && path_char_is_slash(relative_path_abbrev[1]);
 
    free(relative_path_abbrev);
-#endif
    return result;
+#else
+   return true;
+#endif
 }

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -1,4 +1,4 @@
-/* Copyright  (C) 2010-2020 The RetroArch team
+/* Copyright  (C) 2010-2019 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (file_path.h).
@@ -178,7 +178,7 @@ char *path_resolve_realpath(char *buf, size_t size, bool resolve_symlinks);
  *
  * E.g. path /a/b/e/f.cgp with base /a/b/c/d/ turns into ../../e/f.cgp
  **/
-size_t path_relative_to(char *out, const char *path, const char *base, size_t size);
+void path_relative_to(char *out, const char *path, const char *base, size_t size);
 
 /**
  * path_is_absolute:
@@ -226,7 +226,7 @@ void fill_pathname(char *out_path, const char *in_path,
  * E.g.:
  * out_filename = "RetroArch-{month}{day}-{Hours}{Minutes}.{@ext}"
  **/
-size_t fill_dated_filename(char *out_filename,
+void fill_dated_filename(char *out_filename,
       const char *ext, size_t size);
 
 /**
@@ -259,7 +259,7 @@ void fill_str_dated_filename(char *out_filename,
  * present in 'in_path', it will be ignored.
  *
  */
-size_t fill_pathname_noext(char *out_path, const char *in_path,
+void fill_pathname_noext(char *out_path, const char *in_path,
       const char *replace, size_t size);
 
 /**
@@ -289,7 +289,7 @@ char *find_last_slash(const char *str);
  * E.g..: in_dir = "/tmp/some_dir", in_basename = "/some_content/foo.c",
  * replace = ".asm" => in_dir = "/tmp/some_dir/foo.c.asm"
  **/
-size_t fill_pathname_dir(char *in_dir, const char *in_basename,
+void fill_pathname_dir(char *in_dir, const char *in_basename,
       const char *replace, size_t size);
 
 /**
@@ -300,12 +300,12 @@ size_t fill_pathname_dir(char *in_dir, const char *in_basename,
  *
  * Copies basename of @in_path into @out_path.
  **/
-size_t fill_pathname_base(char *out_path, const char *in_path, size_t size);
+void fill_pathname_base(char *out_path, const char *in_path, size_t size);
 
 void fill_pathname_base_noext(char *out_dir,
       const char *in_path, size_t size);
 
-size_t fill_pathname_base_ext(char *out,
+void fill_pathname_base_ext(char *out,
       const char *in_path, const char *ext,
       size_t size);
 
@@ -376,20 +376,20 @@ void fill_pathname_resolve_relative(char *out_path, const char *in_refpath,
  * Makes sure not to get  two consecutive slashes
  * between directory and path.
  **/
-size_t fill_pathname_join(char *out_path, const char *dir,
+void fill_pathname_join(char *out_path, const char *dir,
       const char *path, size_t size);
 
-size_t fill_pathname_join_special_ext(char *out_path,
+void fill_pathname_join_special_ext(char *out_path,
       const char *dir,  const char *path,
       const char *last, const char *ext,
       size_t size);
 
-size_t fill_pathname_join_concat_noext(char *out_path,
+void fill_pathname_join_concat_noext(char *out_path,
       const char *dir, const char *path,
       const char *concat,
       size_t size);
 
-size_t fill_pathname_join_concat(char *out_path,
+void fill_pathname_join_concat(char *out_path,
       const char *dir, const char *path,
       const char *concat,
       size_t size);
@@ -408,10 +408,10 @@ void fill_pathname_join_noext(char *out_path,
  * Joins a directory (@dir) and path (@path) together
  * using the given delimiter (@delim).
  **/
-size_t fill_pathname_join_delim(char *out_path, const char *dir,
+void fill_pathname_join_delim(char *out_path, const char *dir,
       const char *path, const char delim, size_t size);
 
-size_t fill_pathname_join_delim_concat(char *out_path, const char *dir,
+void fill_pathname_join_delim_concat(char *out_path, const char *dir,
       const char *path, const char delim, const char *concat,
       size_t size);
 
@@ -430,7 +430,7 @@ size_t fill_pathname_join_delim_concat(char *out_path, const char *dir,
  * E.g.: "/path/to/game.img" -> game.img
  *       "/path/to/myarchive.7z#folder/to/game.img" -> game.img
  */
-size_t fill_short_pathname_representation(char* out_rep,
+void fill_short_pathname_representation(char* out_rep,
       const char *in_path, size_t size);
 
 void fill_short_pathname_representation_noext(char* out_rep,

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1,9 +1,5 @@
 #include "libretro.h"
 #include "libretro-core.h"
-#include "vkbd.h"
-#include "string/stdstring.h"
-#include "file/file_path.h"
-#include "compat/strcasestr.h"
 
 #include "archdep.h"
 #include "c64.h"
@@ -12,7 +8,10 @@
 #include "machine.h"
 #include "snapshot.h"
 #include "autostart.h"
+#include "drive.h"
 #include "tape.h"
+#include "vdrive.h"
+#include "diskimage.h"
 #include "attach.h"
 #include "interrupt.h"
 #include "datasette.h"
@@ -44,7 +43,7 @@ char slash = FSDEV_DIR_SEP_CHR;
 bool retro_load_ok = false;
 static bool noautostart = false;
 static char* autostartString = NULL;
-char RETRO_DIR[512];
+char RETRO_DIR[RETRO_PATH_MAX];
 static char* core_options_legacy_strings = NULL;
 
 static snapshot_stream_t* snapshot_stream = NULL;
@@ -182,10 +181,11 @@ char resources_var_border[20] = "VICIIBorderMode";
 #endif
 //VICE DEF END
 
-const char *retro_save_directory;
-const char *retro_system_directory;
-const char *retro_content_directory;
-char retro_system_data_directory[512];
+char retro_save_directory[RETRO_PATH_MAX] = {0};
+char retro_temp_directory[RETRO_PATH_MAX] = {0};
+char retro_system_directory[RETRO_PATH_MAX] = {0};
+char retro_content_directory[RETRO_PATH_MAX] = {0};
+char retro_system_data_directory[RETRO_PATH_MAX] = {0};
 
 retro_input_state_t input_state_cb;
 retro_input_poll_t input_poll_cb;
@@ -195,16 +195,9 @@ static retro_audio_sample_t audio_cb;
 static retro_audio_sample_batch_t audio_batch_cb;
 static retro_environment_t environ_cb;
 
-#include "retro_strings.h"
-#include "retro_files.h"
-#include "retro_disk_control.h"
 static dc_storage* dc;
-enum {
-	RUNSTATE_FIRST_START = 0,
-	RUNSTATE_LOADED_CONTENT,
-	RUNSTATE_RUNNING,
-};
-static int runstate = RUNSTATE_FIRST_START; /* used to detect whether we are just starting the core from scratch */
+
+int runstate = RUNSTATE_FIRST_START; /* used to detect whether we are just starting the core from scratch */
 /* runstate = RUNSTATE_FIRST_START: first time retro_run() is called after loading and starting core */
 /* runstate = RUNSTATE_LOADED_CONTENT: load content was selected while core is running, so do an autostart_reset() */
 /* runstate = RUNSTATE_RUNNING: core is running normally */
@@ -222,12 +215,6 @@ static char* x_strdup(const char* str)
 unsigned int retro_get_borders(void)
 {
    return RETROBORDERS;
-}
-
-unsigned int retro_toggle_vkbd_alpha(void)
-{
-   vkbd_alpha = (vkbd_alpha == 255) ? opt_vkbd_alpha : 255;
-   return vkbd_alpha;
 }
 
 void retro_set_input_state(retro_input_state_t cb)
@@ -368,7 +355,7 @@ static int check_joystick_control(const char* filename)
 static int get_image_unit()
 {
     int unit = dc->unit;
-    if (unit == 0 && dc->index < dc->count)
+    if (dc->index < dc->count)
     {
         if (strendswith(dc->files[dc->index], "tap") || strendswith(dc->files[dc->index], "t64"))
            unit = 1;
@@ -413,7 +400,7 @@ static void log_disk_in_tray(bool display)
 
 static int process_cmdline(const char* argv)
 {
-    int i=0;
+    int i = 0;
     bool is_fliplist = false;
     int joystick_control = 0;
 
@@ -464,10 +451,76 @@ static int process_cmdline(const char* argv)
             cur_port_locked = 1;
         }
 
+        // ZIP
+        if (strendswith(argv, ".zip"))
+        {
+            char full_path[RETRO_PATH_MAX] = {0};
+            snprintf(full_path, sizeof(full_path), "%s", argv);
+
+            char zip_basename[RETRO_PATH_MAX] = {0};
+            snprintf(zip_basename, sizeof(zip_basename), "%s", path_basename(full_path));
+            snprintf(zip_basename, sizeof(zip_basename), "%s", path_remove_extension(zip_basename));
+            snprintf(retro_temp_directory, sizeof(retro_temp_directory), "%s%s%s", retro_save_directory, FSDEV_DIR_SEP_STR, "ZIP");
+            char zip_path[RETRO_PATH_MAX] = {0};
+            snprintf(zip_path, sizeof(zip_path), "%s%s%s", retro_temp_directory, FSDEV_DIR_SEP_STR, zip_basename);
+
+            path_mkdir(zip_path);
+            zip_uncompress(full_path, zip_path, NULL);
+
+            // Default to directory mode
+            int zip_mode = 0;
+            snprintf(full_path, sizeof(full_path), "%s", zip_path);
+
+            FILE *zip_m3u;
+            char zip_m3u_buf[2048] = {0};
+            char zip_m3u_path[RETRO_PATH_MAX] = {0};
+            snprintf(zip_m3u_path, sizeof(zip_m3u_path), "%s%s%s.m3u", zip_path, FSDEV_DIR_SEP_STR, zip_basename);
+
+            DIR *zip_dir;
+            struct dirent *zip_dirp;
+            zip_dir = opendir(zip_path);
+            while ((zip_dirp = readdir(zip_dir)) != NULL)
+            {
+               if (zip_dirp->d_name[0] == '.' || strendswith(zip_dirp->d_name, ".m3u") || zip_mode > 1)
+                  continue;
+
+               // Multi file mode, generate playlist
+               if (dc_get_image_type(zip_dirp->d_name) == DC_IMAGE_TYPE_FLOPPY
+                || dc_get_image_type(zip_dirp->d_name) == DC_IMAGE_TYPE_TAPE
+               )
+               {
+                  zip_mode = 1;
+                  snprintf(zip_m3u_buf+strlen(zip_m3u_buf), sizeof(zip_m3u_buf), "%s\n", zip_dirp->d_name);
+               }
+               // Single file mode
+               else if (dc_get_image_type(zip_dirp->d_name) == DC_IMAGE_TYPE_MEM)
+               {
+                  zip_mode = 2;
+                  snprintf(full_path, sizeof(full_path), "%s%s%s", zip_path, FSDEV_DIR_SEP_STR, zip_dirp->d_name);
+               }
+            }
+            closedir(zip_dir);
+
+            switch (zip_mode)
+            {
+               case 0: // Extracted path
+               case 2: // Single image
+                  break;
+               case 1: // Generated playlist
+                  zip_m3u = fopen(zip_m3u_path, "w");
+                  fprintf(zip_m3u, "%s", zip_m3u_buf);
+                  fclose(zip_m3u);
+                  snprintf(full_path, sizeof(full_path), "%s", zip_m3u_path);
+                  break;
+            }
+
+            argv = full_path;
+        }
+
 #if defined(__X64__) || defined(__X64SC__)
-        /* Disable JiffyDOS with PRGs & CRTs */
-        if (strendswith(argv, "prg")
-         || strendswith(argv, "crt"))
+        // Disable JiffyDOS with PRGs & CRTs
+        if (strendswith(argv, ".prg")
+         || strendswith(argv, ".crt"))
             opt_jiffydos_allow = 0;
         else
             opt_jiffydos_allow = 1;
@@ -531,7 +584,7 @@ static int process_cmdline(const char* argv)
         else
         {
             // Some debugging
-            log_cb(RETRO_LOG_INFO, "m3u/vfl file parsed, %d file(s) found\n", dc->count);
+            log_cb(RETRO_LOG_INFO, "M3U/VFL parsed, %d file(s) found\n", dc->count);
 
             if (!dc->command)
             {
@@ -613,7 +666,7 @@ static int process_cmdline(const char* argv)
         if (is_fliplist)
         {
             // Some debugging
-            log_cb(RETRO_LOG_INFO, "m3u file parsed, %d file(s) found\n", dc->count);
+            log_cb(RETRO_LOG_INFO, "M3U/VFL parsed, %d file(s) found\n", dc->count);
         }
     }
 
@@ -3707,7 +3760,36 @@ static bool retro_set_eject_state(bool ejected)
             if (unit == 1)
                 tape_image_attach(unit, dc->files[dc->index]);
             else
+            {
                 file_system_attach_disk(unit, dc->files[dc->index]);
+
+                int drive_type;
+                resources_get_int("Drive8Type", &drive_type);
+
+                // Autodetect drive type
+                vdrive_t *vdrive;
+                struct disk_image_s *diskimg;
+
+                vdrive = file_system_get_vdrive(8);
+                if (vdrive == NULL)
+                    log_cb(RETRO_LOG_ERROR, "Failed to get vdrive reference for unit 8.\n");
+                else
+                {
+                    diskimg = vdrive->image;
+                    if (diskimg == NULL)
+                        log_cb(RETRO_LOG_ERROR, "Failed to get disk image for unit 8.\n");
+                    else
+                    {
+                        log_cb(RETRO_LOG_INFO, "Autodetected image type %u.\n", diskimg->type);
+                        if (log_resources_set_int("Drive8Type", diskimg->type) < 0)
+                            log_cb(RETRO_LOG_ERROR, "Failed to set drive type.\n");
+
+                        // Change from 1581 to 1541 will not detect disk properly without reattaching (?!)
+                        if (diskimg->type != drive_type)
+                            file_system_attach_disk(unit, dc->files[dc->index]);
+                    }
+                }
+            }
 
             display_current_image(dc->files[dc->index], true);
             return true;
@@ -3741,7 +3823,7 @@ static unsigned retro_get_image_index(void)
  * The implementation supports setting "no disk" by using an
  * index >= get_num_images().
  */
-static bool retro_set_image_index(unsigned index)
+bool retro_set_image_index(unsigned index)
 {
     // Switch disk in drive
     if (dc)
@@ -3784,8 +3866,7 @@ static unsigned retro_get_num_images(void)
  * returned 4 before.
  * Index 1 will be removed, and the new index is 3.
  */
-static bool retro_replace_image_index(unsigned index,
-      const struct retro_game_info *info)
+static bool retro_replace_image_index(unsigned index, const struct retro_game_info *info)
 {
     if (dc)
     {
@@ -3896,8 +3977,8 @@ void retro_init(void)
 {
    struct retro_log_callback log;
 
-	// Init disk control context
-   	dc = dc_create();
+   // Init disk control context
+   dc = dc_create();
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &log))
       log_cb = log.log;
@@ -3905,32 +3986,41 @@ void retro_init(void)
       log_cb = fallback_log;
 
    const char *system_dir = NULL;
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir) && system_dir)
    {
       // if defined, use the system directory
-      retro_system_directory=system_dir;
+      strlcpy(
+            retro_system_directory,
+            system_dir,
+            sizeof(retro_system_directory));
    }
 
    const char *content_dir = NULL;
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY, &content_dir) && content_dir)
    {
       // if defined, use the system directory
-      retro_content_directory=content_dir;
+      strlcpy(
+            retro_content_directory,
+            content_dir,
+            sizeof(retro_content_directory));
    }
 
    const char *save_dir = NULL;
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &save_dir) && save_dir)
    {
       // If save directory is defined use it, otherwise use system directory
-      retro_save_directory = *save_dir ? save_dir : retro_system_directory;
+      strlcpy(
+            retro_save_directory,
+            string_is_empty(save_dir) ? retro_system_directory : save_dir,
+            sizeof(retro_save_directory));
    }
    else
    {
       // make retro_save_directory the same in case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY is not implemented by the frontend
-      retro_save_directory=retro_system_directory;
+      strlcpy(
+            retro_save_directory,
+            retro_system_directory,
+            sizeof(retro_save_directory));
    }
 
    if (retro_system_directory==NULL)
@@ -4029,13 +4119,17 @@ void retro_init(void)
 
 void retro_deinit(void)
 {
-   /* Clean the disk control context */
+   // Clean the disk control context
    if (dc)
       dc_free(dc);
+
+   // Clean legacy strings
    if (core_options_legacy_strings)
-   {
-	   free(core_options_legacy_strings);
-   }
+      free(core_options_legacy_strings);
+
+   // Clean ZIP temp
+   if (retro_temp_directory && path_is_directory(retro_temp_directory))
+      remove_recurse(retro_temp_directory);
 }
 
 unsigned retro_api_version(void)
@@ -4063,7 +4157,7 @@ void retro_get_system_info(struct retro_system_info *info)
    info->valid_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf";
 #endif
    info->need_fullpath    = true;
-   info->block_extract    = false;
+   info->block_extract    = true;
 }
 
 double retro_get_aspect_ratio(unsigned int width, unsigned int height)

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -15,7 +15,9 @@
 #include "attach.h"
 #include "interrupt.h"
 #include "datasette.h"
-#ifndef __PET__
+#ifdef __PET__
+#include "keyboard.h"
+#else
 #include "cartridge.h"
 #endif
 #include "initcmdline.h"
@@ -1045,12 +1047,11 @@ void retro_set_environment(retro_environment_t cb)
             { "4032B", NULL },
             { "8032", NULL },
             { "8096", NULL },
-            { "8096", NULL },
             { "8296", NULL },
-            { "SUPERPET", NULL },
+            { "SUPERPET", "SuperPET" },
             { NULL, NULL },
          },
-         "2001"
+         "8032"
       },
 #elif defined(__CBM2__)
       {
@@ -2622,7 +2623,11 @@ static void update_variables(void)
       else if (strcmp(var.value, "SUPERPET") == 0) modl=PETMODEL_SUPERPET;
       
       if (retro_ui_finalized && RETROC64MODL != modl)
+      {
          petmodel_set(modl);
+         // Keyboard layout refresh required. All models below 8032 except B models use graphics layout, others use business.
+         keyboard_init();
+      }
       RETROC64MODL=modl;
    }
 #elif defined(__CBM2__)

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -4353,7 +4353,7 @@ void retro_run(void)
       /* Update geometry if model or zoom mode changes */
       if ((lastW == retroW && lastH == retroH) && zoom_mode_id != zoom_mode_id_prev)
          update_geometry(1);
-      else if (lastW != retroW || lastH != retroH)
+      else if (lastW != retroW || lastH != retroH || retro_region != retro_get_region())
          update_geometry(0);
    }
 

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -6,8 +6,17 @@
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
-
 #include <stdbool.h>
+#include <dirent.h>
+
+#include "vkbd.h"
+#include "retroglue.h"
+#include "retro_files.h"
+#include "retro_strings.h"
+#include "retro_disk_control.h"
+#include "string/stdstring.h"
+#include "file/file_path.h"
+#include "compat/strcasestr.h"
 
 #define MATRIX(a,b) (((a) << 3) | (b))
 #define RGB565(r, g, b) ((((r>>3)<<11) | ((g>>2)<<5) | (b>>3)))
@@ -101,5 +110,10 @@ extern int RETROUSERPORTJOY;
 extern void maincpu_mainloop_retro(void);
 extern long GetTicks(void);
 extern unsigned int retro_get_borders(void);
-extern unsigned int retro_toggle_vkbd_alpha(void);
+
+enum {
+	RUNSTATE_FIRST_START = 0,
+	RUNSTATE_LOADED_CONTENT,
+	RUNSTATE_RUNNING,
+};
 #endif

--- a/libretro/retro_disk_control.h
+++ b/libretro/retro_disk_control.h
@@ -35,12 +35,21 @@ extern int disk_label_mode;
 // Disk control structure and functions
 #define DC_MAX_SIZE 20
 
+enum dc_image_type {
+	DC_IMAGE_TYPE_NONE = 0,
+	DC_IMAGE_TYPE_FLOPPY,
+	DC_IMAGE_TYPE_TAPE,
+	DC_IMAGE_TYPE_MEM,
+	DC_IMAGE_TYPE_UNKNOWN
+};
+
 struct dc_storage
 {
 	char* command;
 	char* files[DC_MAX_SIZE];
 	char* labels[DC_MAX_SIZE];
 	char* names[DC_MAX_SIZE];
+	enum dc_image_type types[DC_MAX_SIZE];
 	unsigned unit;
 	unsigned count;
 	int index;
@@ -56,5 +65,6 @@ void dc_free(dc_storage* dc);
 void dc_reset(dc_storage* dc);
 bool dc_replace_file(dc_storage* dc, int index, const char* filename);
 bool dc_remove_file(dc_storage* dc, int index);
+enum dc_image_type dc_get_image_type(const char* filename);
 
 #endif

--- a/libretro/retroglue.c
+++ b/libretro/retroglue.c
@@ -1,0 +1,163 @@
+#include "libretro-core.h"
+#include "archdep.h"
+
+#include "deps/libz/zlib.h"
+#include "deps/libz/unzip.h"
+#include "file/file_path.h"
+void zip_uncompress(char *in, char *out, char *lastfile)
+{
+    unzFile uf = NULL;
+    unz_file_info file_info;
+    uf = unzOpen(in);
+
+    uLong i;
+    unz_global_info gi;
+    int err;
+    err = unzGetGlobalInfo (uf, &gi);
+
+    const char* password = NULL;
+    int size_buf = 8192;
+
+    for (i = 0; i < gi.number_entry; i++)
+    {
+        char filename_inzip[256];
+        char filename_withpath[512];
+        filename_inzip[0] = '\0';
+        filename_withpath[0] = '\0';
+        char* filename_withoutpath;
+        char* p;
+        unz_file_info file_info;
+        FILE *fout = NULL;
+        void* buf;
+
+        buf = (void*)malloc(size_buf);
+        if (buf == NULL)
+        {
+            fprintf(stderr, "Unzip: Error allocating memory\n");
+            return;
+        }
+
+        err = unzGetCurrentFileInfo(uf, &file_info, filename_inzip, sizeof(filename_inzip), NULL, 0, NULL, 0);
+        snprintf(filename_withpath, sizeof(filename_withpath), "%s%s%s", out, FSDEV_DIR_SEP_STR, filename_inzip);
+        if ((dc_get_image_type(filename_inzip) == DC_IMAGE_TYPE_FLOPPY || dc_get_image_type(filename_inzip) == DC_IMAGE_TYPE_TAPE) && lastfile != NULL)
+            snprintf(lastfile, RETRO_PATH_MAX, "%s", filename_inzip);
+        p = filename_withoutpath = filename_inzip;
+        while ((*p) != '\0')
+        {
+            if (((*p) == '/') || ((*p) == '\\'))
+                filename_withoutpath = p+1;
+            p++;
+        }
+
+        if ((*filename_withoutpath) == '\0')
+        {
+            fprintf(stdout, "Unzip mkdir:   %s\n", filename_withpath);
+            path_mkdir(filename_withpath);
+        }
+        else
+        {
+            const char* write_filename;
+            int skip = 0;
+
+            write_filename = filename_withpath;
+
+            err = unzOpenCurrentFilePassword(uf, password);
+            if (err != UNZ_OK)
+            {
+                fprintf(stderr, "Unzip: Error %d with zipfile in unzOpenCurrentFilePassword: %s\n", err, write_filename);
+            }
+
+            if ((skip == 0) && (err == UNZ_OK))
+            {
+                fout = fopen(write_filename, "wb");
+                if (fout == NULL)
+                {
+                    fprintf(stderr, "Unzip: Error opening %s\n", write_filename);
+                }
+            }
+
+            if (fout != NULL)
+            {
+                fprintf(stdout, "Unzip extract: %s\n", write_filename);
+
+                do
+                {
+                    err = unzReadCurrentFile(uf, buf, size_buf);
+                    if (err < 0)
+                    {
+                        fprintf(stderr, "Unzip: Error %d with zipfile in unzReadCurrentFile\n", err);
+                        break;
+                    }
+                    if (err > 0)
+                    {
+                        if (!fwrite(buf, err, 1, fout))
+                        {
+                            fprintf(stderr, "Unzip: Error in writing extracted file\n");
+                            err = UNZ_ERRNO;
+                            break;
+                        }
+                    }
+                }
+                while (err > 0);
+                if (fout)
+                    fclose(fout);
+            }
+
+            if (err == UNZ_OK)
+            {
+                err = unzCloseCurrentFile(uf);
+                if (err != UNZ_OK)
+                {
+                    fprintf(stderr, "Unzip: Error %d with zipfile in unzCloseCurrentFile\n", err);
+                }
+            }
+            else
+                unzCloseCurrentFile(uf);
+        }
+
+        free(buf);
+
+        if ((i+1) < gi.number_entry)
+        {
+            err = unzGoToNextFile(uf);
+            if (err != UNZ_OK)
+            {
+                fprintf(stderr, "Unzip: Error %d with zipfile in unzGoToNextFile\n", err);
+                break;
+            }
+        }
+    }
+
+    if (uf)
+    {
+        unzCloseCurrentFile(uf);
+        unzClose(uf);
+        uf = NULL;
+    }
+}
+
+void remove_recurse(const char *path)
+{
+   struct dirent *dirp;
+   char filename[RETRO_PATH_MAX];
+   DIR *dir = opendir(path);
+   if (dir == NULL)
+      return;
+
+   while ((dirp = readdir(dir)) != NULL)
+   {
+      if (dirp->d_name[0] == '.')
+         continue;
+
+      sprintf(filename, "%s%s%s", path, FSDEV_DIR_SEP_STR, dirp->d_name);
+      fprintf(stdout, "Unzip clean: %s\n", filename);
+
+      if (path_is_directory(filename))
+         remove_recurse(filename);
+      else
+         remove(filename);
+   }
+
+   closedir(dir);
+   rmdir(path);
+}

--- a/libretro/retroglue.h
+++ b/libretro/retroglue.h
@@ -1,0 +1,10 @@
+#ifndef _RETRO_GLUE_H_
+#define _RETRO_GLUE_H_
+
+#include "deps/libz/zlib.h"
+#include "deps/libz/unzip.h"
+void zip_uncompress(char *in, char *out, char *lastfile);
+
+void remove_recurse(const char *path);
+extern int log_resources_set_int(const char *name, int value);
+#endif

--- a/vice/src/arch/libretro/archdep.c
+++ b/vice/src/arch/libretro/archdep.c
@@ -164,7 +164,7 @@ const char *archdep_program_name(void)
     if (program_name == NULL) {
         char *p;
 #if defined(__WIN32__) 
-  p = strrchr(argv0, '\\');
+        p = strrchr(argv0, '\\');
 #else
         p = strrchr(argv0, '/');
 #endif
@@ -241,7 +241,6 @@ char *archdep_default_sysfile_pathlist(const char *emu_id)
                                    NULL);
         lib_free(default_path_temp);
 #elif defined(__WIN32__) 
-  
        default_path = util_concat( home_path, "\\", emu_id, ARCHDEP_FINDPATH_SEPARATOR_STRING,
                                    home_path, "\\DRIVES", ARCHDEP_FINDPATH_SEPARATOR_STRING,
                                    home_path, "\\PRINTER", NULL);
@@ -280,10 +279,9 @@ char *archdep_make_backup_filename(const char *fname)
 char *archdep_default_resource_file_name(void)
 {
     if(archdep_pref_path==NULL) {
-      const char *home;
-      
-      home = archdep_home_path();
-      return util_concat(home, "/.vice/vicerc", NULL);
+        const char *home;
+        home = archdep_home_path();
+        return util_concat(home, "/.vice/vicerc", NULL);
     } else {
         if (opt_read_vicerc)
             return util_concat(archdep_pref_path, FSDEV_DIR_SEP_STR, "vicerc", NULL);
@@ -321,7 +319,7 @@ char *archdep_default_save_resource_file_name(void)
 #if defined(__WIN32__)
         mkdir(viceuserdir);
 #elif defined(VITA)
-        sceIoMkdir(viceuserdir,0777);
+        sceIoMkdir(viceuserdir, 0777);
 #else
         mkdir(viceuserdir, 0700);
 #endif
@@ -370,7 +368,7 @@ int archdep_default_logger(const char *level_string, const char *txt) {
 int archdep_path_is_relative(const char *path)
 {
 #ifdef __WIN32__
-  return !((isalpha(path[0]) && path[1] == ':') || path[0] == '/' || path[0] == '\\');
+    return !((isalpha(path[0]) && path[1] == ':') || path[0] == '/' || path[0] == '\\');
 #elif defined(VITA) || defined(__SWITCH__) || defined(WIIU) || defined(_3DS)
     if (path == NULL)
         return 0;
@@ -589,12 +587,16 @@ int archdep_file_set_gzip(const char *name)
 int archdep_mkdir(const char *pathname, int mode)
 {
 #if defined(__WIN32__)
-       return mkdir(pathname);
+    return mkdir(pathname);
 #elif defined(VITA)
-       return sceIoMkdir(pathname,0777);
+    return sceIoMkdir(pathname, 0777);
 #else
-     return mkdir(pathname, (mode_t)mode);
+    return mkdir(pathname, (mode_t)mode);
 #endif
+}
+
+int archdep_rmdir(const char *pathname)
+{
 }
 
 int archdep_stat(const char *file_name, unsigned int *len, unsigned int *isdir)
@@ -642,24 +644,6 @@ void archdep_shutdown(void)
 
     lib_free(argv0);
     lib_free(boot_path);
-
-}
-
-signed long kbd_arch_keyname_to_keynum(char *keyname) {
-	return (signed long)atoi(keyname);
-}
-
-const char *kbd_arch_keynum_to_keyname(signed long keynum) {
-	static char keyname[20];
-
-	memset(keyname, 0, 20);
-	sprintf(keyname, "%li", keynum);
-	return keyname;
-}
-
-void kbd_arch_init()
-{
-  keyboard_clear_keymatrix();
 }
 
 /*
@@ -671,12 +655,17 @@ int archdep_network_init(void)
 void archdep_network_shutdown(void)
 {
 }
+
+void archdep_vice_exit(int excode)
+{
+    exit(excode);
+}
 */
 
 char *archdep_get_runtime_os(void)
 {
 #ifndef __WIN32__
-     return "*nix";
+    return "*nix";
 #else
     return "win*";
 #endif
@@ -686,18 +675,3 @@ char *archdep_get_runtime_cpu(void)
 {
     return "Unknown CPU";
 }
-
-
-int archdep_rmdir(const char *pathname)
-{
-}
-
-
-
-
-/*
-void archdep_vice_exit(int excode)
-{
-    exit(excode);
-}
-*/

--- a/vice/src/arch/libretro/defaultkey.inc
+++ b/vice/src/arch/libretro/defaultkey.inc
@@ -1,290 +1,437 @@
-static void retro_defaultkeyboard(){
-
-	//log_message(keyboard_log, "Loading default retro keymap:");
-
+static void libretro_keyboard()
+{
     if (keyconvmap != NULL) {
         keyboard_keyconvmap_free();
     }
 
     keyboard_keyconvmap_alloc();
-
-	/*
-	!CLEAR
-	!LSHIFT 1 7
-	!RSHIFT 6 4
-	!VSHIFT RSHIFT
-	!SHIFTL LSHIFT
-	*/
-
-        keyboard_keyword_clear();
-
-	kbd_lshiftrow = 1;
-	kbd_lshiftcol = 7;
-	kbd_rshiftrow = 6;
-	kbd_rshiftcol = 4;
-	vshift=KEY_RSHIFT;
-	shiftl=KEY_LSHIFT;
+    keyboard_keyword_clear();
 
 #if defined(__VIC20__)
-keyboard_parse_set_pos_row(27, 0, 3, 8);                /*          ESC -> Run/Stop     */
-keyboard_parse_set_pos_row(49, 0, 0, 8);                /*            1 -> 1            */
-keyboard_parse_set_pos_row(50, 0, 7, 8);                /*            2 -> 2            */
-keyboard_parse_set_pos_row(51, 1, 0, 8);                /*            3 -> 3            */
-keyboard_parse_set_pos_row(52, 1, 7, 8);                /*            4 -> 4            */
-keyboard_parse_set_pos_row(53, 2, 0, 8);                /*            5 -> 5            */
-keyboard_parse_set_pos_row(54, 2, 7, 8);                /*            6 -> 6            */
-keyboard_parse_set_pos_row(55, 3, 0, 8);                /*            7 -> 7            */
-keyboard_parse_set_pos_row(56, 3, 7, 8);                /*            8 -> 8            */
-keyboard_parse_set_pos_row(57, 4, 0, 8);                /*            9 -> 9            */
-keyboard_parse_set_pos_row(48, 4, 7, 8);                /*            0 -> 0            */
-keyboard_parse_set_pos_row(45, 5, 0, 8);                /*        Minus -> Plus         */
-keyboard_parse_set_pos_row(61, 5, 7, 8);                /*        Equal -> Minus        */
-keyboard_parse_set_pos_row(8, 7, 0, 8);                 /*    Backspace -> Del          */
-keyboard_parse_set_pos_row(9, 0, 2, 8);                 /*          TAB -> Ctrl         */
-keyboard_parse_set_pos_row(113, 0, 6, 8);               /*            Q -> Q            */
-keyboard_parse_set_pos_row(119, 1, 1, 8);               /*            W -> W            */
-keyboard_parse_set_pos_row(101, 1, 6, 8);               /*            E -> E            */
-keyboard_parse_set_pos_row(114, 2, 1, 8);               /*            R -> R            */
-keyboard_parse_set_pos_row(116, 2, 6, 8);               /*            T -> T            */
-keyboard_parse_set_pos_row(121, 3, 1, 8);               /*            Y -> Y            */
-keyboard_parse_set_pos_row(117, 3, 6, 8);               /*            U -> U            */
-keyboard_parse_set_pos_row(105, 4, 1, 8);               /*            I -> I            */
-keyboard_parse_set_pos_row(111, 4, 6, 8);               /*            O -> O            */
-keyboard_parse_set_pos_row(112, 5, 1, 8);               /*            P -> P            */
-keyboard_parse_set_pos_row(91, 5, 6, 8);                /*            [ -> @            */
-keyboard_parse_set_pos_row(93, 6, 1, 8);                /*            ] -> *            */
-keyboard_parse_set_pos_row(13, 7, 1, 8);                /*       Return -> Return       */
-keyboard_parse_set_pos_row(306, 0, 5, 8);               /*    Left Ctrl -> CBM          */ 
-keyboard_parse_set_pos_row(97, 1, 2, 8);                /*            A -> A            */
-keyboard_parse_set_pos_row(115, 1, 5, 8);               /*            S -> S            */
-keyboard_parse_set_pos_row(100, 2, 2, 8);               /*            D -> D            */
-keyboard_parse_set_pos_row(102, 2, 5, 8);               /*            F -> F            */
-keyboard_parse_set_pos_row(103, 3, 2, 8);               /*            G -> G            */
-keyboard_parse_set_pos_row(104, 3, 5, 8);               /*            H -> H            */
-keyboard_parse_set_pos_row(106, 4, 2, 8);               /*            J -> J            */
-keyboard_parse_set_pos_row(107, 4, 5, 8);               /*            K -> K            */
-keyboard_parse_set_pos_row(108, 5, 2, 8);               /*            L -> L            */
-keyboard_parse_set_pos_row(59, 5, 5, 8);                /*            ; -> :            */
-keyboard_parse_set_pos_row(39, 6, 2, 8);                /*            ' -> ;            */
-keyboard_parse_set_pos_row(96, 0, 1, 8);                /*            ` -> Left Arrow   */
-keyboard_parse_set_pos_row(92, 6, 5, 8);                /*            \ -> =            */
-keyboard_parse_set_pos_row(304, 1, 3, 2);               /*   Left Shift -> Left Shift   */
-keyboard_parse_set_pos_row(301, 1, 3, 64);              /*    Caps Lock -> Shift Lock   */
-keyboard_parse_set_pos_row(122, 1, 4, 8);               /*            Z -> Z            */
-keyboard_parse_set_pos_row(120, 2, 3, 8);               /*            X -> X            */
-keyboard_parse_set_pos_row(99, 2, 4, 8);                /*            C -> C            */
-keyboard_parse_set_pos_row(118, 3, 3, 8);               /*            V -> V            */
-keyboard_parse_set_pos_row(98, 3, 4, 8);                /*            B -> B            */
-keyboard_parse_set_pos_row(110, 4, 3, 8);               /*            N -> N            */
-keyboard_parse_set_pos_row(109, 4, 4, 8);               /*            M -> M            */
-keyboard_parse_set_pos_row(44, 5, 3, 8);                /*            , -> ,            */
-keyboard_parse_set_pos_row(46, 5, 4, 8);                /*            . -> .            */
-keyboard_parse_set_pos_row(47, 6, 3, 8);                /*            / -> /            */
-keyboard_parse_set_pos_row(303, 6, 4, 4);               /*  Right Shift -> Right Shift  */
-keyboard_parse_set_pos_row(32, 0, 4, 8);                /*        Space -> Space        */
-keyboard_parse_set_pos_row(282, 7, 4, 8);               /*           F1 -> F1           */
-keyboard_parse_set_pos_row(283, 7, 4, 1);               /*           F2 -> F2           */
-keyboard_parse_set_pos_row(284, 7, 5, 8);               /*           F3 -> F3           */
-keyboard_parse_set_pos_row(285, 7, 5, 1);               /*           F4 -> F4           */
-keyboard_parse_set_pos_row(286, 7, 6, 8);               /*           F5 -> F5           */
-keyboard_parse_set_pos_row(287, 7, 6, 1);               /*           F6 -> F6           */
-keyboard_parse_set_pos_row(288, 7, 7, 8);               /*           F7 -> F7           */
-keyboard_parse_set_pos_row(289, 7, 7, 1);               /*           F8 -> F8           */
-keyboard_parse_set_pos_row(278, 6, 7, 8);               /*         Home -> CLR/HOME     */
-keyboard_parse_set_pos_row(273, 7, 3, 1);               /*           Up -> CRSR UP      */
-keyboard_parse_set_pos_row(276, 7, 2, 1);               /*         Left -> CRSR LEFT    */
-keyboard_parse_set_pos_row(275, 7, 2, 8);               /*        Right -> CRSR RIGHT   */
-keyboard_parse_set_pos_row(274, 7, 3, 8);               /*         Down -> CRSR DOWN    */
-keyboard_parse_set_pos_row(277, 6, 0, 8);               /*          Ins -> Pound        */
-keyboard_parse_set_pos_row(127, 6, 6, 8);               /*          Del -> Up Arrow     */
+    kbd_lshiftrow = 1;
+    kbd_lshiftcol = 3;
+    kbd_rshiftrow = 6;
+    kbd_rshiftcol = 4;
+    vshift=KEY_RSHIFT;
+    shiftl=KEY_LSHIFT;
+
+    keyboard_parse_set_pos_row(27, 0, 3, 8);                /*          ESC -> Run/Stop     */
+    keyboard_parse_set_pos_row(49, 0, 0, 8);                /*            1 -> 1            */
+    keyboard_parse_set_pos_row(50, 0, 7, 8);                /*            2 -> 2            */
+    keyboard_parse_set_pos_row(51, 1, 0, 8);                /*            3 -> 3            */
+    keyboard_parse_set_pos_row(52, 1, 7, 8);                /*            4 -> 4            */
+    keyboard_parse_set_pos_row(53, 2, 0, 8);                /*            5 -> 5            */
+    keyboard_parse_set_pos_row(54, 2, 7, 8);                /*            6 -> 6            */
+    keyboard_parse_set_pos_row(55, 3, 0, 8);                /*            7 -> 7            */
+    keyboard_parse_set_pos_row(56, 3, 7, 8);                /*            8 -> 8            */
+    keyboard_parse_set_pos_row(57, 4, 0, 8);                /*            9 -> 9            */
+    keyboard_parse_set_pos_row(48, 4, 7, 8);                /*            0 -> 0            */
+    keyboard_parse_set_pos_row(45, 5, 0, 8);                /*        Minus -> Plus         */
+    keyboard_parse_set_pos_row(61, 5, 7, 8);                /*        Equal -> Minus        */
+    keyboard_parse_set_pos_row(8, 7, 0, 8);                 /*    Backspace -> Del          */
+    keyboard_parse_set_pos_row(9, 0, 2, 8);                 /*          TAB -> Ctrl         */
+    keyboard_parse_set_pos_row(113, 0, 6, 8);               /*            Q -> Q            */
+    keyboard_parse_set_pos_row(119, 1, 1, 8);               /*            W -> W            */
+    keyboard_parse_set_pos_row(101, 1, 6, 8);               /*            E -> E            */
+    keyboard_parse_set_pos_row(114, 2, 1, 8);               /*            R -> R            */
+    keyboard_parse_set_pos_row(116, 2, 6, 8);               /*            T -> T            */
+    keyboard_parse_set_pos_row(121, 3, 1, 8);               /*            Y -> Y            */
+    keyboard_parse_set_pos_row(117, 3, 6, 8);               /*            U -> U            */
+    keyboard_parse_set_pos_row(105, 4, 1, 8);               /*            I -> I            */
+    keyboard_parse_set_pos_row(111, 4, 6, 8);               /*            O -> O            */
+    keyboard_parse_set_pos_row(112, 5, 1, 8);               /*            P -> P            */
+    keyboard_parse_set_pos_row(91, 5, 6, 8);                /*            [ -> @            */
+    keyboard_parse_set_pos_row(93, 6, 1, 8);                /*            ] -> *            */
+    keyboard_parse_set_pos_row(13, 7, 1, 8);                /*       Return -> Return       */
+    keyboard_parse_set_pos_row(306, 0, 5, 8);               /*    Left Ctrl -> CBM          */
+    keyboard_parse_set_pos_row(97, 1, 2, 8);                /*            A -> A            */
+    keyboard_parse_set_pos_row(115, 1, 5, 8);               /*            S -> S            */
+    keyboard_parse_set_pos_row(100, 2, 2, 8);               /*            D -> D            */
+    keyboard_parse_set_pos_row(102, 2, 5, 8);               /*            F -> F            */
+    keyboard_parse_set_pos_row(103, 3, 2, 8);               /*            G -> G            */
+    keyboard_parse_set_pos_row(104, 3, 5, 8);               /*            H -> H            */
+    keyboard_parse_set_pos_row(106, 4, 2, 8);               /*            J -> J            */
+    keyboard_parse_set_pos_row(107, 4, 5, 8);               /*            K -> K            */
+    keyboard_parse_set_pos_row(108, 5, 2, 8);               /*            L -> L            */
+    keyboard_parse_set_pos_row(59, 5, 5, 8);                /*            ; -> :            */
+    keyboard_parse_set_pos_row(39, 6, 2, 8);                /*            ' -> ;            */
+    keyboard_parse_set_pos_row(96, 0, 1, 8);                /*            ` -> Left Arrow   */
+    keyboard_parse_set_pos_row(92, 6, 5, 8);                /*            \ -> =            */
+    keyboard_parse_set_pos_row(304, 1, 3, 2);               /*   Left Shift -> Left Shift   */
+    keyboard_parse_set_pos_row(301, 1, 3, 64);              /*    Caps Lock -> Shift Lock   */
+    keyboard_parse_set_pos_row(122, 1, 4, 8);               /*            Z -> Z            */
+    keyboard_parse_set_pos_row(120, 2, 3, 8);               /*            X -> X            */
+    keyboard_parse_set_pos_row(99, 2, 4, 8);                /*            C -> C            */
+    keyboard_parse_set_pos_row(118, 3, 3, 8);               /*            V -> V            */
+    keyboard_parse_set_pos_row(98, 3, 4, 8);                /*            B -> B            */
+    keyboard_parse_set_pos_row(110, 4, 3, 8);               /*            N -> N            */
+    keyboard_parse_set_pos_row(109, 4, 4, 8);               /*            M -> M            */
+    keyboard_parse_set_pos_row(44, 5, 3, 8);                /*            , -> ,            */
+    keyboard_parse_set_pos_row(46, 5, 4, 8);                /*            . -> .            */
+    keyboard_parse_set_pos_row(47, 6, 3, 8);                /*            / -> /            */
+    keyboard_parse_set_pos_row(303, 6, 4, 4);               /*  Right Shift -> Right Shift  */
+    keyboard_parse_set_pos_row(32, 0, 4, 8);                /*        Space -> Space        */
+    keyboard_parse_set_pos_row(282, 7, 4, 8);               /*           F1 -> F1           */
+    keyboard_parse_set_pos_row(283, 7, 4, 1);               /*           F2 -> F2           */
+    keyboard_parse_set_pos_row(284, 7, 5, 8);               /*           F3 -> F3           */
+    keyboard_parse_set_pos_row(285, 7, 5, 1);               /*           F4 -> F4           */
+    keyboard_parse_set_pos_row(286, 7, 6, 8);               /*           F5 -> F5           */
+    keyboard_parse_set_pos_row(287, 7, 6, 1);               /*           F6 -> F6           */
+    keyboard_parse_set_pos_row(288, 7, 7, 8);               /*           F7 -> F7           */
+    keyboard_parse_set_pos_row(289, 7, 7, 1);               /*           F8 -> F8           */
+    keyboard_parse_set_pos_row(278, 6, 7, 8);               /*         Home -> CLR/HOME     */
+    keyboard_parse_set_pos_row(273, 7, 3, 1);               /*           Up -> CRSR UP      */
+    keyboard_parse_set_pos_row(276, 7, 2, 1);               /*         Left -> CRSR LEFT    */
+    keyboard_parse_set_pos_row(275, 7, 2, 8);               /*        Right -> CRSR RIGHT   */
+    keyboard_parse_set_pos_row(274, 7, 3, 8);               /*         Down -> CRSR DOWN    */
+    keyboard_parse_set_pos_row(277, 6, 0, 8);               /*          Ins -> Pound        */
+    keyboard_parse_set_pos_row(127, 6, 6, 8);               /*          Del -> Up Arrow     */
 #elif defined(__CBM2__)
-keyboard_parse_set_pos_row(27, 8, 1, 8);         /*          ESC -> ESC          */
-keyboard_parse_set_pos_row(49, 9, 1, 8);         /*            1 -> 1            */
-keyboard_parse_set_pos_row(50, 10, 1, 8);        /*            2 -> 2            */
-keyboard_parse_set_pos_row(51, 11, 1, 8);        /*            3 -> 3            */
-keyboard_parse_set_pos_row(52, 12, 1, 8);        /*            4 -> 4            */
-keyboard_parse_set_pos_row(53, 13, 1, 8);        /*            5 -> 5            */
-keyboard_parse_set_pos_row(54, 13, 2, 8);        /*            6 -> 6            */
-keyboard_parse_set_pos_row(55, 14, 1, 8);        /*            7 -> 7            */
-keyboard_parse_set_pos_row(56, 15, 1, 8);        /*            8 -> 8            */
-keyboard_parse_set_pos_row(57, 0, 1, 8);         /*            9 -> 9            */
-keyboard_parse_set_pos_row(48, 1, 1, 8);         /*            0 -> 0            */
-keyboard_parse_set_pos_row(45, 1, 2, 8);         /*        Minus -> Minus        */
-keyboard_parse_set_pos_row(61, 2, 1, 8);         /*        Equal -> Equal        */
-keyboard_parse_set_pos_row(8, 3, 3, 8);          /*    Backspace -> Del          */
-keyboard_parse_set_pos_row(9, 8, 2, 8);          /*          TAB -> TAB          */
-keyboard_parse_set_pos_row(113, 9, 2, 8);        /*            Q -> Q            */
-keyboard_parse_set_pos_row(119, 10, 2, 8);       /*            W -> W            */
-keyboard_parse_set_pos_row(101, 11, 2, 8);       /*            E -> E            */
-keyboard_parse_set_pos_row(114, 12, 2, 8);       /*            R -> R            */
-keyboard_parse_set_pos_row(116, 12, 3, 8);       /*            T -> T            */
-keyboard_parse_set_pos_row(121, 13, 3, 8);       /*            Y -> Y            */
-keyboard_parse_set_pos_row(117, 14, 2, 8);       /*            U -> U            */
-keyboard_parse_set_pos_row(105, 15, 2, 8);       /*            I -> I            */
-keyboard_parse_set_pos_row(111, 0, 2, 8);        /*            O -> O            */
-keyboard_parse_set_pos_row(112, 1, 3, 8);        /*            P -> P            */
-keyboard_parse_set_pos_row(91, 1, 4, 8);         /*            [ -> [            */
-keyboard_parse_set_pos_row(93, 2, 3, 8);         /*            ] -> ]            */
-keyboard_parse_set_pos_row(13, 2, 4, 8);         /*       Return -> Return       */
-keyboard_parse_set_pos_row(306, 8, 5, 8);        /*    Left Ctrl -> CTRL         */
-keyboard_parse_set_pos_row(97, 9, 3, 8);         /*            A -> A            */
-keyboard_parse_set_pos_row(115, 10, 3, 8);       /*            S -> S            */
-keyboard_parse_set_pos_row(100, 11, 3, 8);       /*            D -> D            */
-keyboard_parse_set_pos_row(102, 11, 4, 8);       /*            F -> F            */
-keyboard_parse_set_pos_row(103, 12, 4, 8);       /*            G -> G            */
-keyboard_parse_set_pos_row(104, 13, 4, 8);       /*            H -> H            */
-keyboard_parse_set_pos_row(106, 14, 3, 8);       /*            J -> J            */
-keyboard_parse_set_pos_row(107, 15, 3, 8);       /*            K -> K            */
-keyboard_parse_set_pos_row(108, 0, 3, 8);        /*            L -> L            */
-keyboard_parse_set_pos_row(59, 0, 4, 8);         /*            ; -> ;            */
-keyboard_parse_set_pos_row(39, 1, 5, 8);         /*            ' -> '            */
-keyboard_parse_set_pos_row(304, 8, 4, 2);        /*   Left Shift -> Left Shift   */
-keyboard_parse_set_pos_row(122, 9, 4, 8);        /*            Z -> Z            */
-keyboard_parse_set_pos_row(120, 10, 4, 8);       /*            X -> X            */
-keyboard_parse_set_pos_row(99, 10, 5, 8);        /*            C -> C            */
-keyboard_parse_set_pos_row(118, 11, 5, 8);       /*            V -> V            */
-keyboard_parse_set_pos_row(98, 12, 5, 8);        /*            B -> B            */
-keyboard_parse_set_pos_row(110, 13, 5, 8);       /*            N -> N            */
-keyboard_parse_set_pos_row(109, 14, 4, 8);       /*            M -> M            */
-keyboard_parse_set_pos_row(44, 15, 4, 8);        /*            , -> ,            */
-keyboard_parse_set_pos_row(46, 15, 5, 8);        /*            . -> .            */
-keyboard_parse_set_pos_row(47, 0, 5, 8);         /*            / -> /            */
-keyboard_parse_set_pos_row(303, 8, 4, 2);        /*  Right Shift -> Right Shift  */
-keyboard_parse_set_pos_row(32, 14, 5, 8);        /*        Space -> Space        */
-keyboard_parse_set_pos_row(282, 8, 0, 8);        /*           F1 -> F1           */
-keyboard_parse_set_pos_row(283, 9, 0, 8);        /*           F2 -> F2           */
-keyboard_parse_set_pos_row(284, 10, 0, 8);       /*           F3 -> F3           */
-keyboard_parse_set_pos_row(285, 11, 0, 8);       /*           F4 -> F4           */
-keyboard_parse_set_pos_row(286, 12, 0, 8);       /*           F5 -> F5           */
-keyboard_parse_set_pos_row(287, 13, 0, 8);       /*           F6 -> F6           */
-keyboard_parse_set_pos_row(288, 14, 0, 8);       /*           F7 -> F7           */
-keyboard_parse_set_pos_row(289, 15, 0, 8);       /*           F8 -> F8           */
-keyboard_parse_set_pos_row(290, 0, 0, 8);        /*           F9 -> F9           */
-keyboard_parse_set_pos_row(291, 1, 0, 8);        /*          F10 -> F10          */
-keyboard_parse_set_pos_row(278, 4, 0, 8);        /*         Home -> CLR/HOME     */
-keyboard_parse_set_pos_row(273, 3, 0, 8);        /*           Up -> CRSR UP      */
-keyboard_parse_set_pos_row(276, 3, 1, 8);        /*         Left -> CRSR LEFT    */
-keyboard_parse_set_pos_row(275, 3, 2, 8);        /*        Right -> CRSR RIGHT   */
-keyboard_parse_set_pos_row(274, 2, 0, 8);        /*         Down -> CRSR DOWN    */
-keyboard_parse_set_pos_row(277, 2, 2, 8);        /*          Ins -> Pound        */
-keyboard_parse_set_pos_row(127, 4, 1, 8);        /*          Del -> ?            */
-keyboard_parse_set_pos_row(281, 6, 0, 8);        /*       PgDown -> Norm/Graph   */
-keyboard_parse_set_pos_row(19, 2, 5, 8);         /*  Pause/Break -> Pi           */
-keyboard_parse_set_pos_row(280, 5, 0, 8);        /*         PgUp -> Rev/Off      */
-keyboard_parse_set_pos_row(279, 5, 1, 8);        /*          End -> CE           */
-keyboard_parse_set_pos_row(305, 3, 4, 8);        /*   Right Ctrl -> C=           */
-keyboard_parse_set_pos_row(271, 7, 4, 8);        /* Numpad Enter -> Numpad Enter */
-keyboard_parse_set_pos_row(267, 7, 1, 8);        /*     Numpad / -> Numpad /     */
-keyboard_parse_set_pos_row(263, 4, 2, 8);        /*     Numpad 7 -> Numpad 7     */
-keyboard_parse_set_pos_row(264, 5, 2, 8);        /*     Numpad 8 -> Numpad 8     */
-keyboard_parse_set_pos_row(265, 6, 2, 8);        /*     Numpad 9 -> Numpad 9     */
-keyboard_parse_set_pos_row(269, 7, 2, 8);        /*     Numpad - -> Numpad -     */
-keyboard_parse_set_pos_row(260, 4, 3, 8);        /*     Numpad 4 -> Numpad 4     */
-keyboard_parse_set_pos_row(261, 5, 3, 8);        /*     Numpad 5 -> Numpad 5     */
-keyboard_parse_set_pos_row(262, 6, 3, 8);        /*     Numpad 6 -> Numpad 6     */
-keyboard_parse_set_pos_row(270, 7, 3, 8);        /*     Numpad + -> Numpad +     */
-keyboard_parse_set_pos_row(257, 4, 4, 8);        /*     Numpad 1 -> Numpad 1     */
-keyboard_parse_set_pos_row(258, 5, 4, 8);        /*     Numpad 2 -> Numpad 2     */
-keyboard_parse_set_pos_row(259, 6, 4, 8);        /*     Numpad 3 -> Numpad 3     */
-keyboard_parse_set_pos_row(256, 4, 5, 8);        /*     Numpad 0 -> Numpad 0     */
-keyboard_parse_set_pos_row(266, 5, 5, 8);        /*     Numpad . -> Numpad .     */
+    kbd_lshiftrow = 8;
+    kbd_lshiftcol = 4;
+    kbd_rshiftrow = 8;
+    kbd_rshiftcol = 4;
+    vshift=KEY_LSHIFT;
+
+    keyboard_parse_set_pos_row(27, 8, 1, 8);         /*          ESC -> ESC          */
+    keyboard_parse_set_pos_row(49, 9, 1, 8);         /*            1 -> 1            */
+    keyboard_parse_set_pos_row(50, 10, 1, 8);        /*            2 -> 2            */
+    keyboard_parse_set_pos_row(51, 11, 1, 8);        /*            3 -> 3            */
+    keyboard_parse_set_pos_row(52, 12, 1, 8);        /*            4 -> 4            */
+    keyboard_parse_set_pos_row(53, 13, 1, 8);        /*            5 -> 5            */
+    keyboard_parse_set_pos_row(54, 13, 2, 8);        /*            6 -> 6            */
+    keyboard_parse_set_pos_row(55, 14, 1, 8);        /*            7 -> 7            */
+    keyboard_parse_set_pos_row(56, 15, 1, 8);        /*            8 -> 8            */
+    keyboard_parse_set_pos_row(57, 0, 1, 8);         /*            9 -> 9            */
+    keyboard_parse_set_pos_row(48, 1, 1, 8);         /*            0 -> 0            */
+    keyboard_parse_set_pos_row(45, 1, 2, 8);         /*        Minus -> Minus        */
+    keyboard_parse_set_pos_row(61, 2, 1, 8);         /*        Equal -> Equal        */
+    keyboard_parse_set_pos_row(8, 3, 3, 8);          /*    Backspace -> Del          */
+    keyboard_parse_set_pos_row(9, 8, 2, 8);          /*          TAB -> TAB          */
+    keyboard_parse_set_pos_row(113, 9, 2, 8);        /*            Q -> Q            */
+    keyboard_parse_set_pos_row(119, 10, 2, 8);       /*            W -> W            */
+    keyboard_parse_set_pos_row(101, 11, 2, 8);       /*            E -> E            */
+    keyboard_parse_set_pos_row(114, 12, 2, 8);       /*            R -> R            */
+    keyboard_parse_set_pos_row(116, 12, 3, 8);       /*            T -> T            */
+    keyboard_parse_set_pos_row(121, 13, 3, 8);       /*            Y -> Y            */
+    keyboard_parse_set_pos_row(117, 14, 2, 8);       /*            U -> U            */
+    keyboard_parse_set_pos_row(105, 15, 2, 8);       /*            I -> I            */
+    keyboard_parse_set_pos_row(111, 0, 2, 8);        /*            O -> O            */
+    keyboard_parse_set_pos_row(112, 1, 3, 8);        /*            P -> P            */
+    keyboard_parse_set_pos_row(91, 1, 4, 8);         /*            [ -> [            */
+    keyboard_parse_set_pos_row(93, 2, 3, 8);         /*            ] -> ]            */
+    keyboard_parse_set_pos_row(13, 2, 4, 8);         /*       Return -> Return       */
+    keyboard_parse_set_pos_row(306, 8, 5, 8);        /*    Left Ctrl -> CTRL         */
+    keyboard_parse_set_pos_row(97, 9, 3, 8);         /*            A -> A            */
+    keyboard_parse_set_pos_row(115, 10, 3, 8);       /*            S -> S            */
+    keyboard_parse_set_pos_row(100, 11, 3, 8);       /*            D -> D            */
+    keyboard_parse_set_pos_row(102, 11, 4, 8);       /*            F -> F            */
+    keyboard_parse_set_pos_row(103, 12, 4, 8);       /*            G -> G            */
+    keyboard_parse_set_pos_row(104, 13, 4, 8);       /*            H -> H            */
+    keyboard_parse_set_pos_row(106, 14, 3, 8);       /*            J -> J            */
+    keyboard_parse_set_pos_row(107, 15, 3, 8);       /*            K -> K            */
+    keyboard_parse_set_pos_row(108, 0, 3, 8);        /*            L -> L            */
+    keyboard_parse_set_pos_row(59, 0, 4, 8);         /*            ; -> ;            */
+    keyboard_parse_set_pos_row(39, 1, 5, 8);         /*            ' -> '            */
+    keyboard_parse_set_pos_row(304, 8, 4, 2);        /*   Left Shift -> Left Shift   */
+    keyboard_parse_set_pos_row(122, 9, 4, 8);        /*            Z -> Z            */
+    keyboard_parse_set_pos_row(120, 10, 4, 8);       /*            X -> X            */
+    keyboard_parse_set_pos_row(99, 10, 5, 8);        /*            C -> C            */
+    keyboard_parse_set_pos_row(118, 11, 5, 8);       /*            V -> V            */
+    keyboard_parse_set_pos_row(98, 12, 5, 8);        /*            B -> B            */
+    keyboard_parse_set_pos_row(110, 13, 5, 8);       /*            N -> N            */
+    keyboard_parse_set_pos_row(109, 14, 4, 8);       /*            M -> M            */
+    keyboard_parse_set_pos_row(44, 15, 4, 8);        /*            , -> ,            */
+    keyboard_parse_set_pos_row(46, 15, 5, 8);        /*            . -> .            */
+    keyboard_parse_set_pos_row(47, 0, 5, 8);         /*            / -> /            */
+    keyboard_parse_set_pos_row(303, 8, 4, 2);        /*  Right Shift -> Right Shift  */
+    keyboard_parse_set_pos_row(32, 14, 5, 8);        /*        Space -> Space        */
+    keyboard_parse_set_pos_row(282, 8, 0, 8);        /*           F1 -> F1           */
+    keyboard_parse_set_pos_row(283, 9, 0, 8);        /*           F2 -> F2           */
+    keyboard_parse_set_pos_row(284, 10, 0, 8);       /*           F3 -> F3           */
+    keyboard_parse_set_pos_row(285, 11, 0, 8);       /*           F4 -> F4           */
+    keyboard_parse_set_pos_row(286, 12, 0, 8);       /*           F5 -> F5           */
+    keyboard_parse_set_pos_row(287, 13, 0, 8);       /*           F6 -> F6           */
+    keyboard_parse_set_pos_row(288, 14, 0, 8);       /*           F7 -> F7           */
+    keyboard_parse_set_pos_row(289, 15, 0, 8);       /*           F8 -> F8           */
+    keyboard_parse_set_pos_row(290, 0, 0, 8);        /*           F9 -> F9           */
+    keyboard_parse_set_pos_row(291, 1, 0, 8);        /*          F10 -> F10          */
+    keyboard_parse_set_pos_row(278, 4, 0, 8);        /*         Home -> CLR/HOME     */
+    keyboard_parse_set_pos_row(273, 3, 0, 8);        /*           Up -> CRSR UP      */
+    keyboard_parse_set_pos_row(276, 3, 1, 8);        /*         Left -> CRSR LEFT    */
+    keyboard_parse_set_pos_row(275, 3, 2, 8);        /*        Right -> CRSR RIGHT   */
+    keyboard_parse_set_pos_row(274, 2, 0, 8);        /*         Down -> CRSR DOWN    */
+    keyboard_parse_set_pos_row(277, 2, 2, 8);        /*          Ins -> Pound        */
+    keyboard_parse_set_pos_row(127, 4, 1, 8);        /*          Del -> ?            */
+    keyboard_parse_set_pos_row(281, 6, 0, 8);        /*       PgDown -> Norm/Graph   */
+    keyboard_parse_set_pos_row(19, 2, 5, 8);         /*  Pause/Break -> Pi           */
+    keyboard_parse_set_pos_row(280, 5, 0, 8);        /*         PgUp -> Rev/Off      */
+    keyboard_parse_set_pos_row(279, 5, 1, 8);        /*          End -> CE           */
+    keyboard_parse_set_pos_row(305, 3, 4, 8);        /*   Right Ctrl -> C=           */
+    keyboard_parse_set_pos_row(271, 7, 4, 8);        /* Numpad Enter -> Numpad Enter */
+    keyboard_parse_set_pos_row(267, 7, 1, 8);        /*     Numpad / -> Numpad /     */
+    keyboard_parse_set_pos_row(263, 4, 2, 8);        /*     Numpad 7 -> Numpad 7     */
+    keyboard_parse_set_pos_row(264, 5, 2, 8);        /*     Numpad 8 -> Numpad 8     */
+    keyboard_parse_set_pos_row(265, 6, 2, 8);        /*     Numpad 9 -> Numpad 9     */
+    keyboard_parse_set_pos_row(269, 7, 2, 8);        /*     Numpad - -> Numpad -     */
+    keyboard_parse_set_pos_row(260, 4, 3, 8);        /*     Numpad 4 -> Numpad 4     */
+    keyboard_parse_set_pos_row(261, 5, 3, 8);        /*     Numpad 5 -> Numpad 5     */
+    keyboard_parse_set_pos_row(262, 6, 3, 8);        /*     Numpad 6 -> Numpad 6     */
+    keyboard_parse_set_pos_row(270, 7, 3, 8);        /*     Numpad + -> Numpad +     */
+    keyboard_parse_set_pos_row(257, 4, 4, 8);        /*     Numpad 1 -> Numpad 1     */
+    keyboard_parse_set_pos_row(258, 5, 4, 8);        /*     Numpad 2 -> Numpad 2     */
+    keyboard_parse_set_pos_row(259, 6, 4, 8);        /*     Numpad 3 -> Numpad 3     */
+    keyboard_parse_set_pos_row(256, 4, 5, 8);        /*     Numpad 0 -> Numpad 0     */
+    keyboard_parse_set_pos_row(266, 5, 5, 8);        /*     Numpad . -> Numpad .     */
+#elif defined(__PET__)
+    switch(machine_keyboard_type)
+    {
+        case 0: // Business (US)
+            kbd_lshiftrow = 6;
+            kbd_lshiftcol = 0;
+            kbd_rshiftrow = 6;
+            kbd_rshiftcol = 6;
+            vshift=KEY_RSHIFT;
+
+            keyboard_parse_set_pos_row(27, 2, 0, 8);         /*          ESC -> ESC          */
+            keyboard_parse_set_pos_row(49, 1, 0, 8);         /*            1 -> 1            */
+            keyboard_parse_set_pos_row(50, 0, 0, 8);         /*            2 -> 2            */
+            keyboard_parse_set_pos_row(51, 9, 1, 8);         /*            3 -> 3            */
+            keyboard_parse_set_pos_row(52, 1, 1, 8);         /*            4 -> 4            */
+            keyboard_parse_set_pos_row(53, 0, 1, 8);         /*            5 -> 5            */
+            keyboard_parse_set_pos_row(54, 9, 2, 8);         /*            6 -> 6            */
+            keyboard_parse_set_pos_row(55, 1, 2, 8);         /*            7 -> 7            */
+            keyboard_parse_set_pos_row(56, 0, 2, 8);         /*            8 -> 8            */
+            keyboard_parse_set_pos_row(57, 9, 3, 8);         /*            9 -> 9            */
+            keyboard_parse_set_pos_row(48, 1, 3, 8);         /*            0 -> 0            */
+            keyboard_parse_set_pos_row(45, 9, 5, 8);         /*        Minus -> :            */
+            keyboard_parse_set_pos_row(61, 0, 3, 8);         /*        Equal -> Minus        */
+            keyboard_parse_set_pos_row(8, 4, 7, 8);          /*    Backspace -> Del          */
+            keyboard_parse_set_pos_row(9, 4, 0, 8);          /*          TAB -> TAB          */
+            keyboard_parse_set_pos_row(113, 5, 0, 8);        /*            Q -> Q            */
+            keyboard_parse_set_pos_row(119, 4, 1, 8);        /*            W -> W            */
+            keyboard_parse_set_pos_row(101, 5, 1, 8);        /*            E -> E            */
+            keyboard_parse_set_pos_row(114, 4, 2, 8);        /*            R -> R            */
+            keyboard_parse_set_pos_row(116, 5, 2, 8);        /*            T -> T            */
+            keyboard_parse_set_pos_row(121, 4, 3, 8);        /*            Y -> Y            */
+            keyboard_parse_set_pos_row(117, 5, 3, 8);        /*            U -> U            */
+            keyboard_parse_set_pos_row(105, 4, 5, 8);        /*            I -> I            */
+            keyboard_parse_set_pos_row(111, 5, 5, 8);        /*            O -> O            */
+            keyboard_parse_set_pos_row(112, 4, 6, 8);        /*            P -> P            */
+            keyboard_parse_set_pos_row(91, 5, 6, 8);         /*            [ -> [            */
+            keyboard_parse_set_pos_row(93, 2, 4, 8);         /*            ] -> ]            */
+            keyboard_parse_set_pos_row(13, 3, 4, 8);         /*       Return -> Return       */
+            keyboard_parse_set_pos_row(306, 8, 0, 8);        /*    Left Ctrl -> RVS          */
+            keyboard_parse_set_pos_row(97, 3, 0, 8);         /*            A -> A            */
+            keyboard_parse_set_pos_row(115, 2, 1, 8);        /*            S -> S            */
+            keyboard_parse_set_pos_row(100, 3, 1, 8);        /*            D -> D            */
+            keyboard_parse_set_pos_row(102, 2, 2, 8);        /*            F -> F            */
+            keyboard_parse_set_pos_row(103, 3, 2, 8);        /*            G -> G            */
+            keyboard_parse_set_pos_row(104, 2, 3, 8);        /*            H -> H            */
+            keyboard_parse_set_pos_row(106, 3, 3, 8);        /*            J -> J            */
+            keyboard_parse_set_pos_row(107, 2, 5, 8);        /*            K -> K            */
+            keyboard_parse_set_pos_row(108, 3, 5, 8);        /*            L -> L            */
+            keyboard_parse_set_pos_row(59, 2, 6, 8);         /*            ; -> ;            */
+            keyboard_parse_set_pos_row(39, 3, 6, 8);         /*            ' -> @            */
+            keyboard_parse_set_pos_row(96, 9, 0, 8);         /*            ` -> Left Arrow   */
+            keyboard_parse_set_pos_row(304, 6, 0, 2);        /*   Left Shift -> Left Shift   */
+            keyboard_parse_set_pos_row(92, 4, 4, 8);         /*            \ -> \            */
+            keyboard_parse_set_pos_row(122, 7, 0, 8);        /*            Z -> Z            */
+            keyboard_parse_set_pos_row(120, 8, 1, 8);        /*            X -> X            */
+            keyboard_parse_set_pos_row(99, 6, 1, 8);         /*            C -> C            */
+            keyboard_parse_set_pos_row(118, 7, 1, 8);        /*            V -> V            */
+            keyboard_parse_set_pos_row(98, 6, 2, 8);         /*            B -> B            */
+            keyboard_parse_set_pos_row(110, 7, 2, 8);        /*            N -> N            */
+            keyboard_parse_set_pos_row(109, 8, 3, 8);        /*            M -> M            */
+            keyboard_parse_set_pos_row(44, 7, 3, 8);         /*            , -> ,            */
+            keyboard_parse_set_pos_row(46, 6, 3, 8);         /*            . -> .            */
+            keyboard_parse_set_pos_row(47, 8, 6, 8);         /*            / -> /            */
+            keyboard_parse_set_pos_row(303, 6, 6, 4);        /*  Right Shift -> Right Shift  */
+            keyboard_parse_set_pos_row(32, 8, 2, 8);         /*        Space -> Space        */
+            keyboard_parse_set_pos_row(278, 8, 4, 8);        /*         Home -> CLR/HOME     */
+            keyboard_parse_set_pos_row(273, 5, 4, 1);        /*           Up -> CRSR UP      */
+            keyboard_parse_set_pos_row(276, 0, 5, 1);        /*         Left -> CRSR LEFT    */
+            keyboard_parse_set_pos_row(275, 0, 5, 8);        /*        Right -> CRSR RIGHT   */
+            keyboard_parse_set_pos_row(274, 5, 4, 8);        /*         Down -> CRSR DOWN    */
+            keyboard_parse_set_pos_row(277, 9, 4, 8);        /*          Ins -> STOP         */
+            keyboard_parse_set_pos_row(127, 1, 5, 8);        /*          Del -> Up arrow     */
+            keyboard_parse_set_pos_row(305, 7, 6, 8);        /*   Right Ctrl -> RPT          */
+            keyboard_parse_set_pos_row(263, 1, 4, 8);        /*     Numpad 7 -> Numpad 7     */
+            keyboard_parse_set_pos_row(264, 0, 4, 8);        /*     Numpad 8 -> Numpad 8     */
+            keyboard_parse_set_pos_row(265, 1, 7, 8);        /*     Numpad 9 -> Numpad 9     */
+            keyboard_parse_set_pos_row(260, 5, 7, 8);        /*     Numpad 4 -> Numpad 4     */
+            keyboard_parse_set_pos_row(261, 2, 7, 8);        /*     Numpad 5 -> Numpad 5     */
+            keyboard_parse_set_pos_row(262, 3, 7, 8);        /*     Numpad 6 -> Numpad 6     */
+            keyboard_parse_set_pos_row(257, 8, 7, 8);        /*     Numpad 1 -> Numpad 1     */
+            keyboard_parse_set_pos_row(258, 7, 7, 8);        /*     Numpad 2 -> Numpad 2     */
+            keyboard_parse_set_pos_row(259, 6, 7, 8);        /*     Numpad 3 -> Numpad 3     */
+            keyboard_parse_set_pos_row(256, 7, 4, 8);        /*     Numpad 0 -> Numpad 0     */
+            keyboard_parse_set_pos_row(266, 6, 4, 8);        /*     Numpad . -> Numpad .     */
+            break;
+        case 4:
+            kbd_lshiftrow = 8;
+            kbd_lshiftcol = 0;
+            kbd_rshiftrow = 8;
+            kbd_rshiftcol = 5;
+            vshift=KEY_RSHIFT;
+
+            keyboard_parse_set_pos_row(27, 9, 4, 8);         /*          ESC -> Run/Stop     */
+            keyboard_parse_set_pos_row(49, 0, 0, 8);         /*            1 -> !            */
+            keyboard_parse_set_pos_row(50, 1, 0, 8);         /*            2 -> "            */
+            keyboard_parse_set_pos_row(51, 0, 1, 8);         /*            3 -> #            */
+            keyboard_parse_set_pos_row(52, 1, 1, 8);         /*            4 -> $            */
+            keyboard_parse_set_pos_row(53, 0, 2, 8);         /*            5 -> %            */
+            keyboard_parse_set_pos_row(54, 1, 2, 8);         /*            6 -> '            */
+            keyboard_parse_set_pos_row(55, 0, 3, 8);         /*            7 -> &            */
+            keyboard_parse_set_pos_row(56, 1, 3, 8);         /*            8 -> \            */
+            keyboard_parse_set_pos_row(57, 0, 4, 8);         /*            9 -> (            */
+            keyboard_parse_set_pos_row(48, 1, 4, 8);         /*            0 -> )            */
+            keyboard_parse_set_pos_row(45, 0, 5, 8);         /*        Minus -> Left arrow   */
+            keyboard_parse_set_pos_row(8, 1, 8, 8);          /*    Backspace -> Del          */
+            keyboard_parse_set_pos_row(113, 2, 0, 8);        /*            Q -> Q            */
+            keyboard_parse_set_pos_row(119, 3, 0, 8);        /*            W -> W            */
+            keyboard_parse_set_pos_row(101, 2, 1, 8);        /*            E -> E            */
+            keyboard_parse_set_pos_row(114, 3, 1, 8);        /*            R -> R            */
+            keyboard_parse_set_pos_row(116, 2, 2, 8);        /*            T -> T            */
+            keyboard_parse_set_pos_row(121, 3, 2, 8);        /*            Y -> Y            */
+            keyboard_parse_set_pos_row(117, 2, 3, 8);        /*            U -> U            */
+            keyboard_parse_set_pos_row(105, 3, 3, 8);        /*            I -> I            */
+            keyboard_parse_set_pos_row(111, 2, 4, 8);        /*            O -> O            */
+            keyboard_parse_set_pos_row(112, 3, 4, 8);        /*            P -> P            */
+            keyboard_parse_set_pos_row(91, 2, 5, 8);         /*            [ -> Up arrow     */
+            keyboard_parse_set_pos_row(13, 6, 5, 8);         /*       Return -> Return       */
+            keyboard_parse_set_pos_row(306, 9, 0, 8);        /*    Left Ctrl -> RVS ON/OFF   */
+            keyboard_parse_set_pos_row(97, 4, 0, 8);         /*            A -> A            */
+            keyboard_parse_set_pos_row(115, 5, 0, 8);        /*            S -> S            */
+            keyboard_parse_set_pos_row(100, 4, 1, 8);        /*            D -> D            */
+            keyboard_parse_set_pos_row(102, 5, 1, 8);        /*            F -> F            */
+            keyboard_parse_set_pos_row(103, 4, 2, 8);        /*            G -> G            */
+            keyboard_parse_set_pos_row(104, 5, 2, 8);        /*            H -> H            */
+            keyboard_parse_set_pos_row(106, 4, 3, 8);        /*            J -> J            */
+            keyboard_parse_set_pos_row(107, 5, 3, 8);        /*            K -> K            */
+            keyboard_parse_set_pos_row(108, 4, 4, 8);        /*            L -> L            */
+            keyboard_parse_set_pos_row(59, 5, 4, 8);         /*            ; -> :            */
+            keyboard_parse_set_pos_row(304, 8, 0, 2);        /*   Left Shift -> Left Shift   */
+            keyboard_parse_set_pos_row(122, 6, 0, 8);        /*            Z -> Z            */
+            keyboard_parse_set_pos_row(120, 7, 0, 8);        /*            X -> X            */
+            keyboard_parse_set_pos_row(99, 6, 1, 8);         /*            C -> C            */
+            keyboard_parse_set_pos_row(118, 7, 1, 8);        /*            V -> V            */
+            keyboard_parse_set_pos_row(98, 6, 2, 8);         /*            B -> B            */
+            keyboard_parse_set_pos_row(110, 7, 2, 8);        /*            N -> N            */
+            keyboard_parse_set_pos_row(109, 6, 3, 8);        /*            M -> M            */
+            keyboard_parse_set_pos_row(44, 7, 3, 8);         /*            , -> ,            */
+            keyboard_parse_set_pos_row(46, 6, 4, 8);         /*            . -> ;            */
+            keyboard_parse_set_pos_row(47, 7, 4, 8);         /*            / -> ?            */
+            keyboard_parse_set_pos_row(303, 8, 5, 4);        /*  Right Shift -> Right Shift  */
+            keyboard_parse_set_pos_row(32, 9, 2, 8);         /*        Space -> Space        */
+            keyboard_parse_set_pos_row(278, 9, 1, 8);        /*         Home -> [            */
+            keyboard_parse_set_pos_row(273, 1, 6, 1);        /*           Up -> CRSR UP      */
+            keyboard_parse_set_pos_row(276, 0, 7, 1);        /*         Left -> CRSR LEFT    */
+            keyboard_parse_set_pos_row(275, 0, 7, 8);        /*        Right -> CRSR RIGHT   */
+            keyboard_parse_set_pos_row(274, 1, 6, 8);        /*         Down -> CRSR DOWN    */
+            keyboard_parse_set_pos_row(277, 8, 1, 8);        /*          Ins -> @            */
+            keyboard_parse_set_pos_row(127, 0, 6, 8);        /*          Del -> CLR/HOME     */
+            keyboard_parse_set_pos_row(280, 8, 2, 8);        /*         PgUp -> ]            */
+            keyboard_parse_set_pos_row(279, 9, 3, 8);        /*          End -> <            */
+            keyboard_parse_set_pos_row(281, 8, 4, 8);        /*       PgDown -> >            */
+            keyboard_parse_set_pos_row(305, 9, 4, 8);        /*   Right Ctrl -> RUN/STOP     */
+            keyboard_parse_set_pos_row(271, 9, 7, 8);        /* Numpad Enter -> =            */
+            keyboard_parse_set_pos_row(267, 3, 7, 8);        /*     Numpad / -> /            */
+            keyboard_parse_set_pos_row(263, 2, 6, 8);        /*     Numpad 7 -> 7            */
+            keyboard_parse_set_pos_row(264, 3, 6, 8);        /*     Numpad 8 -> 8            */
+            keyboard_parse_set_pos_row(265, 2, 7, 8);        /*     Numpad 9 -> 9            */
+            keyboard_parse_set_pos_row(269, 8, 7, 8);        /*     Numpad - -> Minus        */
+            keyboard_parse_set_pos_row(260, 4, 6, 8);        /*     Numpad 4 -> 4            */
+            keyboard_parse_set_pos_row(261, 5, 6, 8);        /*     Numpad 5 -> 5            */
+            keyboard_parse_set_pos_row(262, 4, 7, 8);        /*     Numpad 6 -> 6            */
+            keyboard_parse_set_pos_row(270, 7, 7, 8);        /*     Numpad + -> +            */
+            keyboard_parse_set_pos_row(257, 6, 6, 8);        /*     Numpad 1 -> 1            */
+            keyboard_parse_set_pos_row(258, 7, 6, 8);        /*     Numpad 2 -> 2            */
+            keyboard_parse_set_pos_row(259, 6, 7, 8);        /*     Numpad 3 -> 3            */
+            keyboard_parse_set_pos_row(256, 8, 6, 8);        /*     Numpad 0 -> 0            */
+            keyboard_parse_set_pos_row(266, 9, 6, 8);        /*     Numpad . -> .            */
+            break;
+    }
 #else
-keyboard_parse_set_pos_row(27, 7, 7, 8);                /*          ESC -> Run/Stop     */
-keyboard_parse_set_pos_row(49, 7, 0, 8);                /*            1 -> 1            */
-keyboard_parse_set_pos_row(50, 7, 3, 8);                /*            2 -> 2            */
-keyboard_parse_set_pos_row(51, 1, 0, 8);                /*            3 -> 3            */
-keyboard_parse_set_pos_row(52, 1, 3, 8);                /*            4 -> 4            */
-keyboard_parse_set_pos_row(53, 2, 0, 8);                /*            5 -> 5            */
-keyboard_parse_set_pos_row(54, 2, 3, 8);                /*            6 -> 6            */
-keyboard_parse_set_pos_row(55, 3, 0, 8);                /*            7 -> 7            */
-keyboard_parse_set_pos_row(56, 3, 3, 8);                /*            8 -> 8            */
-keyboard_parse_set_pos_row(57, 4, 0, 8);                /*            9 -> 9            */
-keyboard_parse_set_pos_row(48, 4, 3, 8);                /*            0 -> 0            */
-keyboard_parse_set_pos_row(45, 5, 0, 8);                /*        Minus -> Plus         */
-keyboard_parse_set_pos_row(61, 5, 3, 8);                /*        Equal -> Minus        */
-keyboard_parse_set_pos_row(8, 0, 0, 8);                 /*    Backspace -> Del          */
-keyboard_parse_set_pos_row(9, 7, 2, 8);                 /*          TAB -> Ctrl         */
-keyboard_parse_set_pos_row(113, 7, 6, 8);               /*            Q -> Q            */
-keyboard_parse_set_pos_row(119, 1, 1, 8);               /*            W -> W            */
-keyboard_parse_set_pos_row(101, 1, 6, 8);               /*            E -> E            */
-keyboard_parse_set_pos_row(114, 2, 1, 8);               /*            R -> R            */
-keyboard_parse_set_pos_row(116, 2, 6, 8);               /*            T -> T            */
-keyboard_parse_set_pos_row(121, 3, 1, 8);               /*            Y -> Y            */
-keyboard_parse_set_pos_row(117, 3, 6, 8);               /*            U -> U            */
-keyboard_parse_set_pos_row(105, 4, 1, 8);               /*            I -> I            */
-keyboard_parse_set_pos_row(111, 4, 6, 8);               /*            O -> O            */
-keyboard_parse_set_pos_row(112, 5, 1, 8);               /*            P -> P            */
-keyboard_parse_set_pos_row(91, 5, 6, 8);                /*            [ -> @            */
-keyboard_parse_set_pos_row(93, 6, 1, 8);                /*            ] -> *            */
-keyboard_parse_set_pos_row(13, 0, 1, 8);                /*       Return -> Return       */
-keyboard_parse_set_pos_row(306, 7, 5, 8);               /*    Left Ctrl -> CBM          */ 
-keyboard_parse_set_pos_row(97, 1, 2, 8);                /*            A -> A            */
-keyboard_parse_set_pos_row(115, 1, 5, 8);               /*            S -> S            */
-keyboard_parse_set_pos_row(100, 2, 2, 8);               /*            D -> D            */
-keyboard_parse_set_pos_row(102, 2, 5, 8);               /*            F -> F            */
-keyboard_parse_set_pos_row(103, 3, 2, 8);               /*            G -> G            */
-keyboard_parse_set_pos_row(104, 3, 5, 8);               /*            H -> H            */
-keyboard_parse_set_pos_row(106, 4, 2, 8);               /*            J -> J            */
-keyboard_parse_set_pos_row(107, 4, 5, 8);               /*            K -> K            */
-keyboard_parse_set_pos_row(108, 5, 2, 8);               /*            L -> L            */
-keyboard_parse_set_pos_row(59, 5, 5, 8);                /*            ; -> :            */
-keyboard_parse_set_pos_row(39, 6, 2, 8);                /*            ' -> ;            */
-keyboard_parse_set_pos_row(96, 7, 1, 8);                /*            ` -> Left Arrow   */
-keyboard_parse_set_pos_row(92, 6, 5, 8);                /*            \ -> =            */
-keyboard_parse_set_pos_row(304, 1, 7, 2);               /*   Left Shift -> Left Shift   */
-keyboard_parse_set_pos_row(301, 1, 7, 64);              /*    Caps Lock -> Shift Lock   */
-keyboard_parse_set_pos_row(122, 1, 4, 8);               /*            Z -> Z            */
-keyboard_parse_set_pos_row(120, 2, 7, 8);               /*            X -> X            */
-keyboard_parse_set_pos_row(99, 2, 4, 8);                /*            C -> C            */
-keyboard_parse_set_pos_row(118, 3, 7, 8);               /*            V -> V            */
-keyboard_parse_set_pos_row(98, 3, 4, 8);                /*            B -> B            */
-keyboard_parse_set_pos_row(110, 4, 7, 8);               /*            N -> N            */
-keyboard_parse_set_pos_row(109, 4, 4, 8);               /*            M -> M            */
-keyboard_parse_set_pos_row(44, 5, 7, 8);                /*            , -> ,            */
-keyboard_parse_set_pos_row(46, 5, 4, 8);                /*            . -> .            */
-keyboard_parse_set_pos_row(47, 6, 7, 8);                /*            / -> /            */
-keyboard_parse_set_pos_row(303, 6, 4, 4);               /*  Right Shift -> Right Shift  */
-keyboard_parse_set_pos_row(32, 7, 4, 8);                /*        Space -> Space        */
-keyboard_parse_set_pos_row(282, 0, 4, 8);               /*           F1 -> F1           */
-keyboard_parse_set_pos_row(283, 0, 4, 1);               /*           F2 -> F2           */
-keyboard_parse_set_pos_row(284, 0, 5, 8);               /*           F3 -> F3           */
-keyboard_parse_set_pos_row(285, 0, 5, 1);               /*           F4 -> F4           */
-keyboard_parse_set_pos_row(286, 0, 6, 8);               /*           F5 -> F5           */
-keyboard_parse_set_pos_row(287, 0, 6, 1);               /*           F6 -> F6           */
-keyboard_parse_set_pos_row(288, 0, 3, 8);               /*           F7 -> F7           */
-keyboard_parse_set_pos_row(289, 0, 3, 1);               /*           F8 -> F8           */
-keyboard_parse_set_pos_row(278, 6, 3, 8);               /*         Home -> CLR/HOME     */
-keyboard_parse_set_pos_row(273, 0, 7, 1);               /*           Up -> CRSR UP      */
-keyboard_parse_set_pos_row(276, 0, 2, 1);               /*         Left -> CRSR LEFT    */
-keyboard_parse_set_pos_row(275, 0, 2, 8);               /*        Right -> CRSR RIGHT   */
-keyboard_parse_set_pos_row(274, 0, 7, 8);               /*         Down -> CRSR DOWN    */
-keyboard_parse_set_pos_row(277, 6, 0, 8);               /*          Ins -> Pound        */
-keyboard_parse_set_pos_row(127, 6, 6, 8);               /*          Del -> Up Arrow     */
-keyboard_parse_set_neg_row(280, -3, 0);			/*	PageUp -> Restore       */
+    kbd_lshiftrow = 1;
+    kbd_lshiftcol = 7;
+    kbd_rshiftrow = 6;
+    kbd_rshiftcol = 4;
+    vshift=KEY_RSHIFT;
+    shiftl=KEY_LSHIFT;
 
-//# Joyport attached keypad key mappings
-keyboard_parse_set_neg_row(300, -5, 0);               /*      NumLock -> keypad x0    */
-keyboard_parse_set_neg_row(263, -5, 1);               /*     NumPad 7 -> keypad 7     */
-keyboard_parse_set_neg_row(264, -5, 2);               /*     NumPad 8 -> keypad 8     */
-keyboard_parse_set_neg_row(265, -5, 3);               /*     NumPad 9 -> keypad 9     */
-keyboard_parse_set_neg_row(267, -5, 4);               /*     NumPad / -> keypad /     */
-keyboard_parse_set_neg_row(302, -5, 5);               /*   ScrollLock -> keypad x1    */
-keyboard_parse_set_neg_row(260, -5, 6);               /*     NumPad 4 -> keypad 4     */
-keyboard_parse_set_neg_row(261, -5, 7);               /*     NumPad 5 -> keypad 5     */
-keyboard_parse_set_neg_row(262, -5, 8);               /*     NumPad 6 -> keypad 6     */
-keyboard_parse_set_neg_row(268, -5, 9);               /*     NumPad * -> keypad *     */
-keyboard_parse_set_neg_row(317, -5, 10);              /*       SysReq -> keypad x2    */
-keyboard_parse_set_neg_row(257, -5, 11);              /*     NumPad 1 -> keypad 1     */
-keyboard_parse_set_neg_row(258, -5, 12);              /*     NumPad 2 -> keypad 2     */
-keyboard_parse_set_neg_row(259, -5, 13);              /*     NumPad 3 -> keypad 3     */
-keyboard_parse_set_neg_row(269, -5, 14);              /*     NumPad - -> keypad -     */
-keyboard_parse_set_neg_row(316, -5, 15);              /*       PrtScr -> keypad x3    */
-keyboard_parse_set_neg_row(256, -5, 16);              /*     NumPad 0 -> keypad 0     */
-keyboard_parse_set_neg_row(266, -5, 17);              /*     NumPad , -> keypad .     */
-keyboard_parse_set_neg_row(271, -5, 18);              /* NumPad Enter -> keypad enter */
-keyboard_parse_set_neg_row(270, -5, 19);              /*     NumPad + -> keypad +     */
+    keyboard_parse_set_pos_row(27, 7, 7, 8);                /*          ESC -> Run/Stop     */
+    keyboard_parse_set_pos_row(49, 7, 0, 8);                /*            1 -> 1            */
+    keyboard_parse_set_pos_row(50, 7, 3, 8);                /*            2 -> 2            */
+    keyboard_parse_set_pos_row(51, 1, 0, 8);                /*            3 -> 3            */
+    keyboard_parse_set_pos_row(52, 1, 3, 8);                /*            4 -> 4            */
+    keyboard_parse_set_pos_row(53, 2, 0, 8);                /*            5 -> 5            */
+    keyboard_parse_set_pos_row(54, 2, 3, 8);                /*            6 -> 6            */
+    keyboard_parse_set_pos_row(55, 3, 0, 8);                /*            7 -> 7            */
+    keyboard_parse_set_pos_row(56, 3, 3, 8);                /*            8 -> 8            */
+    keyboard_parse_set_pos_row(57, 4, 0, 8);                /*            9 -> 9            */
+    keyboard_parse_set_pos_row(48, 4, 3, 8);                /*            0 -> 0            */
+    keyboard_parse_set_pos_row(45, 5, 0, 8);                /*        Minus -> Plus         */
+    keyboard_parse_set_pos_row(61, 5, 3, 8);                /*        Equal -> Minus        */
+    keyboard_parse_set_pos_row(8, 0, 0, 8);                 /*    Backspace -> Del          */
+    keyboard_parse_set_pos_row(9, 7, 2, 8);                 /*          TAB -> Ctrl         */
+    keyboard_parse_set_pos_row(113, 7, 6, 8);               /*            Q -> Q            */
+    keyboard_parse_set_pos_row(119, 1, 1, 8);               /*            W -> W            */
+    keyboard_parse_set_pos_row(101, 1, 6, 8);               /*            E -> E            */
+    keyboard_parse_set_pos_row(114, 2, 1, 8);               /*            R -> R            */
+    keyboard_parse_set_pos_row(116, 2, 6, 8);               /*            T -> T            */
+    keyboard_parse_set_pos_row(121, 3, 1, 8);               /*            Y -> Y            */
+    keyboard_parse_set_pos_row(117, 3, 6, 8);               /*            U -> U            */
+    keyboard_parse_set_pos_row(105, 4, 1, 8);               /*            I -> I            */
+    keyboard_parse_set_pos_row(111, 4, 6, 8);               /*            O -> O            */
+    keyboard_parse_set_pos_row(112, 5, 1, 8);               /*            P -> P            */
+    keyboard_parse_set_pos_row(91, 5, 6, 8);                /*            [ -> @            */
+    keyboard_parse_set_pos_row(93, 6, 1, 8);                /*            ] -> *            */
+    keyboard_parse_set_pos_row(13, 0, 1, 8);                /*       Return -> Return       */
+    keyboard_parse_set_pos_row(306, 7, 5, 8);               /*    Left Ctrl -> CBM          */
+    keyboard_parse_set_pos_row(97, 1, 2, 8);                /*            A -> A            */
+    keyboard_parse_set_pos_row(115, 1, 5, 8);               /*            S -> S            */
+    keyboard_parse_set_pos_row(100, 2, 2, 8);               /*            D -> D            */
+    keyboard_parse_set_pos_row(102, 2, 5, 8);               /*            F -> F            */
+    keyboard_parse_set_pos_row(103, 3, 2, 8);               /*            G -> G            */
+    keyboard_parse_set_pos_row(104, 3, 5, 8);               /*            H -> H            */
+    keyboard_parse_set_pos_row(106, 4, 2, 8);               /*            J -> J            */
+    keyboard_parse_set_pos_row(107, 4, 5, 8);               /*            K -> K            */
+    keyboard_parse_set_pos_row(108, 5, 2, 8);               /*            L -> L            */
+    keyboard_parse_set_pos_row(59, 5, 5, 8);                /*            ; -> :            */
+    keyboard_parse_set_pos_row(39, 6, 2, 8);                /*            ' -> ;            */
+    keyboard_parse_set_pos_row(96, 7, 1, 8);                /*            ` -> Left Arrow   */
+    keyboard_parse_set_pos_row(92, 6, 5, 8);                /*            \ -> =            */
+    keyboard_parse_set_pos_row(304, 1, 7, 2);               /*   Left Shift -> Left Shift   */
+    keyboard_parse_set_pos_row(301, 1, 7, 64);              /*    Caps Lock -> Shift Lock   */
+    keyboard_parse_set_pos_row(122, 1, 4, 8);               /*            Z -> Z            */
+    keyboard_parse_set_pos_row(120, 2, 7, 8);               /*            X -> X            */
+    keyboard_parse_set_pos_row(99, 2, 4, 8);                /*            C -> C            */
+    keyboard_parse_set_pos_row(118, 3, 7, 8);               /*            V -> V            */
+    keyboard_parse_set_pos_row(98, 3, 4, 8);                /*            B -> B            */
+    keyboard_parse_set_pos_row(110, 4, 7, 8);               /*            N -> N            */
+    keyboard_parse_set_pos_row(109, 4, 4, 8);               /*            M -> M            */
+    keyboard_parse_set_pos_row(44, 5, 7, 8);                /*            , -> ,            */
+    keyboard_parse_set_pos_row(46, 5, 4, 8);                /*            . -> .            */
+    keyboard_parse_set_pos_row(47, 6, 7, 8);                /*            / -> /            */
+    keyboard_parse_set_pos_row(303, 6, 4, 4);               /*  Right Shift -> Right Shift  */
+    keyboard_parse_set_pos_row(32, 7, 4, 8);                /*        Space -> Space        */
+    keyboard_parse_set_pos_row(282, 0, 4, 8);               /*           F1 -> F1           */
+    keyboard_parse_set_pos_row(283, 0, 4, 1);               /*           F2 -> F2           */
+    keyboard_parse_set_pos_row(284, 0, 5, 8);               /*           F3 -> F3           */
+    keyboard_parse_set_pos_row(285, 0, 5, 1);               /*           F4 -> F4           */
+    keyboard_parse_set_pos_row(286, 0, 6, 8);               /*           F5 -> F5           */
+    keyboard_parse_set_pos_row(287, 0, 6, 1);               /*           F6 -> F6           */
+    keyboard_parse_set_pos_row(288, 0, 3, 8);               /*           F7 -> F7           */
+    keyboard_parse_set_pos_row(289, 0, 3, 1);               /*           F8 -> F8           */
+    keyboard_parse_set_pos_row(278, 6, 3, 8);               /*         Home -> CLR/HOME     */
+    keyboard_parse_set_pos_row(273, 0, 7, 1);               /*           Up -> CRSR UP      */
+    keyboard_parse_set_pos_row(276, 0, 2, 1);               /*         Left -> CRSR LEFT    */
+    keyboard_parse_set_pos_row(275, 0, 2, 8);               /*        Right -> CRSR RIGHT   */
+    keyboard_parse_set_pos_row(274, 0, 7, 8);               /*         Down -> CRSR DOWN    */
+    keyboard_parse_set_pos_row(277, 6, 0, 8);               /*          Ins -> Pound        */
+    keyboard_parse_set_pos_row(127, 6, 6, 8);               /*          Del -> Up Arrow     */
+    keyboard_parse_set_neg_row(280, -3, 0);                 /*       PageUp -> Restore      */
 #endif
-
-	//log_message(keyboard_log, "Done!");
 }
 

--- a/vice/src/arch/libretro/joy.c
+++ b/vice/src/arch/libretro/joy.c
@@ -91,8 +91,4 @@ void joystick_close(void)
     return;
 }
 
-void kbd_initialize_numpad_joykeys(int* joykeys)
-{
-}
-
 /* ------------------------------------------------------------------------- */

--- a/vice/src/arch/libretro/kbd.c
+++ b/vice/src/arch/libretro/kbd.c
@@ -1,5 +1,6 @@
+#include <stdio.h>
+
 #include "kbd.h"
-#include "libretro.h"
 #include "joystick.h"
 #include "keyboard.h"
 
@@ -11,4 +12,25 @@ void kbd_handle_keydown(int kcode)
 void kbd_handle_keyup(int kcode)
 {
    keyboard_key_released((signed long)kcode);
+}
+
+signed long kbd_arch_keyname_to_keynum(char *keyname) {
+	return (signed long)atoi(keyname);
+}
+
+const char *kbd_arch_keynum_to_keyname(signed long keynum) {
+	static char keyname[20];
+
+	memset(keyname, 0, 20);
+	sprintf(keyname, "%li", keynum);
+	return keyname;
+}
+
+void kbd_arch_init()
+{
+    keyboard_clear_keymatrix();
+}
+
+void kbd_initialize_numpad_joykeys(int* joykeys)
+{
 }

--- a/vice/src/arch/libretro/kbd.h
+++ b/vice/src/arch/libretro/kbd.h
@@ -27,7 +27,6 @@
 #ifndef _KBD_H
 #define _KBD_H
 
-//#define KBD_PORT_PREFIX "retro"
 #define KBD_PORT_PREFIX "sdl"
 
 extern void kbd_arch_init(void);
@@ -41,6 +40,4 @@ extern int kbd_arch_get_host_mapping(void);
 extern void kbd_handle_keydown(int kcode);
 extern void kbd_handle_keyup(int kcode);
 
-
 #endif
-

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -43,6 +43,7 @@
 #include "c128model.h"
 #elif defined(__PET__)
 #include "petmodel.h"
+#include "keyboard.h"
 #elif defined(__CBM2__)
 #include "cbm2model.h"
 #else
@@ -308,6 +309,7 @@ int ui_init_finalize(void)
    c128model_set(RETROC64MODL);
 #elif defined(__PET__)
    petmodel_set(RETROC64MODL);
+   keyboard_init();
 #elif defined(__CBM2__)
    cbm2model_set(RETROC64MODL);
 #elif defined(__XSCPU64__)

--- a/vice/src/keyboard.c
+++ b/vice/src/keyboard.c
@@ -1389,7 +1389,9 @@ static int keyboard_set_keyboard_type(int val, void *param)
 
     mapping = machine_keyboard_mapping;
     idx = machine_keymap_index;
-
+#ifdef __LIBRETRO__
+    machine_keyboard_type = val;
+#endif
     DBG((">keyboard_set_keyboard_type(idx:%d mapping:%d type:%d)\n", idx, mapping, val));
     if (idx < 2) {
         if (switch_keymap_file(&idx, &mapping, &val) < 0) {
@@ -1411,10 +1413,6 @@ static int keyboard_set_keyboard_type(int val, void *param)
     return 0;
 }
 
-#ifdef __LIBRETRO__
-#include "defaultkey.inc"
-#endif
-
 /* handle change if "KeyboardMapping" */
 static int keyboard_set_keyboard_mapping(int val, void *param)
 {
@@ -1430,10 +1428,6 @@ static int keyboard_set_keyboard_mapping(int val, void *param)
         if (switch_keymap_file(&idx, &val, &type) < 0) {
             /*log_error(keyboard_log, "Default keymap not found, this should be fixed. Going on anyway...");*/
             /* return -1; */
-#ifdef __LIBRETRO__
-            log_message(keyboard_log, "Default keymap embedded libretro...");
-            retro_defaultkeyboard();
-#endif
             return 0; /* HACK: allow to start up when default keymap is missing */
         }
         machine_keymap_index = idx;
@@ -1748,6 +1742,9 @@ int keyboard_cmdline_options_init(void)
 }
 
 /*--------------------------------------------------------------------------*/
+#ifdef __LIBRETRO__
+#include "defaultkey.inc"
+#endif
 
 void keyboard_init(void)
 {
@@ -1759,6 +1756,9 @@ void keyboard_init(void)
                             restore_alarm_triggered, NULL);
 
     kbd_arch_init();
+#ifdef __LIBRETRO__
+    libretro_keyboard();
+#endif
 
     if (machine_class != VICE_MACHINE_VSID) {
         load_keymap_ok = 1;

--- a/vice/src/pet/petembedded.c
+++ b/vice/src/pet/petembedded.c
@@ -63,6 +63,31 @@
 #include "crtc_green_vpl.h"
 #include "crtc_white_vpl.h"
 
+#ifdef __LIBRETRO__
+static embedded_t petfiles[] = {
+    { "chargen", -0x800, 0x1000, 0x800, petchargen_embedded },
+    { "basic4", 0x2000, 0x3000, 0x3000, petbasic4_embedded },
+    { "kernal4", 0x1000, 0x1000, 0x1000, petkernal4_embedded },
+    { "edit4b80", -0x800, 0x1000, 0x800, petedit4b80_embedded },
+    { "kernal1", 0x1000, 0x1000, 0x1000, petkernal1_embedded },
+    { "basic1", 0x2000, 0x3000, 0x2000, petbasic1_embedded },
+    { "basic2", 0x2000, 0x3000, 0x2000, petbasic2_embedded },
+    { "kernal2", 0x1000, 0x1000, 0x1000, petkernal2_embedded },
+    { "edit1g", -0x800, 0x1000, 0x800, petedit1g_embedded },
+    { "edit2b", -0x800, 0x1000, 0x800, petedit2b_embedded },
+    { "edit2g", -0x800, 0x1000, 0x800, petedit2g_embedded },
+    { "edit4b40", -0x800, 0x1000, 0x800, petedit4b40_embedded },
+    { "edit4g40", -0x800, 0x1000, 0x800, petedit4g40_embedded },
+    { "characters.901640-01.bin", -0x800, 0x1000, 0x1000, superpet_char_embedded },
+    { "waterloo-a000.901898-01.bin", -0x1000, 0x6000, 0x1000, superpet_waterloo_a000_embedded },
+    { "waterloo-b000.901898-02.bin", -0x1000, 0x5000, 0x1000, superpet_waterloo_b000_embedded },
+    { "waterloo-c000.901898-03.bin", -0x1000, 0x4000, 0x1000, superpet_waterloo_c000_embedded },
+    { "waterloo-d000.901898-04.bin", -0x1000, 0x3000, 0x1000, superpet_waterloo_d000_embedded },
+    { "waterloo-e000.901897-01.bin", -0x800, 0x2000, 0x800, superpet_waterloo_e000_embedded },
+    { "waterloo-f000.901898-05.bin", -0x1000, 0x1000, 0x1000, superpet_waterloo_f000_embedded },
+    EMBEDDED_LIST_END
+};
+#else
 static embedded_t petfiles[] = {
     { "chargen", 0x800, 0x800, 0x800, petchargen_embedded },
     { "basic4", 0x2000, 0x3000, 0x3000, petbasic4_embedded },
@@ -86,6 +111,7 @@ static embedded_t petfiles[] = {
     { "waterloo-f000.901898-05.bin", 0x1000, 0x1000, 0x1000, superpet_waterloo_f000_embedded },
     EMBEDDED_LIST_END
 };
+#endif
 
 static embedded_palette_t palette_files[] = {
     { "amber", "amber.vpl", 2, crtc_amber_vpl },


### PR DESCRIPTION
Additions:
- M3U+ZIP capabilities on par with PUAE (M3U can include zipped disks, and both can be appended/replaced via Disk Control)
  Closes #136 
- Drive type autodetect also when changing disks
  - Main reason for this is because the default is 1541, and thus inserting any other disk than D64 when started without content will not work. Also makes it possible to mix different types in the same M3U, even if not really practical.
  - Tapes and disks can't be mixed, but Datasette can also be enabled/disabled via Disk Control

Fixes:
- Automatic Aspect Ratio not getting the right region after model change with disabled borders, because the borderless dimension stays the same, and the geometry change was only lurking on those to change
Closes #225 

- Proper PET keyboard layout needed some extra care and renovations, because different models use different layout, and the current keymap method was not flexible enough
Closes #223 

Bonus:
- PET required the data files under `system/vice/PET`, because the embedded data checks were goofed by VICE authors, but that is no longer the case
- Changed default PET model to 8032 just like in standalone
- Cleanups on aisle archdep


