### PR TITLE
Remove border stuff, Manual cropping options

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -108,7 +108,6 @@ extern int vic20mem_forced;
 extern int RETROUSERPORTJOY;
 extern int RETROEXTPAL;
 extern int RETROAUTOSTARTWARP;
-extern int RETROBORDERS;
 extern int RETROTHEME;
 extern int RETROKEYRAHKEYPAD;
 extern int RETROKEYBOARDPASSTHROUGH;
@@ -155,14 +154,6 @@ extern int cur_port_locked;
 
 extern int turbo_fire_button;
 extern unsigned int turbo_pulse;
-
-#if defined(__VIC20__)
-char resources_var_border[20] = "VICBorderMode";
-#elif defined(__PLUS4__)
-char resources_var_border[20] = "TEDBorderMode";
-#else
-char resources_var_border[20] = "VICIIBorderMode";
-#endif
 
 //VICE DEF BEGIN
 #include "resources.h"
@@ -215,11 +206,6 @@ int disk_label_mode = DISK_LABEL_MODE_ASCII_OR_CAMELCASE;
 static char* x_strdup(const char* str)
 {
     return str ? strdup(str) : NULL;
-}
-
-unsigned int retro_get_borders(void)
-{
-   return RETROBORDERS;
 }
 
 void retro_set_input_state(retro_input_state_t cb)
@@ -1203,19 +1189,6 @@ void retro_set_environment(retro_environment_t cb)
          },
          "disabled"
       },
-#if !defined(__PET__) && !defined(__CBM2__) && 0
-      {
-         "vice_border",
-         "Display Borders",
-         "All cores except 'x64sc' will reset when this option is changed.",
-         {
-            { "enabled", NULL },
-            { "disabled", NULL },
-            { NULL, NULL },
-         },
-         "enabled"
-      },
-#endif
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__VIC20__) || defined(__PLUS4__)
       {
          "vice_aspect_ratio",
@@ -2875,21 +2848,6 @@ static void update_variables(void)
    }
 #endif
 
-#if !defined(__PET__) && !defined(__CBM2__) && 0
-   var.key = "vice_border";
-   var.value = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      int border=0; /* 0 : normal, 1: full, 2: debug, 3: none */
-      if (strcmp(var.value, "enabled") == 0) border=0;
-      else if (strcmp(var.value, "disabled") == 0) border=3;
-
-      RETROBORDERS=border;
-      if (retro_ui_finalized)
-         log_resources_set_int(resources_var_border, border);
-   }
-#endif
-
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__VIC20__) || defined(__PLUS4__)
    var.key = "vice_zoom_mode";
    var.value = NULL;
@@ -2900,10 +2858,6 @@ static void update_variables(void)
       else if (strcmp(var.value, "medium") == 0) zoom_mode_id=2;
       else if (strcmp(var.value, "maximum") == 0) zoom_mode_id=3;
 
-#if 0
-      if (RETROBORDERS)
-         zoom_mode_id = 0;
-#endif
 #if defined(__X128__)
       if (RETROC128COLUMNKEY==0)
          zoom_mode_id = 0;
@@ -3736,12 +3690,10 @@ static void update_variables(void)
    /* Video options */
    option_display.visible = opt_video_options_display;
 
-#if !defined(__PET__) && !defined(__CBM2__) && 0
-   option_display.key = "vice_border";
-   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
-#endif
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__VIC20__) || defined(__PLUS4__)
    option_display.key = "vice_zoom_mode";
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+   option_display.key = "vice_zoom_mode_crop";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
    option_display.key = "vice_aspect_ratio";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
@@ -4355,23 +4307,6 @@ void update_geometry(int mode)
             environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &system_av_info);
             return;
          }
-#if 0
-         if (retro_get_borders())
-            // When borders are disabled, each system has a different aspect ratio.
-            // For example, C64 & C128 have 320 / 200 pixel resolution with a 15 / 16
-            // pixel aspect ratio leading to a total aspect of 320 / 200 * 15 / 16 = 1.5
-         #if defined(__VIC20__)
-            system_av_info.geometry.aspect_ratio = (float)1.6;
-         #elif defined(__PLUS4__)
-            system_av_info.geometry.aspect_ratio = (float)1.65;
-         #elif defined(__PET__)
-            system_av_info.geometry.aspect_ratio = (float)4.0/3.0;
-         #else
-            system_av_info.geometry.aspect_ratio = (float)1.5;
-         #endif
-         else
-            system_av_info.geometry.aspect_ratio = retro_get_aspect_ratio(retroW, retroH);
-#endif
          break;
 
       case 1:

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -60,6 +60,17 @@ typedef uint8_t uint8;
 extern unsigned short int retro_bmp[RETRO_BMP_SIZE];
 extern int pix_bytes;
 
