### PR TITLE
Core options for floppy write protection & internal palette tint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Vice 3.3 LIBRETRO
+# VICE LIBRETRO
 
-Port of VICE 3.3 for libretro with virtual keyboard
+Port of VICE, the Versatile Commodore Emulator 3.3 with virtual keyboard
 
 Supported platforms: Linux Windows Apple Android emscripten Switch Vita
 
-Source base: `https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.tar.gz`
+Source base: [https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.tar.gz](https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.tar.gz)
 
 ## Recent improvements
 
@@ -23,7 +23,6 @@ Source base: `https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.
   - Zoom mode
   - Paddles & mouse
   - JiffyDOS support
-
 
 ## Default controls
 
@@ -52,7 +51,6 @@ Source base: `https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.
 
 Long press for sticky keys. Stickying the third key will replace the second.
 
-
 ## Joyport control
 
 C64 games sometimes use joystick port 1 and sometimes joystick port 2 for player 1. There are several ways to switch ports in this core:
@@ -63,13 +61,13 @@ C64 games sometimes use joystick port 1 and sometimes joystick port 2 for player
 - Rename the game, eg. `Bruce_Lee_j1.tap` or `Bruce_Lee_(j1).tap` for port 1, and similarly `Bruce_Lee_j2.tap` or `Bruce_Lee_(j2).tap` for port 2.
 
 ## M3U support and disk control
-When you have a multi disk game, you can use a M3U file to be able to change disks via the RetroArch Disc Control interface.
+When you have a multi disk game, you can use a M3U playlist file to be able to change disks via RetroArch Disc Control interface.
 
