### PR TITLE
Misc maintenance

### DIFF
--- a/Makefile.xcbm2
+++ b/Makefile.xcbm2
@@ -18,8 +18,6 @@ INCFLAGS += \
     -I$(EMU)/monitor \
     -I$(EMU)/raster \
     -I$(EMU)/resid \
-    -I$(EMU)/residfp \
-    -I$(EMU)/residfp/builders/residfp-builder/residfp \
     -I$(EMU)/rtc \
     -I$(EMU)/samplerdrv \
     -I$(EMU)/socketdrv \
@@ -40,26 +38,7 @@ SOURCES_CXX += \
     $(EMU)/resid/version.cc \
     $(EMU)/resid/voice.cc \
     $(EMU)/resid/wave.cc \
-    $(EMU)/sid/resid-33.cc \
     $(EMU)/sid/resid.cc \
-    $(EMU)/sid/resid-fp.cc \
-    $(EMU)/residfp/builders/residfp-builder/residfp/version.cc \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Dac.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/EnvelopeGenerator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/ExternalFilter.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter6581.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/FilterModelConfig.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/FilterModelConfig8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Integrator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Integrator8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/OpAmp.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/resample/SincResampler.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/SID.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Spline.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/WaveformCalculator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/WaveformGenerator.cpp
 
 SOURCES_C += \
     $(EMU)/alarm.c \

--- a/Makefile.xcbm5x0
+++ b/Makefile.xcbm5x0
@@ -21,8 +21,6 @@ INCFLAGS += \
     -I$(EMU)/monitor \
     -I$(EMU)/raster \
     -I$(EMU)/resid \
-    -I$(EMU)/residfp \
-    -I$(EMU)/residfp/builders/residfp-builder/residfp \
     -I$(EMU)/rtc \
     -I$(EMU)/samplerdrv \
     -I$(EMU)/socketdrv \
@@ -43,26 +41,7 @@ SOURCES_CXX += \
     $(EMU)/resid/version.cc \
     $(EMU)/resid/voice.cc \
     $(EMU)/resid/wave.cc \
-    $(EMU)/sid/resid-33.cc \
     $(EMU)/sid/resid.cc \
-    $(EMU)/sid/resid-fp.cc \
-    $(EMU)/residfp/builders/residfp-builder/residfp/version.cc \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Dac.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/EnvelopeGenerator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/ExternalFilter.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter6581.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/FilterModelConfig.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/FilterModelConfig8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Integrator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Integrator8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/OpAmp.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/resample/SincResampler.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/SID.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Spline.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/WaveformCalculator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/WaveformGenerator.cpp
 
 SOURCES_C += \
     $(EMU)/alarm.c \

--- a/Makefile.xpet
+++ b/Makefile.xpet
@@ -18,8 +18,6 @@ INCFLAGS += \
     -I$(EMU)/pet \
     -I$(EMU)/raster \
     -I$(EMU)/resid \
-    -I$(EMU)/residfp \
-    -I$(EMU)/residfp/builders/residfp-builder/residfp \
     -I$(EMU)/rtc \
     -I$(EMU)/samplerdrv \
     -I$(EMU)/socketdrv \
@@ -39,26 +37,7 @@ SOURCES_CXX += \
     $(EMU)/resid/version.cc \
     $(EMU)/resid/voice.cc \
     $(EMU)/resid/wave.cc \
-    $(EMU)/sid/resid-33.cc \
     $(EMU)/sid/resid.cc \
-    $(EMU)/sid/resid-fp.cc \
-    $(EMU)/residfp/builders/residfp-builder/residfp/version.cc \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Dac.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/EnvelopeGenerator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/ExternalFilter.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter6581.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/FilterModelConfig.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/FilterModelConfig8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Integrator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Integrator8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/OpAmp.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/resample/SincResampler.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/SID.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Spline.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/WaveformCalculator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/WaveformGenerator.cpp
 
 SOURCES_C += \
     $(EMU)/alarm.c \

--- a/Makefile.xplus4
+++ b/Makefile.xplus4
@@ -19,8 +19,6 @@ INCFLAGS += \
     -I$(EMU)/plus4 \
     -I$(EMU)/raster \
     -I$(EMU)/resid \
-    -I$(EMU)/residfp \
-    -I$(EMU)/residfp/builders/residfp-builder/residfp \
     -I$(EMU)/rtc \
     -I$(EMU)/samplerdrv \
     -I$(EMU)/socketdrv \
@@ -40,26 +38,7 @@ SOURCES_CXX += \
     $(EMU)/resid/version.cc \
     $(EMU)/resid/voice.cc \
     $(EMU)/resid/wave.cc \
-    $(EMU)/sid/resid-33.cc \
     $(EMU)/sid/resid.cc \
-    $(EMU)/sid/resid-fp.cc \
-    $(EMU)/residfp/builders/residfp-builder/residfp/version.cc \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Dac.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/EnvelopeGenerator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/ExternalFilter.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter6581.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/FilterModelConfig.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/FilterModelConfig8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Integrator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Integrator8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/OpAmp.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/resample/SincResampler.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/SID.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Spline.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/WaveformCalculator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/WaveformGenerator.cpp
 
 SOURCES_C += \
     $(EMU)/alarm.c \

--- a/Makefile.xvic
+++ b/Makefile.xvic
@@ -18,8 +18,6 @@ INCFLAGS += \
     -I$(EMU)/monitor \
     -I$(EMU)/raster \
     -I$(EMU)/resid \
-    -I$(EMU)/residfp \
-    -I$(EMU)/residfp/builders/residfp-builder/residfp \
     -I$(EMU)/rtc \
     -I$(EMU)/samplerdrv \
     -I$(EMU)/socketdrv \
@@ -41,26 +39,7 @@ SOURCES_CXX += \
     $(EMU)/resid/version.cc \
     $(EMU)/resid/voice.cc \
     $(EMU)/resid/wave.cc \
-    $(EMU)/sid/resid-33.cc \
     $(EMU)/sid/resid.cc \
