### PR TITLE
Savestate hacks, Misc fixes

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -4799,8 +4799,18 @@ void emu_reset(int type)
    }
 }
 
+static bool retro_disk_set_eject_state(bool ejected);
+
 void retro_reset(void)
 {
+   /* Reset DC index to first entry */
+   if (dc)
+   {
+      dc->index = 0;
+      retro_disk_set_eject_state(true);
+      retro_disk_set_eject_state(false);
+   }
+
    /* Trigger autostart-reset in retro_run() */
    request_restart = true;
 }

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -781,13 +781,13 @@ static int process_cmdline(const char* argv)
             Add_Option("-cart");
 #endif
 
-        if (strendswith(argv, ".m3u"))
+        if (strendswith(argv, "m3u"))
         {
             /* Parse the m3u file */
             dc_parse_m3u(dc, argv);
             is_fliplist = true;
         }
-        else if (strendswith(argv, ".vfl"))
+        else if (strendswith(argv, "vfl"))
         {
             /* Parse the vfl file */
             dc_parse_vfl(dc, argv);
@@ -859,7 +859,7 @@ static int process_cmdline(const char* argv)
                 cur_port = 2;
                 cur_port_locked = true;
             }
-            else if (strendswith(arg, ".m3u"))
+            else if (strendswith(arg, "m3u"))
             {
                 /* Parse the m3u file, don't pass to vice */
                 dc_parse_m3u(dc, arg);

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -5565,9 +5565,6 @@ void retro_run(void)
          opt_model_auto = 2;
       }
 #endif
-      /* Update work disk */
-      if (request_update_work_disk)
-         update_work_disk();
 
       /* Update samplerate if changed by core option */
       if (prev_sound_sample_rate != core_opt.SoundSampleRate)
@@ -5628,7 +5625,13 @@ void retro_run(void)
       /* resetting the aspect to 4/3 etc. So we inform the frontend of the actual */
       /* current aspect ratio and screen size again here */
       update_geometry(0);
-   } 
+   }
+   else if (runstate == RUNSTATE_RUNNING)
+   {
+      /* Update work disk */
+      if (request_update_work_disk)
+         update_work_disk();
+   }
 
    /* Input poll */
    retro_poll_event();

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -550,6 +550,10 @@ static int process_cmdline(const char* argv)
         snprintf(zip_basename, sizeof(zip_basename), "%s", path_remove_extension(zip_basename));
         snprintf(retro_temp_directory, sizeof(retro_temp_directory), "%s%s%s", retro_save_directory, FSDEV_DIR_SEP_STR, "TEMP");
 
+        /* Clean ZIP temp */
+        if (!string_is_empty(retro_temp_directory) && path_is_directory(retro_temp_directory))
+            remove_recurse(retro_temp_directory);
+
         char nib_input[RETRO_PATH_MAX] = {0};
         char nib_output[RETRO_PATH_MAX] = {0};
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1647,9 +1647,9 @@ void retro_set_environment(retro_environment_t cb)
          "vice_jiffydos",
          "System > JiffyDOS",
 #if defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__)
-         "For D64/D71/D81 disk images only!\nROMs required in 'system/vice':\n- 'JiffyDOS_C64.bin'\n- 'JiffyDOS_1541-II.bin'\n- 'JiffyDOS_1571_repl310654.bin'\n- 'JiffyDOS_1581.bin'",
+         "For D64/D71/D81 disk images only!\n'True Drive Emulation' required!\nROMs required in 'system/vice':\n- 'JiffyDOS_C64.bin'\n- 'JiffyDOS_1541-II.bin'\n- 'JiffyDOS_1571_repl310654.bin'\n- 'JiffyDOS_1581.bin'",
 #elif defined(__X128__)
-         "For D64/D71/D81 disk images only!\nROMs required in 'system/vice':\n- 'JiffyDOS_C128.bin'\n- 'JiffyDOS_C64.bin' (GO64)\n- 'JiffyDOS_1541-II.bin'\n- 'JiffyDOS_1571_repl310654.bin'\n- 'JiffyDOS_1581.bin'",
+         "For D64/D71/D81 disk images only!\n'True Drive Emulation' required!\nROMs required in 'system/vice':\n- 'JiffyDOS_C128.bin'\n- 'JiffyDOS_C64.bin' (GO64)\n- 'JiffyDOS_1541-II.bin'\n- 'JiffyDOS_1571_repl310654.bin'\n- 'JiffyDOS_1581.bin'",
 #endif
          {
             { "disabled", NULL },

--- a/vice/src/stamp-h1
+++ b/vice/src/stamp-h1
@@ -1,1 +1,0 @@
-timestamp for src/config.h


### PR DESCRIPTION
Major:
- VICE snapshot behavior hacked to include the attached disk filename instead of disk data
  - Allows proper Disc Control index syncing, because disk label included in the data is not reliable enough for matching purposes
  - Also saves plenty of space, because the disk data in the state is disk size doubled
  - Also hacked to behave the same whether TDE is enabled or not (normally the data is saved only when TDE is enabled)
  - Affects only 1541 drive images (D64, G64/NIB) and old states still work, albeit states depending on the included disk data simply need to be saved again after index is changed

Closes #293 

Minor:
- Reset Disc Control index to first entry on Quick Menu -> Restart
Closes #298 

- Fix work disk insertion at startup
- JiffyDOS core option label tweak
- ZIP temp will be removed also before creating it, in case of crashes