+#define MANUAL_CROP_OPTIONS \
+   { \
+      { "0", NULL }, \
+      { "1", NULL }, { "2", NULL }, { "3", NULL }, { "4", NULL }, { "5", NULL }, { "6", NULL }, { "7", NULL }, { "8", NULL }, { "9", NULL }, { "10", NULL }, \
+      { "11", NULL }, { "12", NULL }, { "13", NULL }, { "14", NULL }, { "15", NULL }, { "16", NULL }, { "17", NULL }, { "18", NULL }, { "19", NULL }, { "20", NULL }, \
+      { "21", NULL }, { "22", NULL }, { "23", NULL }, { "24", NULL }, { "25", NULL }, { "26", NULL }, { "27", NULL }, { "28", NULL }, { "29", NULL }, { "30", NULL }, \
+      { "31", NULL }, { "32", NULL }, { "33", NULL }, { "34", NULL }, { "35", NULL }, { "36", NULL }, { "37", NULL }, { "38", NULL }, { "39", NULL }, { "40", NULL }, \
+      { "41", NULL }, { "42", NULL }, { "43", NULL }, { "44", NULL }, { "45", NULL }, { "46", NULL }, { "47", NULL }, { "48", NULL }, { "49", NULL }, { "50", NULL }, \
+      { NULL, NULL }, \
+   }
+
 //VKBD
 #define NPLGN 11
 #define NLIGN 7

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -109,7 +109,6 @@ extern int RETROUSERPORTJOY;
 //FUNCS
 extern void maincpu_mainloop_retro(void);
 extern long GetTicks(void);
