### PR TITLE
Fix SuperCPU emscripten

### DIFF
--- a/vice/src/scpu64/scpu64rom.c
+++ b/vice/src/scpu64/scpu64rom.c
@@ -41,7 +41,9 @@
 
 static log_t scpu64rom_log = LOG_ERR;
 
+#ifndef __LIBRETRO__
 uint8_t scpu64rom_scpu64_rom[SCPU64_SCPU64_ROM_MAXSIZE];
+#endif
 
 /* Flag: nonzero if the ROMs have been loaded.  */
 static int rom_loaded = 0;

--- a/vice/src/scpu64/scpu64rom.h
+++ b/vice/src/scpu64/scpu64rom.h
@@ -30,6 +30,10 @@
 extern int scpu64rom_load_scpu64(const char *rom_name);
 extern int scpu64rom_load_chargen(const char *rom_name);
 
+#ifdef __LIBRETRO__
+extern BYTE scpu64rom_scpu64_rom[];
+#else
 extern uint8_t scpu64rom_scpu64_rom[];
+#endif
 
 #endif


### PR DESCRIPTION
Evasive maneuvers, because: `error: duplicate symbol: scpu64rom_scpu64_rom`

I'll gladly take any tips that allow getting similar errors with mingw.