-    $(EMU)/sid/resid-fp.cc \
-    $(EMU)/residfp/builders/residfp-builder/residfp/version.cc \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Dac.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/EnvelopeGenerator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/ExternalFilter.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter6581.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Filter8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/FilterModelConfig.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/FilterModelConfig8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Integrator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Integrator8580.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/OpAmp.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/resample/SincResampler.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/SID.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/Spline.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/WaveformCalculator.cpp \
-    $(EMU)/residfp/builders/residfp-builder/residfp/WaveformGenerator.cpp
 
 SOURCES_C += \
     $(EMU)/alarm.c \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Source base: [https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.
 
 |RetroPad button|Action|
 |---|---|
+|D-Pad|Joystick|
 |B|Fire button|
 |X|Space|
 |L2|Escape (RUN/STOP)|

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2342,8 +2342,10 @@ void retro_set_environment(retro_environment_t cb)
          {
             { "FastSID", NULL },
             { "ReSID", NULL },
+#if defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__) || defined(__X128__)
             { "ReSID-3.3", NULL },
             { "ReSID-FP", NULL },
+#endif
             { NULL, NULL },
          },
          "ReSID"

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -211,7 +211,7 @@ int runstate = RUNSTATE_FIRST_START; /* used to detect whether we are just start
 /* runstate = RUNSTATE_RUNNING: core is running normally */
 
 /* Display disk name and label instead of "Changing disk in tray"- maybe make it configurable */
-bool display_disk_name = true;
+bool display_disk_name = false;
 /* See which looks best in most cases and tweak (or make configurable) */
 int disk_label_mode = DISK_LABEL_MODE_ASCII_OR_CAMELCASE;
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -139,7 +139,7 @@ unsigned int opt_joyport_type = 0;
 unsigned int opt_dpadmouse_speed = 6;
 unsigned int opt_mouse_speed = 100;
 unsigned int opt_analogmouse = 0;
-unsigned int opt_analogmouse_deadzone = 15;
+unsigned int opt_analogmouse_deadzone = 20;
 float opt_analogmouse_speed = 1.0;
 
 extern unsigned int datasette_hotkeys;
@@ -1446,7 +1446,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_vic20_memory_expansions",
-         "Memory Expansions",
+         "System > Memory Expansion",
          "Expansion change resets the system!",
          {
             { "none", "disabled" },
@@ -1491,7 +1491,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_c128_video_output",
-         "Video Output",
+         "System > Video Output",
          "",
          {
             { "VICII", "VIC-II (40 cols)" },
@@ -1502,7 +1502,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_c128_go64",
-         "GO64",
+         "System > GO64",
          "Starts in C64 compatibility mode.\nFull restart required.",
          {
             { "disabled", NULL },
@@ -1610,7 +1610,7 @@ void retro_set_environment(retro_environment_t cb)
 #if defined(__XSCPU64__)
       {
          "vice_supercpu_kernal",
-         "SuperCPU Kernal",
+         "System > SuperCPU Kernal",
          "JiffyDOS does not work with the internal kernal! ROMs required in 'system/vice/SCPU64':\n- 'scpu-dos-1.4.bin'\n- 'scpu-dos-2.04.bin'",
          {
             { "0", "Internal" },
@@ -1624,7 +1624,7 @@ void retro_set_environment(retro_environment_t cb)
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
       {
          "vice_jiffydos",
-         "JiffyDOS",
+         "System > JiffyDOS",
 #if defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__)
          "For D64/D71/D81 disk images only!\nROMs required in 'system/vice':\n- 'JiffyDOS_C64.bin'\n- 'JiffyDOS_1541-II.bin'\n- 'JiffyDOS_1571_repl310654.bin'\n- 'JiffyDOS_1581.bin'",
 #elif defined(__X128__)
@@ -1640,7 +1640,7 @@ void retro_set_environment(retro_environment_t cb)
 #endif
       {
          "vice_read_vicerc",
-         "Read 'vicerc'",
+         "System > Read 'vicerc'",
          "Process 'system/vice/vicerc'. The config file can be used to set other options, such as cartridges.",
          {
             { "disabled", NULL },
@@ -1651,20 +1651,20 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_reset",
-         "Reset Type",
+         "System > Reset Type",
          "- 'Autostart' hard resets and reruns content.\n- 'Soft' keeps some code in memory.\n- 'Hard' erases all memory.\n- 'Freeze' is for cartridges.",
          {
-            { "Autostart", NULL },
-            { "Soft", NULL },
-            { "Hard", NULL },
-            { "Freeze", NULL },
+            { "autostart", "Autostart" },
+            { "soft", "Soft" },
+            { "hard", "Hard" },
+            { "freeze", "Freeze" },
             { NULL, NULL },
          },
-         "Autostart"
+         "autostart"
       },
       {
          "vice_autostart",
-         "Autostart",
+         "Media > Autostart",
          "'ON' always runs content, 'OFF' runs only PRG/CRT, 'Warp' turns warp mode on during autostart loading.",
          {
             { "disabled", NULL },
@@ -1676,7 +1676,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_autoloadwarp",
-         "Automatic Load Warp",
+         "Media > Automatic Load Warp",
          "Toggles warp mode always during disk and tape loading. Mutes 'Drive Sound Emulation'.",
          {
             { "disabled", NULL },
@@ -1687,7 +1687,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_drive_true_emulation",
-         "True Drive Emulation",
+         "Media > True Drive Emulation",
          "Loads much slower, but some games need it.",
          {
             { "disabled", NULL },
@@ -1698,7 +1698,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_floppy_write_protection",
-         "Floppy Write Protection",
+         "Media > Floppy Write Protection",
          "Makes device 8 read only.",
          {
             { "disabled", NULL },
@@ -1709,7 +1709,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_work_disk",
-         "Global Work Disk",
+         "Media > Global Work Disk",
          "Global disk in device 8 is only inserted when the core is started without content.",
          {
             { "disabled", NULL },
@@ -1937,8 +1937,8 @@ void retro_set_environment(retro_environment_t cb)
          "",
          {
             { "default", "Internal" },
-            { "amber", "Amber" },
             { "green", "Green" },
+            { "amber", "Amber" },
             { "white", "White" },
             { NULL, NULL },
          },
@@ -1951,8 +1951,8 @@ void retro_set_environment(retro_environment_t cb)
          "",
          {
             { "default", "Internal" },
-            { "amber", "Amber" },
             { "green", "Green" },
+            { "amber", "Amber" },
             { "white", "White" },
             { NULL, NULL },
          },
@@ -2355,13 +2355,13 @@ void retro_set_environment(retro_environment_t cb)
          "Audio > SID Model",
          "The original C64 uses '6581', C64C uses '8580'.",
          {
-            { "Default", NULL },
+            { "default", "Default" },
             { "6581", NULL },
             { "8580", NULL },
             { "8580RD", "8580 ReSID + Digi Boost" },
             { NULL, NULL },
          },
-         "Default"
+         "default"
       },
       {
          "vice_sid_extra",
@@ -2382,16 +2382,16 @@ void retro_set_environment(retro_environment_t cb)
          "Audio > ReSID Sampling",
          "'Resampling' provides best quality. 'Fast' improves performance dramatically on PS Vita.",
          {
-            { "Fast", NULL },
-            { "Interpolation", NULL },
-            { "Resampling", NULL },
-            { "Fast resampling", NULL },
+            { "fast", "Fast" },
+            { "interpolation", "Interpolation" },
+            { "fast resampling", "Fast Resampling" },
+            { "resampling", "Resampling" },
             { NULL, NULL },
          },
 #if defined(PSP) || defined(VITA) || defined(__SWITCH__)
-         "Fast"
+         "fast"
 #else
-         "Resampling"
+         "resampling"
 #endif
       },
       {
@@ -2497,7 +2497,7 @@ void retro_set_environment(retro_environment_t cb)
 #if !defined(__XPET__) && !defined(__XCBM2__)
       {
          "vice_analogmouse_deadzone",
-         "Analog Stick Mouse Deadzone",
+         "Input > Analog Stick Mouse Deadzone",
          "",
          {
             { "0", "0\%" },
@@ -2513,11 +2513,11 @@ void retro_set_environment(retro_environment_t cb)
             { "50", "50\%" },
             { NULL, NULL },
          },
-         "15"
+         "20"
       },
       {
          "vice_analogmouse_speed",
-         "Analog Stick Mouse Speed",
+         "Input > Analog Stick Mouse Speed",
          "",
          {
             { "0.5", "50\%" },
@@ -2537,7 +2537,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_dpadmouse_speed",
-         "D-Pad Mouse Speed",
+         "Input > D-Pad Mouse Speed",
          "",
          {
             { "3", "50\%" },
@@ -2556,7 +2556,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_mouse_speed",
-         "Mouse Speed",
+         "Input > Mouse Speed",
          "Affects mouse speed globally.",
          {
             { "10", "10\%" },
@@ -2587,25 +2587,25 @@ void retro_set_environment(retro_environment_t cb)
 #if !defined(__XCBM5x0__)
       {
          "vice_userport_joytype",
-         "Userport Joystick Adapter",
+         "Input > Userport Joystick Adapter",
          "Essential when 2 joysticks are not enough, for example IK+ Gold with 3 players.",
          {
-            { "None", "disabled" },
-            { "Protovision CGA", NULL },
-            { "PET", NULL },
-            { "Hummer", NULL },
-            { "OEM", NULL },
-            { "Hit", NULL }, 
-            { "Kingsoft", NULL },
-            { "Starbyte", NULL },
+            { "disabled", NULL },
+            { "CGA", "Protovision / Classical Games" },
+            { "HIT", "Digital Excess & Hitmen" },
+            { "Kingsoft", "Kingsoft" },
+            { "Starbyte", "Starbyte" },
+            { "Hummer", "C64DTV Hummer" },
+            { "OEM", "VIC-20 OEM" },
+            { "PET", "PET" },
             { NULL, NULL },
          },
-         "None"
+         "disabled"
       },
 #endif
       {
          "vice_keyrah_keypad_mappings",
-         "Keyrah Keypad Mappings",
+         "Input > Keyrah Keypad Mappings",
          "Hardcoded keypad to joyport mappings for Keyrah hardware.",
          {
             { "disabled", NULL },
@@ -2617,7 +2617,7 @@ void retro_set_environment(retro_environment_t cb)
 #if !defined(__XPET__) && !defined(__XCBM2__) && !defined(__XCBM5x0__)
       {
          "vice_keyboard_keymap",
-         "Keyboard Keymap",
+         "Input > Keyboard Keymap",
 #if defined(__XPLUS4__)
          "User-defined keymaps go in 'system/vice/PLUS4'.\n- Positional: 'sdl_pos.vkm'\n- Symbolic: 'sdl_sym.vkm'",
 #elif defined(__XVIC__)
@@ -2641,7 +2641,7 @@ void retro_set_environment(retro_environment_t cb)
 #endif
       {
          "vice_physical_keyboard_pass_through",
-         "Physical Keyboard Pass-through",
+         "Input > Keyboard Pass-through",
          "'ON' passes all physical keyboard events to the core. 'OFF' prevents RetroPad keys from generating keyboard events.",
          {
             { "disabled", NULL },
@@ -2652,7 +2652,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_datasette_hotkeys",
-         "Datasette Hotkeys",
+         "Input > Datasette Hotkeys",
          "Toggles all Datasette hotkeys.",
          {
             { "disabled", NULL },
@@ -2703,6 +2703,13 @@ void retro_set_environment(retro_environment_t cb)
          {{ NULL, NULL }},
          "RETROK_END"
       },
+      {
+         "vice_mapper_warp_mode",
+         "Hotkey > Hold Warp Mode",
+         "Hold the mapped key for warp mode.",
+         {{ NULL, NULL }},
+         ""
+      },
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__) || defined(__XVIC__) || defined(__XPLUS4__)
       {
          "vice_mapper_zoom_mode_toggle",
@@ -2712,13 +2719,6 @@ void retro_set_environment(retro_environment_t cb)
          "---"
       },
 #endif
-      {
-         "vice_mapper_warp_mode",
-         "Hotkey > Hold Warp Mode",
-         "Hold the mapped key for warp mode.",
-         {{ NULL, NULL }},
-         ""
-      },
       /* Datasette controls */
       {
          "vice_mapper_datasette_toggle_hotkeys",
@@ -2765,84 +2765,84 @@ void retro_set_environment(retro_environment_t cb)
       /* Button mappings */
       {
          "vice_mapper_select",
-         "RetroPad Select",
+         "RetroPad > Select",
          "",
          {{ NULL, NULL }},
          "TOGGLE_VKBD"
       },
       {
          "vice_mapper_start",
-         "RetroPad Start",
+         "RetroPad > Start",
          "VKBD: Press 'Return'. Remapping to non-keyboard keys overrides VKBD function!",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_b",
-         "RetroPad B",
+         "RetroPad > B",
          "Unmapped defaults to fire button.\nVKBD: Press selected key.",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_a",
-         "RetroPad A",
+         "RetroPad > A",
          "VKBD: Toggle transparency. Remapping to non-keyboard keys overrides VKBD function!",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_y",
-         "RetroPad Y",
+         "RetroPad > Y",
          "VKBD: Toggle 'CapsLock'. Remapping to non-keyboard keys overrides VKBD function!",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_x",
-         "RetroPad X",
+         "RetroPad > X",
          "",
          {{ NULL, NULL }},
          "RETROK_SPACE"
       },
       {
          "vice_mapper_l",
-         "RetroPad L",
+         "RetroPad > L",
          "",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_r",
-         "RetroPad R",
+         "RetroPad > R",
          "",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_l2",
-         "RetroPad L2",
+         "RetroPad > L2",
          "",
          {{ NULL, NULL }},
          "RETROK_ESCAPE"
       },
       {
          "vice_mapper_r2",
-         "RetroPad R2",
+         "RetroPad > R2",
          "",
          {{ NULL, NULL }},
          "RETROK_RETURN"
       },
       {
          "vice_mapper_l3",
-         "RetroPad L3",
+         "RetroPad > L3",
          "",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_r3",
-         "RetroPad R3",
+         "RetroPad > R3",
          "",
          {{ NULL, NULL }},
          "---"
@@ -2850,28 +2850,28 @@ void retro_set_environment(retro_environment_t cb)
       /* Left Stick */
       {
          "vice_mapper_lu",
-         "RetroPad L-Up",
+         "RetroPad > Left Analog > Up",
          "Mapping for left analog stick up.",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_ld",
-         "RetroPad L-Down",
+         "RetroPad > Left Analog > Down",
          "Mapping for left analog stick down.",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_ll",
-         "RetroPad L-Left",
+         "RetroPad > Left Analog > Left",
          "Mapping for left analog stick left.",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_lr",
-         "RetroPad L-Right",
+         "RetroPad > Left Analog > Right",
          "Mapping for left analog stick right.",
          {{ NULL, NULL }},
          "---"
@@ -2879,36 +2879,37 @@ void retro_set_environment(retro_environment_t cb)
       /* Right Stick */
       {
          "vice_mapper_ru",
-         "RetroPad R-Up",
+         "RetroPad > Right Analog > Up",
          "Mapping for right analog stick up.",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_rd",
-         "RetroPad R-Down",
+         "RetroPad > Right Analog > Down",
          "Mapping for right analog stick down.",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_rl",
-         "RetroPad R-Left",
+         "RetroPad > Right Analog > Left",
          "Mapping for right analog stick left.",
          {{ NULL, NULL }},
          "---"
       },
       {
          "vice_mapper_rr",
-         "RetroPad R-Right",
+         "RetroPad > Right Analog > Right",
          "Mapping for right analog stick right.",
          {{ NULL, NULL }},
          "---"
       },
+#if !defined(__XPET__) && !defined(__XCBM2__)
       /* Turbo Fire */
       {
          "vice_turbo_fire_button",
-         "RetroPad Turbo Fire",
+         "RetroPad > Turbo Fire",
          "Replaces the mapped button with turbo fire button.",
          {
             { "disabled", NULL },
@@ -2926,36 +2927,37 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_turbo_pulse",
-         "RetroPad Turbo Pulse",
-         "Frames in a button cycle. 2 equals button press on a frame and release on the next frame.",
+         "RetroPad > Turbo Pulse",
+         "Frames in a button cycle.\n- '2' = 1 frame down, 1 frame up\n- '4' = 2 frames down, 2 frames up\n- '6' = 3 frames down, 3 frames up\netc.",
          {
-            { "2", NULL },
-            { "4", NULL },
-            { "6", NULL },
-            { "8", NULL },
-            { "10", NULL },
-            { "12", NULL },
+            { "2", "2 frames" },
+            { "4", "4 frames" },
+            { "6", "6 frames" },
+            { "8", "8 frames" },
+            { "10", "10 frames" },
+            { "12", "12 frames" },
             { NULL, NULL },
          },
          "4"
       },
+#endif
 #if !defined(__XPET__) && !defined(__XCBM2__) && !defined(__XVIC__)
       {
          "vice_joyport",
-         "RetroPad Port",
+         "RetroPad > Port",
          "Most games use port 2, some use port 1.\nFilename forcing or hotkey toggling disables this option until core restart.",
          {
-            { "Port 1", NULL },
-            { "Port 2", NULL },
+            { "1", "Port 1" },
+            { "2", "Port 2" },
             { NULL, NULL },
          },
-         "Port 2"
+         "2"
       },
 #endif
 #if !defined(__XPET__) && !defined(__XCBM2__)
       {
          "vice_joyport_type",
-         "RetroPad Port Type",
+         "RetroPad > Port Type",
          "Non-joysticks are plugged in current port only and are controlled with left analog stick or mouse. Paddles are split to 1st and 2nd RetroPort.",
          {
             { "1", "Joystick" },
@@ -2972,10 +2974,9 @@ void retro_set_environment(retro_environment_t cb)
          },
          "1"
       },
-#endif
       {
          "vice_retropad_options",
-         "RetroPad Face Button Options",
+         "RetroPad > Face Button Options",
          "Rotates face buttons clockwise and/or makes 2nd fire press up.",
          {
             { "disabled", "B = Fire" },
@@ -2986,6 +2987,7 @@ void retro_set_environment(retro_environment_t cb)
          },
          "disabled"
       },
+#endif
       { NULL, NULL, NULL, {{0}}, NULL },
    };
 
@@ -3189,11 +3191,11 @@ static void update_variables(void)
       if (!strcmp(var.value, "disabled"))    opt_work_disk_type = 0;
       else
       {
-         if (strstr(var.value, "_d64"))      opt_work_disk_type = DISK_IMAGE_TYPE_D64;
+         if      (strstr(var.value, "_d64")) opt_work_disk_type = DISK_IMAGE_TYPE_D64;
          else if (strstr(var.value, "_d71")) opt_work_disk_type = DISK_IMAGE_TYPE_D71;
          else if (strstr(var.value, "_d81")) opt_work_disk_type = DISK_IMAGE_TYPE_D81;
 
-         if (strstr(var.value, "8_"))        opt_work_disk_unit = 8;
+         if      (strstr(var.value, "8_"))   opt_work_disk_unit = 8;
          else if (strstr(var.value, "9_"))   opt_work_disk_unit = 9;
       }
 
@@ -3290,7 +3292,7 @@ static void update_variables(void)
       if (strstr(var.value, "auto")) opt_model_auto = 1;
       else                           opt_model_auto = 0;
 
-      if (!strcmp(var.value, "VIC20 PAL auto"))       model = VIC20MODEL_VIC20_PAL;
+      if      (!strcmp(var.value, "VIC20 PAL auto"))  model = VIC20MODEL_VIC20_PAL;
       else if (!strcmp(var.value, "VIC20 NTSC auto")) model = VIC20MODEL_VIC20_NTSC;
       else if (!strcmp(var.value, "VIC20 PAL"))       model = VIC20MODEL_VIC20_PAL;
       else if (!strcmp(var.value, "VIC20 NTSC"))      model = VIC20MODEL_VIC20_NTSC;
@@ -3313,7 +3315,7 @@ static void update_variables(void)
    {
       int vic20mem = 0;
 
-      if (!strcmp(var.value, "none"))      vic20mem = 0;
+      if      (!strcmp(var.value, "none")) vic20mem = 0;
       else if (!strcmp(var.value, "3kB"))  vic20mem = 1;
       else if (!strcmp(var.value, "8kB"))  vic20mem = 2;
       else if (!strcmp(var.value, "16kB")) vic20mem = 3;
@@ -3370,7 +3372,7 @@ static void update_variables(void)
    {
       int model = 0;
 
-      if (!strcmp(var.value, "C16 PAL"))         model = PLUS4MODEL_C16_PAL;
+      if      (!strcmp(var.value, "C16 PAL"))    model = PLUS4MODEL_C16_PAL;
       else if (!strcmp(var.value, "C16 NTSC"))   model = PLUS4MODEL_C16_NTSC;
       else if (!strcmp(var.value, "PLUS4 PAL"))  model = PLUS4MODEL_PLUS4_PAL;
       else if (!strcmp(var.value, "PLUS4 NTSC")) model = PLUS4MODEL_PLUS4_NTSC;
@@ -3389,7 +3391,7 @@ static void update_variables(void)
    {
       int model = 0;
 
-      if (!strcmp(var.value, "C128 PAL"))           model = C128MODEL_C128_PAL;
+      if      (!strcmp(var.value, "C128 PAL"))      model = C128MODEL_C128_PAL;
       else if (!strcmp(var.value, "C128 NTSC"))     model = C128MODEL_C128_NTSC;
       else if (!strcmp(var.value, "C128 DCR PAL"))  model = C128MODEL_C128DCR_PAL;
       else if (!strcmp(var.value, "C128 DCR NTSC")) model = C128MODEL_C128DCR_NTSC;
@@ -3406,8 +3408,8 @@ static void update_variables(void)
    {
       int c128columnkey = 1;
 
-      if (!strcmp(var.value, "VICII"))    c128columnkey = 1;
-      else if (!strcmp(var.value, "VDC")) c128columnkey = 0;
+      if      (!strcmp(var.value, "VICII")) c128columnkey = 1;
+      else if (!strcmp(var.value, "VDC"))   c128columnkey = 0;
 
       if (retro_ui_finalized && core_opt.C128ColumnKey != c128columnkey)
       {
@@ -3424,8 +3426,8 @@ static void update_variables(void)
    {
       int c128go64 = 0;
 
-      if (!strcmp(var.value, "disabled"))     c128go64 = 0;
-      else if (!strcmp(var.value, "enabled")) c128go64 = 1;
+      if (!strcmp(var.value, "disabled")) c128go64 = 0;
+      else                                c128go64 = 1;
 
       // Force VIC-II with GO64
       if (c128go64)
@@ -3450,7 +3452,7 @@ static void update_variables(void)
    {
       int model = 0;
 
-      if (!strcmp(var.value, "2001"))          model = PETMODEL_2001;
+      if      (!strcmp(var.value, "2001"))     model = PETMODEL_2001;
       else if (!strcmp(var.value, "3008"))     model = PETMODEL_3008;
       else if (!strcmp(var.value, "3016"))     model = PETMODEL_3016;
       else if (!strcmp(var.value, "3032"))     model = PETMODEL_3032;
@@ -3478,7 +3480,7 @@ static void update_variables(void)
    {
       int model = 0;
 
-      if (!strcmp(var.value, "610 PAL"))           model = CBM2MODEL_610_PAL;
+      if      (!strcmp(var.value, "610 PAL"))      model = CBM2MODEL_610_PAL;
       else if (!strcmp(var.value, "610 NTSC"))     model = CBM2MODEL_610_NTSC;
       else if (!strcmp(var.value, "620 PAL"))      model = CBM2MODEL_620_PAL;
       else if (!strcmp(var.value, "620 NTSC"))     model = CBM2MODEL_620_NTSC;
@@ -3500,7 +3502,7 @@ static void update_variables(void)
    {
       int model = 0;
 
-      if (!strcmp(var.value, "510 PAL"))       model = CBM2MODEL_510_PAL;
+      if      (!strcmp(var.value, "510 PAL"))  model = CBM2MODEL_510_PAL;
       else if (!strcmp(var.value, "510 NTSC")) model = CBM2MODEL_510_NTSC;
 
       if (retro_ui_finalized && core_opt.Model != model)
@@ -3515,7 +3517,7 @@ static void update_variables(void)
    {
       int model = 0;
 
-      if (!strcmp(var.value, "DTV2 PAL"))         model = DTVMODEL_V2_PAL;
+      if      (!strcmp(var.value, "DTV2 PAL"))    model = DTVMODEL_V2_PAL;
       else if (!strcmp(var.value, "DTV2 NTSC"))   model = DTVMODEL_V2_NTSC;
       else if (!strcmp(var.value, "DTV3 PAL"))    model = DTVMODEL_V3_PAL;
       else if (!strcmp(var.value, "DTV3 NTSC"))   model = DTVMODEL_V3_NTSC;
@@ -3536,7 +3538,7 @@ static void update_variables(void)
       if (strstr(var.value, "auto")) opt_model_auto = 1;
       else                           opt_model_auto = 0;
 
-      if (!strcmp(var.value, "C64 PAL auto"))        model = C64MODEL_C64_PAL;
+      if      (!strcmp(var.value, "C64 PAL auto"))   model = C64MODEL_C64_PAL;
       else if (!strcmp(var.value, "C64 NTSC auto"))  model = C64MODEL_C64_NTSC;
       else if (!strcmp(var.value, "C64C PAL auto"))  model = C64MODEL_C64C_PAL;
       else if (!strcmp(var.value, "C64C NTSC auto")) model = C64MODEL_C64C_NTSC;
@@ -3571,7 +3573,7 @@ static void update_variables(void)
    {
       int sid_engine = 0;
 
-      if (!strcmp(var.value, "ReSID"))          sid_engine = 1;
+      if      (!strcmp(var.value, "ReSID"))     sid_engine = 1;
       else if (!strcmp(var.value, "ReSID-3.3")) sid_engine = 6;
       else if (!strcmp(var.value, "ReSID-FP"))  sid_engine = 7;
 
@@ -3592,7 +3594,7 @@ static void update_variables(void)
    {
       int sid_model = 0xff;
 
-      if (!strcmp(var.value, "6581"))        sid_model = 0;
+      if      (!strcmp(var.value, "6581"))   sid_model = 0;
       else if (!strcmp(var.value, "8580"))   sid_model = 1;
       /* There is no digiboost for FastSID (and it's not needed either) */
       else if (!strcmp(var.value, "8580RD")) sid_model = (!core_opt.SidEngine ? 1 : 2);
@@ -3632,10 +3634,10 @@ static void update_variables(void)
    {
       int val = 0;
 
-      if (!strcmp(var.value, "Fast"))                 val = 0;
-      else if (!strcmp(var.value, "Interpolation"))   val = 1;
-      else if (!strcmp(var.value, "Resampling"))      val = 2;
-      else if (!strcmp(var.value, "Fast resampling")) val = 3;
+      if      (!strcmp(var.value, "fast"))            val = 0;
+      else if (!strcmp(var.value, "interpolation"))   val = 1;
+      else if (!strcmp(var.value, "resampling"))      val = 2;
+      else if (!strcmp(var.value, "fast resampling")) val = 3;
 
       if (retro_ui_finalized && core_opt.SidResidSampling != val)
          log_resources_set_int("SidResidSampling", val);
@@ -3704,14 +3706,14 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "none"))         zoom_mode_id = 0;
+      if      (!strcmp(var.value, "none"))    zoom_mode_id = 0;
       else if (!strcmp(var.value, "small"))   zoom_mode_id = 1;
       else if (!strcmp(var.value, "medium"))  zoom_mode_id = 2;
       else if (!strcmp(var.value, "maximum")) zoom_mode_id = 3;
       else if (!strcmp(var.value, "manual"))  zoom_mode_id = 4;
 
 #if defined(__X128__)
-      if (core_opt.C128ColumnKey == 0)
+      if (!core_opt.C128ColumnKey)
          zoom_mode_id = 0;
 #endif
 
@@ -3724,7 +3726,7 @@ static void update_variables(void)
    {
       int zoom_mode_crop_id_prev = zoom_mode_crop_id;
 
-      if (!strcmp(var.value, "both"))            zoom_mode_crop_id = 0;
+      if      (!strcmp(var.value, "both"))       zoom_mode_crop_id = 0;
       else if (!strcmp(var.value, "vertical"))   zoom_mode_crop_id = 1;
       else if (!strcmp(var.value, "horizontal")) zoom_mode_crop_id = 2;
       else if (!strcmp(var.value, "16:9"))       zoom_mode_crop_id = 3;
@@ -3743,7 +3745,7 @@ static void update_variables(void)
    {
       int opt_aspect_ratio_prev = opt_aspect_ratio;
 
-      if (!strcmp(var.value, "auto"))      opt_aspect_ratio = 0;
+      if      (!strcmp(var.value, "auto")) opt_aspect_ratio = 0;
       else if (!strcmp(var.value, "pal"))  opt_aspect_ratio = 1;
       else if (!strcmp(var.value, "ntsc")) opt_aspect_ratio = 2;
       else if (!strcmp(var.value, "raw"))  opt_aspect_ratio = 3;
@@ -4022,29 +4024,29 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      int joyadaptertype = -1;
+      int userportjoytype = -1;
 
-      if (!strcmp(var.value, "None"))                 joyadaptertype = -1;
-      else if (!strcmp(var.value, "Protovision CGA")) joyadaptertype = USERPORT_JOYSTICK_CGA;
-      else if (!strcmp(var.value, "PET"))             joyadaptertype = USERPORT_JOYSTICK_PET;
-      else if (!strcmp(var.value, "Hummer"))          joyadaptertype = USERPORT_JOYSTICK_HUMMER;
-      else if (!strcmp(var.value, "OEM"))             joyadaptertype = USERPORT_JOYSTICK_OEM;
-      else if (!strcmp(var.value, "Hit"))             joyadaptertype = USERPORT_JOYSTICK_HIT;
-      else if (!strcmp(var.value, "Kingsoft"))        joyadaptertype = USERPORT_JOYSTICK_KINGSOFT;
-      else if (!strcmp(var.value, "Starbyte"))        joyadaptertype = USERPORT_JOYSTICK_STARBYTE;
+      if      (!strcmp(var.value, "disabled")) userportjoytype = -1;
+      else if (!strcmp(var.value, "CGA"))      userportjoytype = USERPORT_JOYSTICK_CGA;
+      else if (!strcmp(var.value, "PET"))      userportjoytype = USERPORT_JOYSTICK_PET;
+      else if (!strcmp(var.value, "Hummer"))   userportjoytype = USERPORT_JOYSTICK_HUMMER;
+      else if (!strcmp(var.value, "OEM"))      userportjoytype = USERPORT_JOYSTICK_OEM;
+      else if (!strcmp(var.value, "HIT"))      userportjoytype = USERPORT_JOYSTICK_HIT;
+      else if (!strcmp(var.value, "Kingsoft")) userportjoytype = USERPORT_JOYSTICK_KINGSOFT;
+      else if (!strcmp(var.value, "Starbyte")) userportjoytype = USERPORT_JOYSTICK_STARBYTE;
 
-      if (retro_ui_finalized && core_opt.UserportJoy != joyadaptertype)
+      if (retro_ui_finalized && core_opt.UserportJoyType != userportjoytype)
       {
-         if (joyadaptertype == -1)
+         if (userportjoytype == -1)
             log_resources_set_int("UserportJoy", 0);
          else
          {
             log_resources_set_int("UserportJoy", 1);
-            log_resources_set_int("UserportJoyType", joyadaptertype);
+            log_resources_set_int("UserportJoyType", userportjoytype);
          }
       }
 
-      core_opt.UserportJoy = joyadaptertype;
+      core_opt.UserportJoyType = userportjoytype;
    }
 #endif
 
@@ -4053,8 +4055,8 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "Port 1") && !cur_port_locked)      cur_port = 1;
-      else if (!strcmp(var.value, "Port 2") && !cur_port_locked) cur_port = 2;
+      if      (!strcmp(var.value, "1") && !cur_port_locked) cur_port = 1;
+      else if (!strcmp(var.value, "2") && !cur_port_locked) cur_port = 2;
    }
 #endif
 
@@ -4099,8 +4101,8 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "disabled"))     opt_keyrah_keypad = 0;
-      else if (!strcmp(var.value, "enabled")) opt_keyrah_keypad = 1;
+      if (!strcmp(var.value, "disabled")) opt_keyrah_keypad = 0;
+      else                                opt_keyrah_keypad = 1;
    }
 
    var.key = "vice_keyboard_keymap";
@@ -4109,7 +4111,7 @@ static void update_variables(void)
    {
       int val = opt_keyboard_keymap;
 
-      if (!strcmp(var.value, "symbolic"))             opt_keyboard_keymap = KBD_INDEX_SYM;
+      if      (!strcmp(var.value, "symbolic"))        opt_keyboard_keymap = KBD_INDEX_SYM;
       else if (!strcmp(var.value, "positional"))      opt_keyboard_keymap = KBD_INDEX_POS;
       else if (!strcmp(var.value, "symbolic-user"))   opt_keyboard_keymap = KBD_INDEX_USERSYM;
       else if (!strcmp(var.value, "positional-user")) opt_keyboard_keymap = KBD_INDEX_USERPOS;
@@ -4122,15 +4124,15 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "disabled"))     opt_keyboard_pass_through = 0;
-      else if (!strcmp(var.value, "enabled")) opt_keyboard_pass_through = 1;
+      if (!strcmp(var.value, "disabled")) opt_keyboard_pass_through = 0;
+      else                                opt_keyboard_pass_through = 1;
    }
 
    var.key = "vice_retropad_options";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "disabled"))         opt_retropad_options = 0;
+      if      (!strcmp(var.value, "disabled"))    opt_retropad_options = 0;
       else if (!strcmp(var.value, "rotate"))      opt_retropad_options = 1;
       else if (!strcmp(var.value, "jump"))        opt_retropad_options = 2;
       else if (!strcmp(var.value, "rotate_jump")) opt_retropad_options = 3;
@@ -4140,15 +4142,15 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "disabled")) turbo_fire_button = -1;
-      else if (!strcmp(var.value, "B"))   turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_B;
-      else if (!strcmp(var.value, "A"))   turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_A;
-      else if (!strcmp(var.value, "Y"))   turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_Y;
-      else if (!strcmp(var.value, "X"))   turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_X;
-      else if (!strcmp(var.value, "L"))   turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_L;
-      else if (!strcmp(var.value, "R"))   turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_R;
-      else if (!strcmp(var.value, "L2"))  turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_L2;
-      else if (!strcmp(var.value, "R2"))  turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_R2;
+      if      (!strcmp(var.value, "disabled")) turbo_fire_button = -1;
+      else if (!strcmp(var.value, "B"))        turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_B;
+      else if (!strcmp(var.value, "A"))        turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_A;
+      else if (!strcmp(var.value, "Y"))        turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_Y;
+      else if (!strcmp(var.value, "X"))        turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_X;
+      else if (!strcmp(var.value, "L"))        turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_L;
+      else if (!strcmp(var.value, "R"))        turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_R;
+      else if (!strcmp(var.value, "L2"))       turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_L2;
+      else if (!strcmp(var.value, "R2"))       turbo_fire_button = RETRO_DEVICE_ID_JOYPAD_R2;
    }
 
    var.key = "vice_turbo_pulse";
@@ -4162,10 +4164,10 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "Autostart"))   opt_reset_type = 0;
-      else if (!strcmp(var.value, "Soft"))   opt_reset_type = 1;
-      else if (!strcmp(var.value, "Hard"))   opt_reset_type = 2;
-      else if (!strcmp(var.value, "Freeze")) opt_reset_type = 3;
+      if      (!strcmp(var.value, "autostart")) opt_reset_type = 0;
+      else if (!strcmp(var.value, "soft"))      opt_reset_type = 1;
+      else if (!strcmp(var.value, "hard"))      opt_reset_type = 2;
+      else if (!strcmp(var.value, "freeze"))    opt_reset_type = 3;
    }
 
    var.key = "vice_vkbd_theme";
@@ -4200,24 +4202,24 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "disabled"))     opt_mapping_options_display = 0;
-      else if (!strcmp(var.value, "enabled")) opt_mapping_options_display = 1;
+      if (!strcmp(var.value, "disabled")) opt_mapping_options_display = 0;
+      else                                opt_mapping_options_display = 1;
    }
 
    var.key = "vice_audio_options_display";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "disabled"))     opt_audio_options_display = 0;
-      else if (!strcmp(var.value, "enabled")) opt_audio_options_display = 1;
+      if (!strcmp(var.value, "disabled")) opt_audio_options_display = 0;
+      else                                opt_audio_options_display = 1;
    }
 
    var.key = "vice_video_options_display";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "disabled"))     opt_video_options_display = 0;
-      else if (!strcmp(var.value, "enabled")) opt_video_options_display = 1;
+      if (!strcmp(var.value, "disabled")) opt_video_options_display = 0;
+      else                                opt_video_options_display = 1;
    }
 
    var.key = "vice_read_vicerc";
@@ -4225,8 +4227,8 @@ static void update_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       int opt_read_vicerc_prev = opt_read_vicerc;
-      if (!strcmp(var.value, "disabled"))     opt_read_vicerc = 0;
-      else if (!strcmp(var.value, "enabled")) opt_read_vicerc = 1;
+      if (!strcmp(var.value, "disabled")) opt_read_vicerc = 0;
+      else                                opt_read_vicerc = 1;
 
       if (retro_ui_finalized)
          request_reload_restart = (opt_read_vicerc != opt_read_vicerc_prev) ? 1 : request_reload_restart;
@@ -4251,8 +4253,8 @@ static void update_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       int opt_jiffydos_prev = opt_jiffydos;
-      if (!strcmp(var.value, "disabled"))     opt_jiffydos = 0;
-      else if (!strcmp(var.value, "enabled")) opt_jiffydos = 1;
+      if (!strcmp(var.value, "disabled")) opt_jiffydos = 0;
+      else                                opt_jiffydos = 1;
 
       if (!opt_jiffydos_allow)
          opt_jiffydos = 0;
@@ -4451,8 +4453,8 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      if (!strcmp(var.value, "disabled"))     datasette_hotkeys = 0;
-      else if (!strcmp(var.value, "enabled")) datasette_hotkeys = 1;
+      if (!strcmp(var.value, "disabled")) datasette_hotkeys = 0;
+      else                                datasette_hotkeys = 1;
    }
 
    var.key = "vice_mapper_datasette_toggle_hotkeys";

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -27,9 +27,6 @@
 #if defined(__ANDROID__) || defined(ANDROID)
 #include <android/log.h>
 #define LOG_TAG "RetroArch.vice"
-#define LOGI(...)  __android_log_print(ANDROID_LOG_INFO,LOG_TAG,__VA_ARGS__)
-#else
-#define LOGI printf
 #endif
 
 // Types

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -131,7 +131,7 @@ extern void retro_audio_render(signed short int *sound_buffer, int sndbufsize);
 // Core options
 struct libretro_core_options {
     int Model;
-    int UserportJoy;
+    int UserportJoyType;
     int AutostartWarp;
     int AttachDevice8Readonly;
     int DriveTrueEmulation;

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -541,24 +541,24 @@ void update_input(int disable_physical_cursor_keys)
    {
       if (!vkflag[4]) /* Allow directions when key is not pressed */
       {
-         if (!vkflag[0] && (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP)))
+         if (!vkflag[0] && (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) || input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_UP)))
             vkflag[0] = 1;
-         else if (vkflag[0] && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP)))
+         else if (vkflag[0] && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) && !input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_UP)))
             vkflag[0] = 0;
 
-         if (!vkflag[1] && (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN)))
+         if (!vkflag[1] && (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) || input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_DOWN)))
             vkflag[1] = 1;
-         else if (vkflag[1] && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN)))
+         else if (vkflag[1] && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) && !input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_DOWN)))
             vkflag[1] = 0;
 