-A M3U file is a simple text file with one disk per line (see `https://en.wikipedia.org/wiki/M3U`).
+A M3U file is a simple text file with one disk per line ([Wikipedia](https://en.wikipedia.org/wiki/M3U)).
 
 Example:
 
-Ultima VI - The False Prophet (1990)(Origin Systems).m3u
+`Ultima VI - The False Prophet (1990)(Origin Systems).m3u`
 ```
 Ultima VI - The False Prophet (1990)(Origin Systems)(Disk 1 of 3 Side A)(Game).d64
 Ultima VI - The False Prophet (1990)(Origin Systems)(Disk 1 of 3 Side B)(Surface).d64
@@ -80,13 +78,14 @@ Ultima VI - The False Prophet (1990)(Origin Systems)(Disk 3 of 3 Side B)(Populac
 ```
 Path can be absolute or relative to the location of the M3U file.
 
-When a game ask for it, you can change the current disk in the RetroArch "Disc Control" menu:
+When the game asks for it, you can change the current disk in the RetroArch "Disc Control" menu:
 - Eject the current disk with "Eject Disc"
 - Select the right disk index with "Current Disc Index"
 - Insert the new disk with "Insert Disc"
 
-Note: ZIP support is provided by the core, which allows the use of zipped images in M3Us.
-
+ZIP support is provided by the core, which allows:
+- Automatic M3U playlist generation of all files
+- The use of zipped images in M3Us
 
 ## JiffyDOS support
 
@@ -100,10 +99,9 @@ External ROM files required in `system/vice`:
 |**JiffyDOS_1571_repl310654.bin**|32 768|41c6cc528e9515ffd0ed9b180f8467c0|
 |**JiffyDOS_1581.bin**|32 768|20b6885c6dc2d42c38754a365b043d71|
 
-
 ## Command file operation
 
-VICE command line options are supported with RetroArch by by placing the desired command line in a text file with a `.cmd` file extension. The command line format is as documented in the Vice documentation (see `http://vice-emu.sourceforge.net/vice_6.html`).
+VICE command line options are supported by placing the desired command line in a text file with `.cmd` file extension. The command line format is as documented in the [VICE manual](http://vice-emu.sourceforge.net/vice_6.html).
 
 Using this you can overcome limitations of the GUI and set advanced configurations required for running problematic files. Here are a couple of examples for the xvic core:
 
@@ -384,7 +382,6 @@ ndk-build
  Business Machines, as well as Mammoth Toys, a division of nsi ltd.,
  Digital Concepts DC studios inc., Ironstone Partners ltd., and
  Toy:Lobster company ltd.
-
 
 ### NIBTOOLS
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -5442,6 +5442,8 @@ bool retro_load_game(const struct retro_game_info *info)
 void retro_unload_game(void)
 {
    file_system_detach_disk(8);
+   if (opt_work_disk_type && opt_work_disk_unit == 9)
+      file_system_detach_disk(9);
    tape_image_detach(1);
    cartridge_detach_image(-1);
    dc_reset(dc);

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1970,16 +1970,16 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__)
-         "vice_vicii_color_saturation",
-         "Video > VIC-II Color Saturation",
+         "vice_vicii_color_brightness",
+         "Video > VIC-II Color Brightness",
 #elif defined(__XVIC__)
-         "vice_vic_color_saturation",
-         "Video > VIC Color Saturation",
+         "vice_vic_color_brightness",
+         "Video > VIC Color Brightness",
 #elif defined(__XPLUS4__)
-         "vice_ted_color_saturation",
-         "Video > TED Color Saturation",
+         "vice_ted_color_brightness",
+         "Video > TED Color Brightness",
 #endif
-         "Saturation for the internal palette.",
+         "Brightness for the internal palette.",
          {
             { "200", "10\%" },
             { "250", "12.5\%" },
@@ -2020,7 +2020,7 @@ void retro_set_environment(retro_environment_t cb)
             { "2000", "100\%" },
             { NULL, NULL },
          },
-         "1000"
+         "900"
       },
       {
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__)
@@ -2078,16 +2078,16 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__)
-         "vice_vicii_color_brightness",
-         "Video > VIC-II Color Brightness",
+         "vice_vicii_color_saturation",
+         "Video > VIC-II Color Saturation",
 #elif defined(__XVIC__)
-         "vice_vic_color_brightness",
-         "Video > VIC Color Brightness",
+         "vice_vic_color_saturation",
+         "Video > VIC Color Saturation",
 #elif defined(__XPLUS4__)
-         "vice_ted_color_brightness",
-         "Video > TED Color Brightness",
+         "vice_ted_color_saturation",
+         "Video > TED Color Saturation",
 #endif
-         "Brightness for the internal palette.",
+         "Saturation for the internal palette.",
          {
             { "200", "10\%" },
             { "250", "12.5\%" },
@@ -2128,7 +2128,61 @@ void retro_set_environment(retro_environment_t cb)
             { "2000", "100\%" },
             { NULL, NULL },
          },
-         "900"
+         "1000"
+      },
+      {
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__)
+         "vice_vicii_color_tint",
+         "Video > VIC-II Color Tint",
+#elif defined(__XVIC__)
+         "vice_vic_color_tint",
+         "Video > VIC Color Tint",
+#elif defined(__XPLUS4__)
+         "vice_ted_color_tint",
+         "Video > TED Color Tint",
+#endif
+         "Tint for the internal palette.",
+         {
+            { "200", "10\%" },
+            { "250", "12.5\%" },
+            { "300", "15\%" },
+            { "350", "17.5\%" },
+            { "400", "20\%" },
+            { "450", "22.5\%" },
+            { "500", "25\%" },
+            { "550", "27.5\%" },
+            { "600", "30\%" },
+            { "650", "32.5\%" },
+            { "700", "35\%" },
+            { "750", "37.5\%" },
+            { "800", "40\%" },
+            { "850", "42.5\%" },
+            { "900", "45\%" },
+            { "950", "47.5\%" },
+            { "1000", "50\%" },
+            { "1050", "52.5\%" },
+            { "1100", "55\%" },
+            { "1150", "57.5\%" },
+            { "1200", "60\%" },
+            { "1250", "62.5\%" },
+            { "1300", "65\%" },
+            { "1350", "67.5\%" },
+            { "1400", "70\%" },
+            { "1450", "72.5\%" },
+            { "1500", "75\%" },
+            { "1550", "77.5\%" },
+            { "1600", "80\%" },
+            { "1650", "82.5\%" },
+            { "1700", "85\%" },
+            { "1750", "87.5\%" },
+            { "1800", "90\%" },
+            { "1850", "92.5\%" },
+            { "1900", "95\%" },
+            { "1950", "97.5\%" },
+            { "2000", "100\%" },
+            { NULL, NULL },
+         },
+         "1000"
       },
 #endif
       {
@@ -3758,6 +3812,31 @@ static void update_variables(void)
 
       core_opt.ColorGamma = color_gamma;
    }
