### PR TITLE
2nd SID, Sound adjustments, VIC-20 updates

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1476,7 +1476,7 @@ void retro_set_environment(retro_environment_t cb)
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__VIC20__) || defined(__PLUS4__)
       {
          "vice_aspect_ratio",
-         "Pixel Aspect Ratio",
+         "Video > Pixel Aspect Ratio",
          "",
          {
             { "auto", "Automatic" },
@@ -1489,7 +1489,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_zoom_mode",
-         "Zoom Mode",
+         "Video > Zoom Mode",
          "Crops the borders to fit various host screens. Requirements in RetroArch settings:\n- Aspect Ratio: Core provided,\n- Integer Scale: Off.",
          {
             { "none", "disabled" },
@@ -1503,7 +1503,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_zoom_mode_crop",
-         "Zoom Mode Crop",
+         "Video > Zoom Mode Crop",
          "Use 'Both' & 'Maximum' to remove borders completely. Ignored with 'Manual' zoom.",
          {
             { "both", "Both" },
@@ -1519,7 +1519,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_manual_crop_top",
-         "Manual Crop Top",
+         "Video > Manual Crop Top",
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
          "VIC-II top border height:\n- 35px PAL\n- 23px NTSC",
 #elif defined(__VIC20__)
@@ -1532,7 +1532,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_manual_crop_bottom",
-         "Manual Crop Bottom",
+         "Video > Manual Crop Bottom",
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
          "VIC-II bottom border height:\n- 37px PAL\n- 24px NTSC",
 #elif defined(__VIC20__)
@@ -1545,7 +1545,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_manual_crop_left",
-         "Manual Crop Left",
+         "Video > Manual Crop Left",
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
          "VIC-II left border width:\n- 32px",
 #elif defined(__VIC20__)
@@ -1558,7 +1558,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_manual_crop_right",
-         "Manual Crop Right",
+         "Video > Manual Crop Right",
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
          "VIC-II right border width:\n- 32px",
 #elif defined(__VIC20__)
@@ -1572,7 +1572,7 @@ void retro_set_environment(retro_environment_t cb)
 #endif
       {
          "vice_statusbar",
-         "Statusbar Mode",
+         "Video > Statusbar Mode",
          "- Full: Joyports + Current image + LEDs\n- Basic: Current image + LEDs\n- Minimal: Track number + FPS hidden",
          {
             { "bottom", "Bottom Full" },
@@ -1589,8 +1589,8 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_vkbd_theme",
-         "Virtual Keyboard Theme",
-         "By default, the keyboard comes up with SELECT button or F11 key.",
+         "Video > Virtual KBD Theme",
+         "By default, the keyboard comes up with RetroPad Select or F11.",
          {
             { "0", "C64" },
             { "1", "C64C" },
@@ -1602,8 +1602,8 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_vkbd_alpha",
-         "Virtual Keyboard Transparency",
-         "",
+         "Video > Virtual KBD Transparency",
+         "Keyboard transparency can be toggled with RetroPad A.",
          {
             { "0\%", NULL },
             { "5\%", NULL },
@@ -1631,7 +1631,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_gfx_colors",
-         "Color Depth",
+         "Video > Color Depth",
          "24-bit is slower and not available on all platforms. Full restart required.",
          {
             { "16bit", "Thousands (16-bit)" },
@@ -1643,7 +1643,7 @@ void retro_set_environment(retro_environment_t cb)
 #if defined(__VIC20__)
       {
          "vice_vic20_external_palette",
-         "Color Palette",
+         "Video > Color Palette",
          "Colodore is recommended for the most accurate colors.",
          {
             { "default", "Default" },
@@ -1658,7 +1658,7 @@ void retro_set_environment(retro_environment_t cb)
 #elif defined(__PLUS4__) 
       {
          "vice_plus4_external_palette",
-         "Color Palette",
+         "Video > Color Palette",
          "Colodore is recommended for the most accurate colors.",
          {
             { "default", "Default" },
@@ -1672,7 +1672,7 @@ void retro_set_environment(retro_environment_t cb)
 #elif defined(__PET__)
       {
          "vice_pet_external_palette",
-         "Color Palette",
+         "Video > Color Palette",
          "",
          {
             { "default", "Default" },
@@ -1686,7 +1686,7 @@ void retro_set_environment(retro_environment_t cb)
 #elif defined(__CBM2__)
       {
          "vice_cbm2_external_palette",
-         "Color Palette",
+         "Video > Color Palette",
          "",
          {
             { "default", "Default" },
@@ -1700,7 +1700,7 @@ void retro_set_environment(retro_environment_t cb)
 #else
       {
          "vice_external_palette",
-         "Color Palette",
+         "Video > Color Palette",
          "Colodore is recommended for most accurate colors.",
          {
             { "default", "Default" },
@@ -1727,7 +1727,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_vicii_color_gamma",
-         "VIC-II Color Gamma",
+         "Video > VIC-II Color Gamma",
          "Gamma for the internal default palette.",
          {
             { "1000", "1.00" },
@@ -1767,7 +1767,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_vicii_color_saturation",
-         "VIC-II Color Saturation",
+         "Video > VIC-II Color Saturation",
          "Saturation for the internal default palette.",
          {
             { "400", "20\%" },
@@ -1809,7 +1809,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_vicii_color_contrast",
-         "VIC-II Color Contrast",
+         "Video > VIC-II Color Contrast",
          "Contrast for the internal default palette.",
          {
             { "400", "20\%" },
@@ -1851,7 +1851,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_vicii_color_brightness",
-         "VIC-II Color Brightness",
+         "Video > VIC-II Color Brightness",
          "Brightness for the internal default palette.",
          {
             { "400", "20\%" },
@@ -1905,7 +1905,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_drive_sound_emulation",
-         "Drive Sound Emulation",
+         "Audio > Drive Sound Emulation",
          "Emulates the iconic floppy drive sounds.\n- True Drive Emulation & D64 or D71 disk image required.",
          {
             { "disabled", NULL },
@@ -1936,9 +1936,9 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_audio_leak_emulation",
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
-         "VIC-II Audio Leak Emulation",
+         "Audio > VIC-II Audio Leak Emulation",
 #elif defined(__VIC20__)
-         "VIC Audio Leak Emulation",
+         "Audio > VIC Audio Leak Emulation",
 #endif
          "",
          {
@@ -1960,7 +1960,7 @@ void retro_set_environment(retro_environment_t cb)
 #endif
       {
          "vice_sound_sample_rate",
-         "Sound Output Sample Rate",
+         "Audio > Sound Output Sample Rate",
          "Slightly higher quality or higher performance.",
          {
             { "22050", NULL },
@@ -1974,7 +1974,7 @@ void retro_set_environment(retro_environment_t cb)
 #if !defined(__PET__) && !defined(__PLUS4__) && !defined(__VIC20__)
       {
          "vice_sid_engine",
-         "SID Engine",
+         "Audio > SID Engine",
          "ReSID is accurate but slower.",
          {
             { "FastSID", NULL },
@@ -1987,7 +1987,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_sid_model",
-         "SID Model",
+         "Audio > SID Model",
          "The original C64 uses 6581, C64C uses 8580.",
          {
             { "Default", NULL },
@@ -2000,7 +2000,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_sid_extra",
-         "SID Extra",
+         "Audio > SID Extra",
          "Second SID base address.",
          {
             { "disabled", NULL },
@@ -2014,7 +2014,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_resid_sampling",
-         "ReSID Sampling",
+         "Audio > ReSID Sampling",
          "'Resampling' provides best quality. 'Fast' improves performance dramatically on PS Vita.",
          {
             { "Fast", NULL },
@@ -2031,7 +2031,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_resid_passband",
-         "ReSID Filter Passband",
+         "Audio > ReSID Filter Passband",
          "Parameters for SID Filter.",
          {
             { "0", NULL },
@@ -2050,7 +2050,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_resid_gain",
-         "ReSID Filter Gain",
+         "Audio > ReSID Filter Gain",
          "Parameters for SID Filter.",
          {
             { "90", NULL },
@@ -2070,7 +2070,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_resid_filterbias",
-         "ReSID Filter Bias",
+         "Audio > ReSID Filter Bias",
          "Parameters for SID Filter.",
          {
             { "-5000", NULL },
@@ -2100,7 +2100,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_resid_8580filterbias",
-         "ReSID Filter 8580 Bias",
+         "Audio > ReSID Filter 8580 Bias",
          "Parameters for SID Filter.",
          {
             { "-5000", NULL },
@@ -2130,36 +2130,6 @@ void retro_set_environment(retro_environment_t cb)
       },
 #endif
 #if !defined(__PET__) && !defined(__CBM2__) && !defined(__VIC20__)
-      {
-         "vice_joyport",
-         "RetroPad Port",
-         "Most games use port 2, some use port 1.\nFilename forcing or hotkey toggling will disable this option until core restart.",
-         {
-            { "Port 2", NULL },
-            { "Port 1", NULL },
-            { NULL, NULL },
-         },
-         "Port 2"
-      },
-      {
-         "vice_joyport_type",
-         "RetroPad Port Type",
-         "Non-joysticks will be plugged into current port only and are controlled with the left analog stick or a real mouse. Paddles will be split to 1st and 2nd RetroPort.",
-         {
-            { "1", "Joystick" },
-            { "2", "Paddles" },
-            { "3", "Mouse (1351)" },
-            { "4", "Mouse (NEOS)" },
-            { "5", "Mouse (Amiga)" },
-            { "6", "Trackball (Atari CX-22)" },
-            { "7", "Mouse (Atari ST)" },
-            { "8", "Mouse (SmartMouse)" },
-            { "9", "Mouse (Micromys)" },
-            { "10", "Koalapad" },
-            { NULL, NULL },
-         },
-         "1"
-      },
       {
          "vice_analogmouse_deadzone",
          "Analog Stick Mouse Deadzone",
@@ -2289,6 +2259,17 @@ void retro_set_environment(retro_environment_t cb)
          "disabled"
       },
       {
+         "vice_datasette_hotkeys",
+         "Datasette Hotkeys",
+         "Enable/disable all Datasette hotkeys.",
+         {
+            { "disabled", NULL },
+            { "enabled", NULL },
+            { NULL, NULL },
+         },
+         "disabled"
+      },
+      {
          "vice_mapping_options_display",
          "Show Mapping Options",
          "Show options for hotkeys & RetroPad mappings.\nCore options page refresh required.",
@@ -2302,14 +2283,14 @@ void retro_set_environment(retro_environment_t cb)
       /* Hotkeys */
       {
          "vice_mapper_vkbd",
-         "Hotkey: Toggle Virtual Keyboard",
+         "Hotkey > Toggle Virtual Keyboard",
          "Press the mapped key to toggle the virtual keyboard.",
          {{ NULL, NULL }},
          "RETROK_F11"
       },
       {
          "vice_mapper_statusbar",
-         "Hotkey: Toggle Statusbar",
+         "Hotkey > Toggle Statusbar",
          "Press the mapped key to toggle the statusbar.",
          {{ NULL, NULL }},
          "RETROK_F12"
@@ -2317,7 +2298,7 @@ void retro_set_environment(retro_environment_t cb)
 #if !defined(__PET__) && !defined(__CBM2__) && !defined(__VIC20__)
       {
          "vice_mapper_joyport_switch",
-         "Hotkey: Switch Joyports",
+         "Hotkey > Switch Joyports",
          "Press the mapped key to switch joyports 1 & 2.\nSwitching will disable 'RetroPad Port' option until core restart.",
          {{ NULL, NULL }},
          "RETROK_RCTRL"
@@ -2325,7 +2306,7 @@ void retro_set_environment(retro_environment_t cb)
 #endif
       {
          "vice_mapper_reset",
-         "Hotkey: Reset",
+         "Hotkey > Reset",
          "Press the mapped key to trigger reset.",
          {{ NULL, NULL }},
          "RETROK_END"
@@ -2333,7 +2314,7 @@ void retro_set_environment(retro_environment_t cb)
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__VIC20__) || defined(__PLUS4__)
       {
          "vice_mapper_zoom_mode_toggle",
-         "Hotkey: Toggle Zoom Mode",
+         "Hotkey > Toggle Zoom Mode",
          "Press the mapped key to toggle zoom mode.",
          {{ NULL, NULL }},
          "---"
@@ -2341,7 +2322,7 @@ void retro_set_environment(retro_environment_t cb)
 #endif
       {
          "vice_mapper_warp_mode",
-         "Hotkey: Hold Warp Mode",
+         "Hotkey > Hold Warp Mode",
          "Hold the mapped key for warp mode.",
          {{ NULL, NULL }},
          ""
@@ -2349,53 +2330,42 @@ void retro_set_environment(retro_environment_t cb)
       /* Datasette controls */
       {
          "vice_mapper_datasette_toggle_hotkeys",
-         "Hotkey: Toggle Datasette Hotkeys",
+         "Hotkey > Toggle Datasette Hotkeys",
          "Press the mapped key to toggle the Datasette hotkeys.",
          {{ NULL, NULL }},
          "---"
       },
       {
-         "vice_datasette_hotkeys",
-         "Datasette Hotkeys",
-         "Enable/disable all Datasette hotkeys.",
-         {
-            { "disabled", NULL },
-            { "enabled", NULL },
-            { NULL, NULL },
-         },
-         "disabled"
-      },
-      {
          "vice_mapper_datasette_start",
-         "Hotkey: Datasette Start",
+         "Hotkey > Datasette Start",
          "Press start on tape.",
          {{ NULL, NULL }},
          "RETROK_UP"
       },
       {
          "vice_mapper_datasette_stop",
-         "Hotkey: Datasette Stop",
+         "Hotkey > Datasette Stop",
          "Press stop on tape.",
          {{ NULL, NULL }},
          "RETROK_DOWN"
       },
       {
          "vice_mapper_datasette_rewind",
-         "Hotkey: Datasette Rewind",
+         "Hotkey > Datasette Rewind",
          "Press rewind on tape.",
          {{ NULL, NULL }},
          "RETROK_LEFT"
       },
       {
          "vice_mapper_datasette_forward",
-         "Hotkey: Datasette Fast Forward",
+         "Hotkey > Datasette Fast Forward",
          "Press fast forward on tape.",
          {{ NULL, NULL }},
          "RETROK_RIGHT"
       },
       {
          "vice_mapper_datasette_reset",
-         "Hotkey: Datasette Reset",
+         "Hotkey > Datasette Reset",
          "Press reset on tape.",
          {{ NULL, NULL }},
          "---"
@@ -2576,6 +2546,38 @@ void retro_set_environment(retro_environment_t cb)
          },
          "4"
       },
+#if !defined(__PET__) && !defined(__CBM2__) && !defined(__VIC20__)
+      {
+         "vice_joyport",
+         "RetroPad Port",
+         "Most games use port 2, some use port 1.\nFilename forcing or hotkey toggling will disable this option until core restart.",
+         {
+            { "Port 2", NULL },
+            { "Port 1", NULL },
+            { NULL, NULL },
+         },
+         "Port 2"
+      },
+      {
+         "vice_joyport_type",
+         "RetroPad Port Type",
+         "Non-joysticks will be plugged into current port only and are controlled with the left analog stick or a real mouse. Paddles will be split to 1st and 2nd RetroPort.",
+         {
+            { "1", "Joystick" },
+            { "2", "Paddles" },
+            { "3", "Mouse (1351)" },
+            { "4", "Mouse (NEOS)" },
+            { "5", "Mouse (Amiga)" },
+            { "6", "Trackball (Atari CX-22)" },
+            { "7", "Mouse (Atari ST)" },
+            { "8", "Mouse (SmartMouse)" },
+            { "9", "Mouse (Micromys)" },
+            { "10", "Koalapad" },
+            { NULL, NULL },
+         },
+         "1"
+      },
+#endif
       {
          "vice_retropad_options",
          "RetroPad Face Button Options",
@@ -4026,6 +4028,8 @@ static void update_variables(void)
    option_display.key = "vice_sid_engine";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
    option_display.key = "vice_sid_model";
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+   option_display.key = "vice_sid_extra";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
    option_display.key = "vice_resid_sampling";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -4533,8 +4533,12 @@ void retro_init(void)
    else
       environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, &diskControl);
 
-   static uint32_t quirks =  RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE | RETRO_SERIALIZATION_QUIRK_CORE_VARIABLE_SIZE;
+   // Keep as incomplete until rewind can be enabled at startup (snapshot size is 0 at that time)
+   static uint32_t quirks = RETRO_SERIALIZATION_QUIRK_INCOMPLETE | RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE | RETRO_SERIALIZATION_QUIRK_CORE_VARIABLE_SIZE;
    environ_cb(RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS, &quirks);
+
+   bool achievements = true;
+   environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS, &achievements);
 
    //microSecCounter = 0;
 }

--- a/libretro/retro_disk_control.c
+++ b/libretro/retro_disk_control.c
@@ -860,6 +860,11 @@ enum dc_image_type dc_get_image_type(const char* filename)
 	// Memory image
 	if (strendswith(filename, "prg") ||
 	    strendswith(filename, "p00") ||
+	    strendswith(filename, "20")  ||
+	    strendswith(filename, "40")  ||
+	    strendswith(filename, "60")  ||
+	    strendswith(filename, "a0")  ||
+	    strendswith(filename, "b0")  ||
 	    strendswith(filename, "crt") ||
 	    strendswith(filename, "bin"))
 	   return DC_IMAGE_TYPE_MEM;

--- a/vice/src/arch/libretro/archdep.h
+++ b/vice/src/arch/libretro/archdep.h
@@ -43,8 +43,10 @@ extern char retro_save_directory[512];
 #undef VICE_ARCHAPI_PRIVATE_API
 
 /* Default sound output mode */
-#define ARCHDEP_SOUND_OUTPUT_MODE SOUND_OUTPUT_SYSTEM
-#define ARCHDEP_SOCKET_ERROR errno
+#define ARCHDEP_SOUND_OUTPUT_MODE SOUND_OUTPUT_MONO
+
+/* Default sound fragment size */
+#define ARCHDEP_SOUND_FRAGMENT_SIZE SOUND_FRAGMENT_VERY_SMALL
 
 #if defined(__WIN32__) 
 /* Filesystem dependant operators.  */
@@ -151,9 +153,6 @@ extern char retro_save_directory[512];
 
 #endif
 
-/* Default sound fragment size */
-#define ARCHDEP_SOUND_FRAGMENT_SIZE SOUND_FRAGMENT_VERY_SMALL
-
 /* Video chip scaling.  */
 #define ARCHDEP_VICII_DSIZE   1
 #define ARCHDEP_VICII_DSCAN   1
@@ -178,15 +177,16 @@ extern char retro_save_directory[512];
 #define ARCHDEP_CRTC_DBUF  0
 #define ARCHDEP_TED_DBUF   0
 
+#define ARCHDEP_SOCKET_ERROR errno
 
 /* No key symcode.  */
 #define ARCHDEP_KEYBOARD_SYM_NONE 0
 /* Keyword to use for a static prototype */
 #define STATIC_PROTOTYPE static
-extern const char *archdep_home_path(void);
 
 /* set this path to customize the preference storage */ 
 extern const char *archdep_pref_path;
+extern const char *archdep_home_path(void);
 
 /* Define the default system directory (where the ROMs are).  */
 #ifndef __LIBRETRO__
@@ -205,6 +205,4 @@ extern const char *archdep_pref_path;
 
 #define VICEUSERDIR     ".vice"
 
-#endif
-
-
+#endif // _ARCHDEP_H

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -72,6 +72,7 @@ int RETROTDE=0;
 int RETRODSE=0;
 int RETROSIDENGINE=0;
 int RETROSIDMODL=0;
+int RETROSIDEXTRA=0;
 int RETRORESIDSAMPLING=0;
 int RETROSOUNDSAMPLERATE=0;
 int RETRORESIDPASSBAND=0;
@@ -353,6 +354,14 @@ int ui_init_finalize(void)
    log_resources_set_int("SidResid8580Passband", RETRORESIDPASSBAND);
    log_resources_set_int("SidResid8580Gain", RETRORESIDGAIN);
    log_resources_set_int("SidResid8580FilterBias", RETRORESID8580FILTERBIAS);
+
+   if (RETROSIDEXTRA)
+   {
+      log_resources_set_int("SidStereo", 1);
+      log_resources_set_int("SidStereoAddressStart", RETROSIDEXTRA);
+   }
+   else
+      log_resources_set_int("SidStereo", 0);
 #endif
 
 #if defined(__X128__)

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -36,6 +36,7 @@
 #if defined(__VIC20__)
 #include "c64model.h"
 #include "vic20model.h"
+#include "vic20mem.h"
 #elif defined(__PLUS4__)
 #include "c64model.h"
 #include "plus4model.h"
@@ -292,7 +293,7 @@ int ui_init_finalize(void)
    memcpy(c128kernal64_embedded, c128memrom_kernal64_rom_original, C128_KERNAL64_ROM_SIZE);
    memcpy(kernal_int, c128memrom_kernal128_rom_original, C128_KERNAL_ROM_IMAGE_SIZE);
 #endif
-   static char tmp_str[RETRO_PATH_MAX] = {0};
+   char tmp_str[RETRO_PATH_MAX] = {0};
    if (opt_jiffydos)
    {
 #if defined(__X64__) || defined(__X64SC__)
@@ -370,63 +371,45 @@ int ui_init_finalize(void)
 #endif
 
 #if defined(__VIC20__)
-   static unsigned int vic20mem = 0;
+   unsigned int vic20mem = 0;
    vic20mem = (vic20mem_forced > -1) ? vic20mem_forced : RETROVIC20MEM;
 
    // Super VIC uses memory blocks 1+2 by default
    if (!vic20mem && RETROMODEL == VIC20MODEL_VIC21)
-       vic20mem = 3;
+      vic20mem = 3;
 
+   unsigned int vic_blocks = 0;
    switch (vic20mem)
    {
-      case 0:
-         log_resources_set_int("RAMBlock0", 0);
-         log_resources_set_int("RAMBlock1", 0);
-         log_resources_set_int("RAMBlock2", 0);
-         log_resources_set_int("RAMBlock3", 0);
-         log_resources_set_int("RAMBlock5", 0);
-         break;
-
       case 1:
-         log_resources_set_int("RAMBlock0", 1);
-         log_resources_set_int("RAMBlock1", 0);
-         log_resources_set_int("RAMBlock2", 0);
-         log_resources_set_int("RAMBlock3", 0);
-         log_resources_set_int("RAMBlock5", 0);
+         vic_blocks |= VIC_BLK0;
          break;
 
       case 2:
-         log_resources_set_int("RAMBlock0", 0);
-         log_resources_set_int("RAMBlock1", 1);
-         log_resources_set_int("RAMBlock2", 0);
-         log_resources_set_int("RAMBlock3", 0);
-         log_resources_set_int("RAMBlock5", 0);
+         vic_blocks |= VIC_BLK1;
          break;
 
       case 3:
-         log_resources_set_int("RAMBlock0", 0);
-         log_resources_set_int("RAMBlock1", 1);
-         log_resources_set_int("RAMBlock2", 1);
-         log_resources_set_int("RAMBlock3", 0);
-         log_resources_set_int("RAMBlock5", 0);
+         vic_blocks |= VIC_BLK1;
+         vic_blocks |= VIC_BLK2;
          break;
 
       case 4:
-         log_resources_set_int("RAMBlock0", 0);
-         log_resources_set_int("RAMBlock1", 1);
-         log_resources_set_int("RAMBlock2", 1);
-         log_resources_set_int("RAMBlock3", 1);
-         log_resources_set_int("RAMBlock5", 0);
+         vic_blocks |= VIC_BLK1;
+         vic_blocks |= VIC_BLK2;
+         vic_blocks |= VIC_BLK3;
          break;
 
       case 5:
-         log_resources_set_int("RAMBlock0", 1);
-         log_resources_set_int("RAMBlock1", 1);
-         log_resources_set_int("RAMBlock2", 1);
-         log_resources_set_int("RAMBlock3", 1);
-         log_resources_set_int("RAMBlock5", 1);
+         vic_blocks = VIC_BLK_ALL;
          break;
-  }
+   }
+
+   log_resources_set_int("RAMBlock0", (vic_blocks & VIC_BLK0) ? 1 : 0);
+   log_resources_set_int("RAMBlock1", (vic_blocks & VIC_BLK1) ? 1 : 0);
+   log_resources_set_int("RAMBlock2", (vic_blocks & VIC_BLK2) ? 1 : 0);
+   log_resources_set_int("RAMBlock3", (vic_blocks & VIC_BLK3) ? 1 : 0);
+   log_resources_set_int("RAMBlock5", (vic_blocks & VIC_BLK5) ? 1 : 0);
 #endif
    retro_ui_finalized = 1;
    return 0;

--- a/vice/src/resources.c
+++ b/vice/src/resources.c
@@ -1174,7 +1174,7 @@ static char* disabled_resources[] =
     "CrtcExternalPalette", "CrtcPaletteFile", "VICIIExternalPalette", "VICIIPaletteFile",
     "VICIIColorGamma", "VICIIColorSaturation", "VICIIColorContrast", "VICIIColorBrightness", "VICIIColorTint",
     "UserportJoy", "UserportJoyType", "DriveTrueEmulation", "DriveSoundEmulation", "DriveSoundEmulationVolume",
-    "AutostartWarp", "VICIIAudioLeak", "VICAudioLeak",
+    "AutostartWarp", "VICIIAudioLeak", "VICAudioLeak", "SidStereo", "SidStereoAddressStart",
     "SidEngine", "SidModel", "SidResidSampling", "SidResidPassband", "SidResidGain", "SidResidFilterBias",
     "SidResid8580Passband", "SidResid8580Gain", "SidResid8580FilterBias",
     "Go64Mode", "C128ColumnKey", "RAMBlock0", "RAMBlock1", "RAMBlock2", "RAMBlock3", "RAMBlock5",

--- a/vice/src/sound.h
+++ b/vice/src/sound.h
@@ -65,7 +65,7 @@
 #ifdef __LIBRETRO__
 #define SOUND_SAMPLE_RATE 44100
 #define SOUND_CHANNELS_MAX 1
-#define SOUND_BUFSIZE 1024
+#define SOUND_BUFSIZE 2048 // 1024 will crash with 96kHz
 #define SOUND_SIDS_MAX 4
 #define SOUND_SAMPLE_BUFFER_SIZE 0
 

--- a/vice/src/sound.h
+++ b/vice/src/sound.h
@@ -62,6 +62,15 @@
 
 
 /* Sound defaults.  */
+#ifdef __LIBRETRO__
+#define SOUND_SAMPLE_RATE 44100
+#define SOUND_CHANNELS_MAX 1
+#define SOUND_BUFSIZE 1024
+#define SOUND_SIDS_MAX 4
+#define SOUND_SAMPLE_BUFFER_SIZE 0
+
+#else
+
 #ifdef ANDROID_COMPILE
 #define SOUND_SAMPLE_RATE 22050
 #else
@@ -69,15 +78,16 @@
 #endif
 
 #define SOUND_CHANNELS_MAX 2
-#define SOUND_BUFSIZE 4096
+#define SOUND_BUFSIZE 32768
 #define SOUND_SIDS_MAX 4
 
 #ifdef __OS2__
 # define SOUND_SAMPLE_BUFFER_SIZE       400
 #endif
 #ifndef SOUND_SAMPLE_BUFFER_SIZE
-# define SOUND_SAMPLE_BUFFER_SIZE       20
+# define SOUND_SAMPLE_BUFFER_SIZE       100
 #endif
+#endif // __LIBRETRO__
 
 /* largest value in the UIs. also used by VSID as default */
 #define SOUND_SAMPLE_MAX_BUFFER_SIZE    350

--- a/vice/src/sounddrv/soundretro.c
+++ b/vice/src/sounddrv/soundretro.c
@@ -16,7 +16,7 @@ static int retro_sound_init(const char *param, int *speed, int *fragsize, int *f
 {
     *speed = RETROSOUNDSAMPLERATE;
     //*fragsize = 32;
-    *fragnr = 0;
+    //*fragnr = 0;
     //*channels = 1;
     //printf("speed:%d fragsize:%d fragnr:%d channels:%d\n", *speed, *fragsize, *fragnr, *channels);
     return 0;

--- a/vice/src/video/video-resources.c
+++ b/vice/src/video/video-resources.c
@@ -196,7 +196,9 @@ static int set_hwscale_enabled(int val, void *param)
         && !hwscale_possible)
 #endif
     {
+#ifndef __LIBRETRO__
         log_message(LOG_DEFAULT, "HW scale not available, forcing to disabled");
+#endif
         return 0;
     }
 


### PR DESCRIPTION
Regular:
- Core option for 2nd SID base address
- Reworked warp mode
- Improved autoloadwarp with floppies

VIC-20 updates:
- RAM block set tidying
- Fixed starting carts in M3Us

Core option lipstick:
- Prefixes for hidden options
- Minor reordering

Bonus:
- Sound buffer finetuning
- Achievements environment 
  Closes #214 



@AnaLogiC76 You wouldn't happen to have any idea why only reSID-fp creates an endless echo loop if output is in stereo? I forced it to mono for now even with the 2nd SID, because no buffer or fragment fiddling helped. And it isn't that big of a deal really, just curious. I also took a slightly different approach on the warp mode frame thingie, trying to reach maximum reasonable speed, so please take a look at that too if it could be even better/simpler. 

Seems to be fast enough though, since now with the automatic warp enabled games such as The Three Stooges is almost like using a cartridge with a D81+TDE+JiffyDOS-combo.