-         if (!vkflag[2] && (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT)))
+         if (!vkflag[2] && (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) || input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_LEFT)))
             vkflag[2] = 1;
-         else if (vkflag[2] && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT)))
+         else if (vkflag[2] && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) && !input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_LEFT)))
             vkflag[2] = 0;
 
-         if (!vkflag[3] && (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)))
+         if (!vkflag[3] && (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) || input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) || input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_RIGHT)))
             vkflag[3] = 1;
-         else if (vkflag[3] && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)))
+         else if (vkflag[3] && (!input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) && !input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT) && !input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_RIGHT)))
             vkflag[3] = 0;
       }
       else /* Release all directions when key is pressed */

--- a/libretro/retro_disk_control.h
+++ b/libretro/retro_disk_control.h
@@ -55,6 +55,7 @@ struct dc_storage
 	unsigned count;
 	int index;
 	bool eject_state;
+	bool replace;
 };
 
 typedef struct dc_storage dc_storage;

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -253,12 +253,12 @@ int ui_init_finalize(void)
 #endif
 
 #if !defined(__XCBM5x0__)
-   if (core_opt.UserportJoy == -1)
+   if (core_opt.UserportJoyType == -1)
       log_resources_set_int("UserportJoy", 0);
    else
    {
       log_resources_set_int("UserportJoy", 1);
-      log_resources_set_int("UserportJoyType", core_opt.UserportJoy);
+      log_resources_set_int("UserportJoyType", core_opt.UserportJoyType);
    }
 #endif
 