+
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__)
+   var.key = "vice_vicii_color_tint";
+#elif defined(__XVIC__)
+   var.key = "vice_vic_color_tint";
+#elif defined(__XPLUS4__)
+   var.key = "vice_ted_color_tint";
+#endif
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int color_tint = atoi(var.value);
+
+      if (retro_ui_finalized && core_opt.ColorTint != color_tint)
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__)
+         log_resources_set_int("VICIIColorTint", color_tint);
+#elif defined(__XVIC__)
+         log_resources_set_int("VICColorTint", color_tint);
+#elif defined(__XPLUS4__)
+         log_resources_set_int("TEDColorTint", color_tint);
+#endif
+
+      core_opt.ColorTint = color_tint;
+   }
+
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__)
    var.key = "vice_vicii_color_saturation";
 #elif defined(__XVIC__)

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1394,7 +1394,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_vic20_memory_expansions",
          "Memory Expansions",
-         "Expansion change will reset the system.",
+         "Expansion change resets the system!",
          {
             { "none", "disabled" },
             { "3kB", "3KB" },
@@ -1609,7 +1609,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_autoloadwarp",
          "Automatic Load Warp",
-         "Toggles warp mode always during disk and tape loading. Drive Sound Emulation will be muted.",
+         "Toggles warp mode always during disk and tape loading. Mutes Drive Sound Emulation.",
          {
             { "disabled", NULL },
             { "enabled", NULL },
@@ -1629,9 +1629,20 @@ void retro_set_environment(retro_environment_t cb)
          "enabled"
       },
       {
+         "vice_floppy_write_protection",
+         "Floppy Write Protection",
+         "Makes device 8 read only.",
+         {
+            { "disabled", NULL },
+            { "enabled", NULL },
+            { NULL, NULL },
+         },
+         "disabled"
+      },
+      {
          "vice_work_disk",
          "Global Work Disk",
-         "Global disk in device 8 will only be inserted when the core is started without content.",
+         "Global disk in device 8 is only inserted when the core is started without content.",
          {
             { "disabled", NULL },
             { "8_d64", "D64 - 664 blocks, 170KB - Device 8" },
@@ -2507,7 +2518,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_physical_keyboard_pass_through",
          "Physical Keyboard Pass-through",
-         "Pass all physical keyboard events to the core. Disable this to prevent cursor keys and fire key from generating key events.",
+         "'ON' passes all physical keyboard events to the core. 'OFF' prevents RetroPad keys from generating keyboard events.",
          {
             { "disabled", NULL },
             { "enabled", NULL },
@@ -2518,7 +2529,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_datasette_hotkeys",
          "Datasette Hotkeys",
-         "Enable/disable all Datasette hotkeys.",
+         "Toggles all Datasette hotkeys.",
          {
             { "disabled", NULL },
             { "enabled", NULL },
@@ -2556,7 +2567,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_mapper_joyport_switch",
          "Hotkey > Switch Joyports",
-         "Press the mapped key to switch joyports 1 & 2.\nSwitching will disable 'RetroPad Port' option until core restart.",
+         "Press the mapped key to switch joyports 1 & 2.\nSwitching disables 'RetroPad Port' option until core restart.",
          {{ NULL, NULL }},
          "RETROK_RCTRL"
       },
@@ -2588,7 +2599,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_mapper_datasette_toggle_hotkeys",
          "Hotkey > Toggle Datasette Hotkeys",
-         "Press the mapped key to toggle the Datasette hotkeys.",
+         "Press the mapped key to toggle Datasette hotkeys.",
          {{ NULL, NULL }},
          "---"
       },
@@ -2808,7 +2819,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_joyport",
          "RetroPad Port",
-         "Most games use port 2, some use port 1.\nFilename forcing or hotkey toggling will disable this option until core restart.",
+         "Most games use port 2, some use port 1.\nFilename forcing or hotkey toggling disables this option until core restart.",
          {
             { "Port 2", NULL },
             { "Port 1", NULL },
@@ -2819,7 +2830,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_joyport_type",
          "RetroPad Port Type",
-         "Non-joysticks will be plugged into current port only and are controlled with the left analog stick or a real mouse. Paddles will be split to 1st and 2nd RetroPort.",
+         "Non-joysticks are plugged into current port only and are controlled with the left analog stick or a real mouse. Paddles are split to 1st and 2nd RetroPort.",
          {
             { "1", "Joystick" },
             { "2", "Paddles" },
@@ -2839,7 +2850,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_retropad_options",
          "RetroPad Face Button Options",
-         "Rotate face buttons clockwise and/or make 2nd fire press up.",
+         "Rotates face buttons clockwise and/or makes 2nd fire press up.",
          {
             { "disabled", "B = Fire" },
             { "jump", "B = Fire, A = Up" },
@@ -3017,6 +3028,17 @@ static void update_variables(void)
       // Silently restore sounds when autoloadwarp is disabled and DSE is enabled
       if (retro_ui_finalized && core_opt.DriveSoundEmulation && core_opt.DriveTrueEmulation && !opt_autoloadwarp)
          resources_set_int("DriveSoundEmulationVolume", core_opt.DriveSoundEmulation);
+   }
+
+   var.key = "vice_floppy_write_protection";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "disabled")) core_opt.AttachDevice8Readonly = 0;
+      else core_opt.AttachDevice8Readonly = 1;
+
+      if (retro_ui_finalized)
+         log_resources_set_int("AttachDevice8Readonly", core_opt.AttachDevice8Readonly);
    }
 
    var.key = "vice_work_disk";

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -152,6 +152,7 @@ struct libretro_core_options {
     int SidResid8580FilterBias;
     char ExternalPalette[RETRO_PATH_MAX];
     int ColorGamma;
+    int ColorTint;
     int ColorSaturation;
     int ColorContrast;
     int ColorBrightness;

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -137,6 +137,7 @@ struct libretro_core_options {
     int Model;
     int UserportJoy;
     int AutostartWarp;
+    int AttachDevice8Readonly;
     int DriveTrueEmulation;
     int DriveSoundEmulation;
     int AudioLeak;

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -238,10 +238,9 @@ int ui_init_finalize(void)
    }
 #endif
 
-   if (core_opt.DriveTrueEmulation)
-      log_resources_set_int("DriveTrueEmulation", 1);
-   else
-      log_resources_set_int("DriveTrueEmulation", 0);
+   log_resources_set_int("DriveTrueEmulation", core_opt.DriveTrueEmulation);
+   log_resources_set_int("AttachDevice8Readonly", core_opt.AttachDevice8Readonly);
+   log_resources_set_int("AutostartWarp", core_opt.AutostartWarp);
 
    if (core_opt.DriveSoundEmulation)
    {
@@ -250,10 +249,9 @@ int ui_init_finalize(void)
    }
    else
       log_resources_set_int("DriveSoundEmulation", 0);
+
    if (opt_autoloadwarp)
       log_resources_set_int("DriveSoundEmulationVolume", 0);
-
-   log_resources_set_int("AutostartWarp", core_opt.AutostartWarp);
 
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
    log_resources_set_int("VICIIAudioLeak", core_opt.AudioLeak);

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -213,16 +213,19 @@ int ui_init_finalize(void)
 
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__)
    log_resources_set_int("VICIIColorGamma", core_opt.ColorGamma);
+   log_resources_set_int("VICIIColorTint", core_opt.ColorTint);
    log_resources_set_int("VICIIColorSaturation", core_opt.ColorSaturation);
    log_resources_set_int("VICIIColorContrast", core_opt.ColorContrast);
    log_resources_set_int("VICIIColorBrightness", core_opt.ColorBrightness);
 #elif defined(__XVIC__)
    log_resources_set_int("VICColorGamma", core_opt.ColorGamma);
+   log_resources_set_int("VICColorTint", core_opt.ColorTint);
    log_resources_set_int("VICColorSaturation", core_opt.ColorSaturation);
    log_resources_set_int("VICColorContrast", core_opt.ColorContrast);
    log_resources_set_int("VICColorBrightness", core_opt.ColorBrightness);
 #elif defined(__XPLUS4__)
    log_resources_set_int("TEDColorGamma", core_opt.ColorGamma);
+   log_resources_set_int("TEDColorTint", core_opt.ColorTint);
    log_resources_set_int("TEDColorSaturation", core_opt.ColorSaturation);
    log_resources_set_int("TEDColorContrast", core_opt.ColorContrast);
    log_resources_set_int("TEDColorBrightness", core_opt.ColorBrightness);


### PR DESCRIPTION
New core options:
- Floppy write protection, applies only to device 8 for now and comes into effect immediately
- Tint for internal palette

Bonus:
- Core option label finetuning and reorganizing
  - Changed palette options order to: Gamma, Brightness, Contrast, Saturation, Tint
- Readme updates
- Detach device 9 on unload if it is used for work disk

