### PR TITLE
Add OpenDingux target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,19 @@ else ifeq ($(platform), psl1ght)
    COMMONFLAGS += -DHAVE_STRTOUL -D__PSL1GHT__
    STATIC_LINKING = 1
 
+# GCW0
+else ifeq ($(platform), gcw0)
+   TARGET := $(TARGET_NAME)_libretro.so
+   CC = /opt/gcw0-toolchain/usr/bin/mipsel-linux-gcc
+   CXX = /opt/gcw0-toolchain/usr/bin/mipsel-linux-g++
+   AR = /opt/gcw0-toolchain/usr/bin/mipsel-linux-ar
+   LDFLAGS += -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T
+   fpic := -fPIC
+   OLD_GCC := 1
+   COMMONFLAGS += -DDINGUX -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
+   COMMONFLAGS += -DHAVE_SYS_TYPES_H -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L
+   CFLAGS += -std=c99
+
 # ARM
 else ifneq (,$(findstring armv,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2412,7 +2412,7 @@ void retro_set_environment(retro_environment_t cb)
             { "resampling", "Resampling" },
             { NULL, NULL },
          },
-#if defined(PSP) || defined(VITA) || defined(__SWITCH__)
+#if defined(PSP) || defined(VITA) || defined(__SWITCH__) || defined(DINGUX)
          "fast"
 #else
          "resampling"
@@ -3752,6 +3752,14 @@ static void update_variables(void)
          zoom_mode_id = 0;
 #endif
 
+#if defined(DINGUX)
+      /* Changing the zoom mode on OpenDingux devices
+       * causes an instant crash. It is very difficult
+       * to debug this, so disable the option until the
+       * issue is resolved */
+      zoom_mode_id = 0;
+#endif
+
       opt_zoom_mode_id = zoom_mode_id;
    }
 
@@ -5035,7 +5043,7 @@ void retro_init(void)
       environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, &disk_interface);
 
    /* Keep as incomplete until rewind can be enabled at startup (snapshot size is 0 at that time) */
-   static uint32_t quirks = RETRO_SERIALIZATION_QUIRK_INCOMPLETE | RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE | RETRO_SERIALIZATION_QUIRK_CORE_VARIABLE_SIZE;
+   static uint64_t quirks = RETRO_SERIALIZATION_QUIRK_INCOMPLETE | RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE | RETRO_SERIALIZATION_QUIRK_CORE_VARIABLE_SIZE;
    environ_cb(RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS, &quirks);
 
    /* Inputs */


### PR DESCRIPTION
This PR adds an OpenDingux (GCW0) target to the makefile.

Tested on an RG350M, the core works perfectly - with the (sizeable) caveat that changing the zoom mode causes a hard crash of RetroArch. It is somewhat difficult to debug this on the RG350 (it requires telnet using a network adaptor, which I do not have...), so until the issue can be resolved the zoom mode option has been disabled on OpenDingux devices.