--- a/vice/src/arch/libretro/uistatusbar.c
+++ b/vice/src/arch/libretro/uistatusbar.c
@@ -150,7 +150,7 @@ static void display_joyport(void)
        sprintf(tmpstr, "J%s%3s ", joy1, joystick_value_human(joystick_value[1], 0));
 #endif
 
-    if (core_opt.UserportJoy != -1)
+    if (core_opt.UserportJoyType != -1)
     {
         sprintf(tmpstr + strlen(tmpstr), "J%d%3s ", 3, joystick_value_human(joystick_value[3], 0));
         sprintf(tmpstr + strlen(tmpstr), "J%d%3s ", 4, joystick_value_human(joystick_value[4], 0));

--- a/vice/src/drive/drive.c
+++ b/vice/src/drive/drive.c
@@ -751,7 +751,7 @@ static void drive_led_update(drive_t *drive, drive_t *drive0)
 #include <stdbool.h>
 extern unsigned int opt_autoloadwarp;
 extern int retro_warp_mode_enabled();
-extern bool retro_get_eject_state();
+extern bool retro_disk_get_eject_state();
 static int warpmode_counter = 0;
 static int drive_half_track = 0;
 static int drive_half_track_prev = 0;
@@ -789,7 +789,7 @@ void drive_update_ui_status(void)
                                        drive->current_half_track + (drive->side * DRIVE_HALFTRACKS_1571));
             }
 #ifdef __LIBRETRO__
