### PR TITLE
VIC-20 Mega-Cart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,17 @@
 # VICE LIBRETRO
 
-Port of VICE, the Versatile Commodore Emulator 3.3 with virtual keyboard
-
-Supported platforms: Linux Windows Apple Android emscripten Switch Vita
+Port of VICE, the Versatile Commodore Emulator 3.3
 
 Source base: [https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.tar.gz](https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.tar.gz)
 
-## Recent improvements
-
-- Automatic NIB->G64 conversion
-- Savestates
-- Virtual keyboard revamped: more responsive, cleaner design, much easier to control
-- GUI removed
-- Autostart PRG mode to inject
-- System-subdir renamed to `vice` and created automatically
-- Keyboard keys disabled while using RetroPad
-- New settings:
-  - Drive Sound Emulation (1541 & 1571 only)
-  - Reset Type (Autostart, Soft, Hard, Freeze)
-  - Customizable hotkeys for essential functions (virtual keyboard, statusbar, joyport switch, reset, Datasette controls)
-  - Keyrah joystick maps
-  - Zoom mode
-  - Paddles & mouse
-  - JiffyDOS support
+Supported platforms: Linux, Windows, Apple, Android, emscripten, Switch, Vita
 
 ## Default controls
 
 |RetroPad button|Action|
 |---|---|
 |D-Pad|Joystick|
+|Left Analog|Mouse/paddles|
 |B|Fire button|
 |X|Space|
 |L2|Escape (RUN/STOP)|
