### PR TITLE
SuperCPU kernal core option, T64 autoloadwarp fix

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -123,6 +123,9 @@ static unsigned int opt_jiffydos_allow = 1;
 unsigned int opt_jiffydos = 0;
 static unsigned int opt_jiffydos_prev = 0;
 #endif
+#if defined(__XSCPU64__)
+unsigned int opt_supercpu_kernal = 0;
+#endif
 static unsigned int sound_volume_counter = 3;
 unsigned int opt_audio_leak_volume = 0;
 unsigned int opt_statusbar = 0;
@@ -1377,6 +1380,20 @@ void retro_set_environment(retro_environment_t cb)
             { NULL, NULL },
          },
          "C64 PAL auto"
+      },
+#endif
+#if defined(__XSCPU64__)
+      {
+         "vice_supercpu_kernal",
+         "SuperCPU Kernal",
+         "JiffyDOS does not work with the internal kernal! ROMs required in 'system/vice/SCPU64':\n- 'scpu-dos-1.4.bin'\n- 'scpu-dos-2.04.bin'",
+         {
+            { "0", "Internal" },
+            { "1", "1.40" },
+            { "2", "2.04" },
+            { NULL, NULL },
+         },
+         "0"
       },
 #endif
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
@@ -3846,6 +3863,18 @@ static void update_variables(void)
       request_reload_restart = (opt_read_vicerc != opt_read_vicerc_prev) ? 1 : request_reload_restart;
       opt_read_vicerc_prev = opt_read_vicerc;
    }
+
+#if defined(__XSCPU64__)
+   var.key = "vice_supercpu_kernal";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int opt_supercpu_kernal_prev = opt_supercpu_kernal;
+      opt_supercpu_kernal = atoi(var.value);
+
+      request_reload_restart = (opt_supercpu_kernal != opt_supercpu_kernal_prev) ? 1 : request_reload_restart;
+   }
+#endif
 
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
    var.key = "vice_jiffydos";

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2361,7 +2361,7 @@ void retro_set_environment(retro_environment_t cb)
             { "enabled", NULL },
             { NULL, NULL },
          },
-         "disabled"
+         "enabled"
       },
       /* Hotkeys */
       {

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -54,6 +54,13 @@ BYTE c64memrom_kernal64_rom_original[C64_KERNAL_ROM_SIZE] = {0};
 #if defined(__XVIC__)
 extern int vic20mem_forced;
 #endif
+#if defined(__XSCPU64__)
+#include "scpu64.h"
+#include "scpu64mem.h"
+#include "scpu64rom.h"
+extern unsigned int opt_supercpu_kernal;
+BYTE scpu64rom_scpu64_rom_original[SCPU64_SCPU64_ROM_MAXSIZE] = {0};
+#endif
 
 int retro_ui_finalized = 0;
 int cur_port_locked = 0; /* 0: not forced by filename 1: forced by filename */
@@ -256,6 +263,23 @@ int ui_init_finalize(void)
    log_resources_set_int("TEDAudioLeak", core_opt.AudioLeak);
 #endif
 
+#if defined(__XSCPU64__)
+   // Replace kernal always from backup, because kernal loading replaces the embedded variable
+   memcpy(scpu64rom_scpu64_rom, scpu64rom_scpu64_rom_original, SCPU64_SCPU64_ROM_MAXSIZE);
+   switch (opt_supercpu_kernal)
+   {
+      case 2:
+         log_resources_set_string("SCPU64Name", "scpu-dos-2.04.bin");
+         break;
+      case 1:
+         log_resources_set_string("SCPU64Name", "scpu-dos-1.4.bin");
+         break;
+      default:
+         log_resources_set_string("SCPU64Name", "scpu64");
+         break;
+   }
+#endif
+
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
    // Replace kernal always from backup, because kernal loading replaces the embedded variable
 #if defined(__X64__) || defined(__X64SC__)
@@ -405,6 +429,7 @@ int c64scui_init_early(void)
 #elif defined(__XSCPU64__)
 int scpu64ui_init_early(void)
 {
+   memcpy(scpu64rom_scpu64_rom_original, scpu64rom_scpu64_rom, SCPU64_SCPU64_ROM_MAXSIZE);
    return 0;
 }
 #elif defined(__X128__)

--- a/vice/src/arch/libretro/uistatusbar.c
+++ b/vice/src/arch/libretro/uistatusbar.c
@@ -369,11 +369,11 @@ static void display_tape(void)
     if (drive_enabled)
         return;
 
-    if (opt_autoloadwarp)
+    if (opt_autoloadwarp && tape_enabled)
     {
-        if (tape_control == 1 && tape_motor && !retro_warp_mode_enabled())
+        if (tape_control && tape_motor && !retro_warp_mode_enabled())
             resources_set_int("WarpMode", 1);
-        else if ((tape_control == 0 || !tape_motor) && retro_warp_mode_enabled())
+        else if ((!tape_control || !tape_motor) && retro_warp_mode_enabled())
             resources_set_int("WarpMode", 0);
     }
 


### PR DESCRIPTION
- T64 images got stuck in warp mode thanks to Datasette motor controls getting updated on (even if it is not a real tape) but not updated off, which naturally means autoloadwarp thinks loading is still going on
  Closes #263 
- SuperCPU kernal core option = no need to hassle with `vicerc`
- Enabled the visibility of mapping core options by default

