### PR TITLE
Autoloadwarp fix for D81s, Statusbar cleanups

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -4176,12 +4176,9 @@ static bool retro_set_eject_state(bool ejected)
 
         if (dc->eject_state == ejected)
             return true;
-        else
-            dc->eject_state = ejected;
 
-        if (ejected && dc->index <= dc->count)
+        if (ejected && dc->index <= dc->count && dc->files[dc->index] != NULL)
         {
-            dc->eject_state = ejected;
             if (unit == 1)
                 tape_image_detach(unit);
             else if (unit >= 8 && unit <= 11)
@@ -4189,11 +4186,9 @@ static bool retro_set_eject_state(bool ejected)
             else if (unit == 0)
                 cartridge_detach_image(-1);
             display_current_image("", false);
-            return true;
         }
         else if (!ejected && dc->index < dc->count && dc->files[dc->index] != NULL)
         {
-            dc->eject_state = ejected;
             if (unit == 1)
                 tape_image_attach(unit, dc->files[dc->index]);
             else if (unit >= 8 && unit <= 11)
@@ -4213,15 +4208,17 @@ static bool retro_set_eject_state(bool ejected)
                     emu_reset(0);
             }
             display_current_image(dc->files[dc->index], true);
-            return true;
         }
+
+        dc->eject_state = ejected;
+        return true;
     }
 
     return false;
 }
 
 /* Gets current eject state. The initial state is 'not ejected'. */
-static bool retro_get_eject_state(void)
+bool retro_get_eject_state(void)
 {
     if (dc)
         return dc->eject_state;

--- a/vice/src/arch/libretro/uistatusbar.c
+++ b/vice/src/arch/libretro/uistatusbar.c
@@ -602,17 +602,13 @@ void uistatusbar_draw(void)
         // Drive/tape LED color
         if (i >= STATUSBAR_TAPE_POS && i < STATUSBAR_SPEED_POS - 1)
         {
-            if (drive_enabled)
-            {
-                color_f_16 = color_black_16;
-                color_f_32 = color_black_32;
-            }
-            else if (tape_enabled)
+            color_f_16 = color_black_16;
+            color_f_32 = color_black_32;
+
+            if (tape_enabled)
             {
                 color_b_16 = color_brown_16;
                 color_b_32 = color_brown_32;
-                color_f_16 = color_black_16;
-                color_f_32 = color_black_32;
             }
         }
 
@@ -639,6 +635,8 @@ void uistatusbar_draw(void)
         // Power LED color
         else if (i == STATUSBAR_SPEED_POS || i == STATUSBAR_SPEED_POS + 1)
         {
+            color_f_16 = color_black_16;
+            color_f_32 = color_black_32;
             color_b_16 = color_red_16;
             color_b_32 = color_red_32;
 

--- a/vice/src/drive/drive.c
+++ b/vice/src/drive/drive.c
@@ -742,8 +742,10 @@ static void drive_led_update(drive_t *drive, drive_t *drive0)
 }
 
 #ifdef __LIBRETRO__
+#include <stdbool.h>
 extern unsigned int opt_autoloadwarp;
 extern int retro_warp_mode_enabled();
+extern bool retro_get_eject_state();
 static int warpmode_counter = 0;
 static int drive_half_track = 0;
 static int drive_half_track_prev = 0;
@@ -781,7 +783,7 @@ void drive_update_ui_status(void)
                                        drive->current_half_track + (drive->side * DRIVE_HALFTRACKS_1571));
             }
 #ifdef __LIBRETRO__
-            if (opt_autoloadwarp && drive->image)
+            if (opt_autoloadwarp && !retro_get_eject_state())
             {
                 drive_half_track = drive->current_half_track;
                 //printf("track:%2d prev:%2d led:%d timer:%2d\n", drive_half_track, drive_half_track_prev, drive->led_status, warpmode_counter);


### PR DESCRIPTION
Whoops, for some reason the recent check for `drive->image` added in Autoloadwarper (because disk access with an empty drive resulted in useless and endless warping) caused autowarping to not work with D81s at all..

Changed the detection method to be `retro_get_eject_state`-based and cleaned up some statusbar and `retro_set_eject_state` stuff while I was at it.

Bonus fixed Plus/4 cartridges.
Double bonus: Plus/4 cartridges needed one more special trick to go down smoothly.