@@ -53,8 +36,7 @@ Source base: [https://sourceforge.net/projects/vice-emu/files/releases/vice-3.3.
 Long press for sticky keys. Stickying the third key will replace the second.
 
 ## Joyport control
-
-C64 games sometimes use joystick port 1 and sometimes joystick port 2 for player 1. There are several ways to switch ports in this core:
+Older C64 games tend to use joystick port 1 and newer ones tend to use port 2 for player 1. There are several ways to switch ports in this core:
 - Use the core option: `Quick Menu -> Options -> RetroPad Port`.
 - Bring up the virtual keyboard with `Select` button, and press the key labeled `JOY`.
 - Press the default keyboard shortcut `Right Control`.
@@ -89,7 +71,6 @@ ZIP support is provided by the core, which allows:
 - The use of zipped images in M3Us
 
 ## JiffyDOS support
-
 External ROM files required in `system/vice`:
 
 |Filename|Size|MD5|
@@ -101,26 +82,42 @@ External ROM files required in `system/vice`:
 |**JiffyDOS_1581.bin**|32 768|20b6885c6dc2d42c38754a365b043d71|
 
 ## Command file operation
-
 VICE command line options are supported by placing the desired command line in a text file with `.cmd` file extension. The command line format is as documented in the [VICE manual](http://vice-emu.sourceforge.net/vice_6.html).
 
-Using this you can overcome limitations of the GUI and set advanced configurations required for running problematic files. Here are a couple of examples for the xvic core:
+Using this you can overcome limitations of the GUI and set advanced configurations required for running problematic files.
 
-VIC-20 megacart support:
-```
-xvic -cartmega /path/to/rom/mega-cart-name.rom
-```
-VIC-20 games which require specific memory configs such as 8k expansion (`-memory (3k/8k/16k/24k/all) / (0/1/2/3/5) / (04/20/40/60/a0)`):
-```
-xvic -memory 1 /path/to/rom/some-8k-game.d64
-xvic -memory 8k /path/to/rom/some-8k-game.d64
-xvic -memory 20 /path/to/rom/some-8k-game.d64
-```
 
-VIC-20 memory expansion will also be set with filename tags or directory matching: `some game (8k).prg` or `/8k/some game.prg`.
+VIC-20 Mega-Cart can be launched via `.cmd`:
+```
+xvic -cartmega "/path/to/rom/mega-cart-name.rom"
+```
+**VIC-20 Mega-Cart is supported automatically with NvRAM file directed to `saves`.**
+
+
+VIC-20 memory expansion can be set via `.cmd`: `-memory (3k/8k/16k/24k/all) / (0/1/2/3/5) / (04/20/40/60/a0)`:
+```
+xvic -memory 1 "/path/to/rom/some-8k-game.d64"
+xvic -memory 8k "/path/to/rom/some-8k-game.d64"
+xvic -memory 20 "/path/to/rom/some-8k-game.d64"
+```
+**VIC-20 memory expansion can be set with filename tags or directory matching:**
+- `some game (8k).prg` or `/8k/some game.prg`
+- `vicdoom (35k).d64`
+
+## Latest features
+- Automatic VIC-20 Mega-Cart support (with NvRAM)
+- Automatic NIB->G64 conversion
+- Region (PAL/NTSC) filepath tags for C64 & VIC-20
+- Memory expansion filepath tags for VIC-20
+- JiffyDOS support
+- Paddles & mouse
+- Zoom mode
+- Savestates
+- Keyrah joystick maps
+- Drive Sound Emulation (1541 & 1571 only)
+- Reset Type (Autostart, Soft, Hard, Freeze)
 
 ## Build instructions
-
 Remember to run `make clean EMUTYPE=x` when building different EMUTYPEs.
 
 Currently working EMUTYPEs:

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -5132,26 +5132,41 @@ double retro_get_aspect_ratio(unsigned int width, unsigned int height, bool pixe
    }
 
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__)
-      if (region == RETRO_REGION_NTSC)
-         par = (double)0.75000000;
-      else
-         par = (double)0.93650794;
+      switch (region)
+      {
+         case RETRO_REGION_NTSC:
+            par = (double)0.75000000;
+            break;
+         case RETRO_REGION_PAL:
+            par = (double)0.93650794;
+            break;
+      }
       ar = ((double)width / (double)height) * par;
 #if defined(__X128__)
       if (core_opt.C128ColumnKey == 0)
          ar = ((double)width / (double)height) / (double)2.0;
 #endif
 #elif defined(__XVIC__)
-      if (region == RETRO_REGION_NTSC)
-         par = ((double)1.50411479 / (double)2.0);
-      else
-         par = ((double)1.66574035 / (double)2.0);
+      switch (region)
+      {
+         case RETRO_REGION_NTSC:
+            par = ((double)1.50411479 / (double)2.0);
+            break;
+         case RETRO_REGION_PAL:
+            par = ((double)1.66574035 / (double)2.0);
+            break;
+      }
       ar = ((double)width / (double)height) * par;
 #elif defined(__XPLUS4__)
-      if (region == RETRO_REGION_NTSC)
-         par = (double)0.85760931;
-      else
-         par = (double)1.03743478;
+      switch (region)
+      {
+         case RETRO_REGION_NTSC:
+            par = (double)0.85760931;
+            break;
+         case RETRO_REGION_PAL:
+            par = (double)1.03743478;
+            break;
+      }
       ar = ((double)width / (double)height) * par;
 #else
       ar = (double)4 / (double)3;
@@ -5260,26 +5275,24 @@ void update_geometry(int mode)
                         break;
                      case 3: /* 16:9 */
                         zoom_dar = (double)16/9;
-                        zoom_crop_width = retroW - ((double)(retroH - zoom_crop_height) * (double)zoom_dar / (double)zoom_par);
                         break;
                      case 4: /* 16:10 */
                         zoom_dar = (double)16/10;
-                        zoom_crop_width = retroW - ((double)(retroH - zoom_crop_height) * (double)zoom_dar / (double)zoom_par);
                         break;
                      case 5: /* 4:3 */
                         zoom_dar = (double)4/3;
-                        zoom_crop_height = retroH - zoom_height_max - ((double)zoom_border_height * (double)zoom_dar / (double)zoom_par);
-                        zoom_crop_width = retroW - ((double)(retroH - zoom_crop_height) * (double)zoom_dar / (double)zoom_par);
-                        if (retroW - zoom_crop_width <= zoom_width_max)
-                           zoom_crop_height = retroH - ((double)(zoom_width_max) / (double)zoom_dar * (double)zoom_par);
                         break;
                      case 6: /* 5:4 */
                         zoom_dar = (double)5/4;
-                        zoom_crop_height = retroH - zoom_height_max - ((double)zoom_border_height * (double)zoom_dar / (double)zoom_par);
-                        zoom_crop_width = retroW - ((double)(retroH - zoom_crop_height) * (double)zoom_dar / (double)zoom_par);
-                        if (retroW - zoom_crop_width <= zoom_width_max)
-                           zoom_crop_height = retroH - ((double)(zoom_width_max) / (double)zoom_dar * (double)zoom_par);
                         break;
+                  }
+
+                  if (zoom_dar > 0)
+                  {
+                     zoom_crop_height = retroH - zoom_height_max - ((double)zoom_border_height * (double)zoom_dar / (double)zoom_par);
+                     zoom_crop_width = retroW - ((double)(retroH - zoom_crop_height) * (double)zoom_dar / (double)zoom_par);
+                     if (retroW - zoom_crop_width <= zoom_width_max)
+                        zoom_crop_height = retroH - ((double)(zoom_width_max) / (double)zoom_dar * (double)zoom_par);
                   }
 
                   if (retroW - zoom_crop_width < zoom_width_max)

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -437,6 +437,8 @@ static int autodetect_vic20_cartridge_type(const char* argv)
             type = CARTRIDGE_VIC20_8KB_A000;
         else if (len <= 0x4000)
             type = CARTRIDGE_VIC20_16KB_6000;