-            if (opt_autoloadwarp && !retro_get_eject_state())
+            if (opt_autoloadwarp && !retro_disk_get_eject_state())
             {
                 drive_half_track = drive->current_half_track;
                 //printf("track:%2d prev:%2d led:%d timer:%2d\n", drive_half_track, drive_half_track_prev, drive->led_status, warpmode_counter);

--- a/vice/src/sid/sid.c
+++ b/vice/src/sid/sid.c
@@ -56,7 +56,7 @@
 
 #ifdef HAVE_RESID
 #include "resid.h"
-#if defined(__LIBRETRO__) && !defined(__X64DTV__)
+#if defined(__LIBRETRO__) && (defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__) || defined(__X128__))
 extern sid_engine_t resid33_hooks;
 extern sid_engine_t residfp_hooks;
 #endif
@@ -346,7 +346,7 @@ sound_t *sid_sound_machine_open(int chipno)
     if (sidengine == SID_ENGINE_RESID) {
         sid_engine = resid_hooks;
     }
-#if defined(__LIBRETRO__) && !defined(__X64DTV__)
+#if defined(__LIBRETRO__) && (defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__) || defined(__X128__))
     if (sidengine == SID_ENGINE_RESID33) {
         sid_engine = resid33_hooks;
     }
@@ -568,7 +568,7 @@ int sid_sound_machine_cycle_based(void)
             return 0;
 #ifdef HAVE_RESID
         case SID_ENGINE_RESID:
-#if defined(__LIBRETRO__) && !defined(__X64DTV__)
+#if defined(__LIBRETRO__) && (defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__) || defined(__X128__))
         case SID_ENGINE_RESID33:
         case SID_ENGINE_RESIDFP:
 #endif
@@ -618,7 +618,7 @@ static void set_sound_func(void)
             sid_store_func = sound_store;
             sid_dump_func = sound_dump;
         }
-#if defined(__LIBRETRO__) && !defined(__X64DTV__)
+#if defined(__LIBRETRO__) && (defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__) || defined(__X128__))
         if (sid_engine_type == SID_ENGINE_RESID33) {
             sid_read_func = sound_read;
             sid_store_func = sound_store;


### PR DESCRIPTION
- Removed fancy ReSID options (3.3 + FP) from cores that either has very little use for them or need extra SID carts to even have SID
  - This trims the core a whopping ~3MB, which is almost half!
  - Affects XCBM2, XCBM5x0, XPET, XPLUS4 and XVIC
- Core options tunings (labels and values)
- Disk Control cleanup
- Allow using VKBD with arrow keys even when in Game Focus
- Disabled separate disk index change message in favor of frontend already doing it, but without the actual disk label
