### PR TITLE
AutostartWarp fix, Warp tune + cleanup

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -880,6 +880,9 @@ void update_from_vice()
     {
         autostartString = NULL;
         attachedImage = dc->files[dc->index];
+        // Disable AutostartWarp & WarpMode, otherwise warp gets stuck with PRGs in M3Us
+        resources_set_int("AutostartWarp", 0);
+        resources_set_int("WarpMode", 0);
     }
     else
     {

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -605,7 +605,7 @@ static int process_cmdline(const char* argv)
             }
         }
 #elif defined(__XPLUS4__)
-        if (dc_get_image_type(argv) == DC_IMAGE_TYPE_MEM)
+        if (strendswith(argv, ".crt") || strendswith(argv, ".bin"))
             Add_Option("-cart");
 #endif
 


### PR DESCRIPTION
- Playlisted (ZIP/M3U) PRGs got stuck in warp limbo if AutostartWarp is enabled with JiffyDOS (because Jiffy is not allowed with this filetype, and for Jiffy to get disabled post-start, it requires ninja restarting, which confuses the internal autostart so that warp never ends, nhhggh..)
Closes #259 

- Apparently some platforms don't handle `RETRO_ENVIRONMENT_GET_PERF_INTERFACE` `get_time_usec()` properly, thus fallback to the previous method added
Closes #260 

- Prevented PLUS/4 from adding `-cart` for PRGs
Closes #262 