+        else if (len == 0x200000 && addr == 0)
+            type = CARTRIDGE_VIC20_MEGACART;
     }
 
     /* Separate ROM combinations (type = -1) */
@@ -658,6 +660,7 @@ static int process_cmdline(const char* argv)
             Add_Option("-cartB");
         else if (strendswith(argv, ".prg")
               || strendswith(argv, ".crt")
+              || strendswith(argv, ".rom")
               || strendswith(argv, ".bin")
               || strendswith(argv, ".m3u"))
         {
@@ -670,6 +673,8 @@ static int process_cmdline(const char* argv)
                 char cart_2000[RETRO_PATH_MAX] = {0};
                 char cart_6000[RETRO_PATH_MAX] = {0};
                 char cart_A000[RETRO_PATH_MAX] = {0};
+                char cartmega_nvram[RETRO_PATH_MAX] = {0};
+                char cartmega_temp[RETRO_PATH_MAX] = {0};
 
                 int type = autodetect_vic20_cartridge_type(argv);
                 switch (type)
@@ -691,6 +696,16 @@ static int process_cmdline(const char* argv)
                         break;
                     case CARTRIDGE_VIC20_GENERIC:
                         Add_Option("-cartgeneric");
+                        break;
+                    case CARTRIDGE_VIC20_MEGACART:
+                        snprintf(cartmega_temp, sizeof(cartmega_temp), "%s", argv);
+                        snprintf(cartmega_temp, sizeof(cartmega_temp), "%s", path_basename(cartmega_temp));
+                        snprintf(cartmega_temp, sizeof(cartmega_temp), "%s", path_remove_extension(cartmega_temp));
+                        snprintf(cartmega_nvram, sizeof(cartmega_nvram), "%s%s%s%s",
+                                 retro_save_directory, FSDEV_DIR_SEP_STR, cartmega_temp, ".nvr");
+                        Add_Option("-mcnvramfile");
+                        Add_Option(cartmega_nvram);
+                        Add_Option("-cartmega");
                         break;
                     case -1: /* Separate ROM combination shenanigans */
                         snprintf(cart_2000, sizeof(cart_2000), "%s", argv);
@@ -5103,7 +5118,7 @@ void retro_get_system_info(struct retro_system_info *info)
    info->library_name     = "VICE " CORE_NAME;
    info->library_version  = "3.3" GIT_VERSION;
 #if defined(__XVIC__)
-   info->valid_extensions = "20|40|60|a0|b0|d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz";
+   info->valid_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz|20|40|60|a0|b0|rom";
 #else
    info->valid_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz";
 #endif

--- a/libretro/retro_disk_control.c
+++ b/libretro/retro_disk_control.c
@@ -870,6 +870,7 @@ enum dc_image_type dc_get_image_type(const char* filename)
 	    strendswith(filename, "a0")  ||
 	    strendswith(filename, "b0")  ||
 	    strendswith(filename, "crt") ||
+	    strendswith(filename, "rom") ||
 	    strendswith(filename, "bin"))
 	   return DC_IMAGE_TYPE_MEM;
 

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -388,6 +388,8 @@ int ui_init_finalize(void)
 #endif
 
 #if defined(__XVIC__)
+   log_resources_set_int("MegaCartNvRAMWriteBack", 1);
+
    unsigned int vic20mem = 0;
    vic20mem = (vic20mem_forced > -1) ? vic20mem_forced : core_opt.VIC20Memory;
 


### PR DESCRIPTION
- Direct support for VIC-20 Mega-Cart with NvRAM saving to `saves` without `.cmd` hassle
- Allowed the use of relative paths in `.cmd`s
- Fixed 1:1 pixel aspect zoom preset calculations

Closes #284 