-extern unsigned int retro_get_borders(void);
 
 enum {
 	RUNSTATE_FIRST_START = 0,

--- a/libretro/vkbd.c
+++ b/libretro/vkbd.c
@@ -120,120 +120,81 @@ void print_virtual_kbd(unsigned short int *pixels)
    int BKG_PADDING_Y_DEFAULT = -3;
 
 #if defined(__VIC20__)
-   if (retro_get_borders())
+   if (retro_get_region() == RETRO_REGION_NTSC)
    {
-      XOFFSET           = 4;
-      YOFFSET           = -4;
-      XPADDING          = 4;
-      YPADDING          = 8;
-      
-      if (opt_statusbar & STATUSBAR_TOP)
-         YOFFSET        = 4;
+      XOFFSET           = 9;
+      YOFFSET           = -3;
+      XPADDING          = 44;
+      YPADDING          = 58;
+
+      if (zoom_mode_id == 3)
+      {
+         if (opt_statusbar & STATUSBAR_TOP)
+            YOFFSET = -2;
+         else
+            YOFFSET = -7;
+      }
    }
    else
-   {
-      if (retro_get_region() == RETRO_REGION_NTSC)
-      {
-         XOFFSET           = 9;
-         YOFFSET           = -3;
-         XPADDING          = 44;
-         YPADDING          = 58;
-
-         if (zoom_mode_id == 3)
-         {
-            if (opt_statusbar & STATUSBAR_TOP)
-               YOFFSET = -2;
-            else
-               YOFFSET = -7;
-         }
-      }
-      else
-      {
-         XOFFSET           = 4;
-         YOFFSET           = -3;
-         XPADDING          = 98;
-         YPADDING          = 108;
-
-         if (zoom_mode_id == 3)
-         {
-            if (opt_statusbar & STATUSBAR_TOP)
-               YOFFSET = 2;
-            else
-               YOFFSET = -6;
-         }
-      }
-   }
-#elif defined(__PLUS4__)
-   if (retro_get_borders())
    {
       XOFFSET           = 4;
       YOFFSET           = -3;
-      XPADDING          = 4;
-      YPADDING          = 8;
-      
-      if (opt_statusbar & STATUSBAR_TOP)
-         YOFFSET        = 5;
+      XPADDING          = 98;
+      YPADDING          = 108;
+
+      if (zoom_mode_id == 3)
+      {
+         if (opt_statusbar & STATUSBAR_TOP)
+            YOFFSET = 2;
+         else
+            YOFFSET = -6;
+      }
+   }
+#elif defined(__PLUS4__)
+   if (retro_get_region() == RETRO_REGION_NTSC)
+   {
+      XOFFSET           = 0;
+      YOFFSET           = -3;
+      XPADDING          = 64;
+      YPADDING          = 52;
+
+      if (zoom_mode_id == 3)
+      {
+         if (opt_statusbar & STATUSBAR_TOP)
+            YOFFSET = 1;
+         else
+            YOFFSET = -7;
+      }
    }
    else
    {
-      if (retro_get_region() == RETRO_REGION_NTSC)
-      {
-         XOFFSET           = 0;
-         YOFFSET           = -3;
-         XPADDING          = 64;
-         YPADDING          = 52;
+      XOFFSET           = 4;
+      YOFFSET           = -3;
+      XPADDING          = 66;
+      YPADDING          = 96;
 
-         if (zoom_mode_id == 3)
-         {
-            if (opt_statusbar & STATUSBAR_TOP)
-               YOFFSET = 1;
-            else
-               YOFFSET = -7;
-         }
-      }
-      else
+      if (zoom_mode_id == 3)
       {
-         XOFFSET           = 4;
-         YOFFSET           = -3;
-         XPADDING          = 66;
-         YPADDING          = 96;
-
-         if (zoom_mode_id == 3)
-         {
-            if (opt_statusbar & STATUSBAR_TOP)
-               YOFFSET = 1;
-            else
-               YOFFSET = -7;
-         }      
+         if (opt_statusbar & STATUSBAR_TOP)
+            YOFFSET = 1;
+         else
+            YOFFSET = -7;
       }
    }
 #else
-   if (retro_get_borders())
-   {
-      XOFFSET           = 1;
-      YOFFSET           = -4;
-      XPADDING          = 8;
-      YPADDING          = 10;
-      
-      if (opt_statusbar & STATUSBAR_TOP)
-         YOFFSET        = 4;
-   }
-   else
-   {
-      XOFFSET           = 0;
-      YOFFSET           = 1;
-      XPADDING          = 74;
-      YPADDING          = 78;
+   XOFFSET           = 0;
+   YOFFSET           = 1;
+   XPADDING          = 74;
+   YPADDING          = 78;
 
-      if (retro_get_region() != RETRO_REGION_NTSC)
-      {
-         if (zoom_mode_id == 3)
-            YOFFSET = -3;
-      }
-
-      if (opt_statusbar & STATUSBAR_TOP)
-         YOFFSET = 5;
+   if (retro_get_region() != RETRO_REGION_NTSC)
+   {
+      if (zoom_mode_id == 3)
+         YOFFSET = -3;
    }
+
+   if (opt_statusbar & STATUSBAR_TOP)
+      YOFFSET = 5;
 #endif
 
    int XSIDE = (retroW - XPADDING) / NPLGN;

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -89,7 +89,6 @@ int vic20mem_forced=-1;
 int RETROUSERPORTJOY=-1;
 int RETROEXTPAL=-1;
 int RETROAUTOSTARTWARP=0;
-int RETROBORDERS=0;
 int RETROTHEME=0;
 int RETROKEYRAHKEYPAD=0;
 int RETROKEYBOARDPASSTHROUGH=0;
@@ -354,16 +353,6 @@ int ui_init_finalize(void)
    log_resources_set_int("SidResid8580Passband", RETRORESIDPASSBAND);
    log_resources_set_int("SidResid8580Gain", RETRORESIDGAIN);
    log_resources_set_int("SidResid8580FilterBias", RETRORESID8580FILTERBIAS);
-#endif
-
-#if !defined(__PET__) && !defined(__CBM2__)
-#if defined(__VIC20__)
-   log_resources_set_int("VICBorderMode", RETROBORDERS);
-#elif defined(__PLUS4__)
-   log_resources_set_int("TEDBorderMode", RETROBORDERS);
-#else
-   log_resources_set_int("VICIIBorderMode", RETROBORDERS);
-#endif
 #endif
 
 #if defined(__X128__)

--- a/vice/src/arch/libretro/uistatusbar.c
+++ b/vice/src/arch/libretro/uistatusbar.c
@@ -554,11 +554,9 @@ void uistatusbar_draw(void)
     int bkg_height = char_width + 2;
 
     // Right alignment offset
-    int x_align_offset = (retroW - zoomed_width) + 4 - ((retroXS_offset > 0) ? (retroXS_offset * 2) : 0);
-    if (retroW != zoomed_width)
+    int x_align_offset = 4;
+    if (retroW != zoomed_width && retroXS_offset != 0)
         x_align_offset += 1;
-    if (x_align_offset < 0)
-        x_align_offset = 0;
 
     // Basic mode statusbar background
     if (opt_statusbar & STATUSBAR_BASIC && imagename_timer == 0)


### PR DESCRIPTION
Forgot the visibility for the new core option, oops. Also removed all the old border bits.

Bonus addition:
- Manual cropping core options (top/bottom/left/right)
  - Overrides zoom if any is not 0, restores zoom if all are 0
