### PR TITLE
Work disk core option with device selection

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -17,7 +17,7 @@ Source base: https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.t
 - System-subdir renamed to `vice` and created automatically
 - Cursor keys disabled while using RetroPad
 - New settings:
-  - Drive Sound Emulation (D64 only)
+  - Drive Sound Emulation (D64 & D71 only)
   - Reset Type (Autostart, Soft, Hard)
   - Customizable hotkeys for essential functions (virtual keyboard, statusbar, joyport switch, reset, Datasette controls)
   - Keyrah joystick maps

--- a/vice/src/autostart.c
+++ b/vice/src/autostart.c
@@ -1212,6 +1212,9 @@ int autostart_disk(const char *file_name, const char *program_name,
                     drive_cpu_trigger_reset(0);
                 }
             }
+
+            // Autostarting D71s will fail without re-attaching (?!)
+            file_system_attach_disk(8, file_name);
 #endif
 
             reboot_for_autostart(name, AUTOSTART_HASDISK, runmode);


### PR DESCRIPTION
- Disks are created in `saves`, named as `vice_work.<ext>` and labeled as `work-<ext>`
- Having a work disk in device 8 does nothing when starting content
- Skipped less known disk types and devices 10 & 11 for now from polluting the option list

Please point out any inconvenience with this method, and of course if more options are needed.
