### PR TITLE
New core options, Per-content vicerc

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1631,6 +1631,26 @@ void retro_set_environment(retro_environment_t cb)
          },
          "C64 PAL auto"
       },
+#if !defined(__XSCPU64__)
+      {
+         "vice_ram_expansion_unit",
+         "System > RAM Expansion Unit",
+         "Changing while running resets the system!",
+         {
+            { "none", "disabled" },
+            { "128kB", "128kB (1700)" },
+            { "256kB", "256kB (1764)" },
+            { "512kB", "512kB (1750)" },
+            { "1024kB", "1024kB" },
+            { "2048kB", "2048kB" },
+            { "4096kB", "4096kB" },
+            { "8192kB", "8192kB" },
+            { "16384kB", "16384kB" },
+            { NULL, NULL },
+         },
+         "none"
+      },
+#endif
 #endif
 #if defined(__XSCPU64__)
       {
@@ -1702,7 +1722,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_autoloadwarp",
          "Media > Automatic Load Warp",
-         "Toggles warp mode always during disk and tape loading. Mutes 'Drive Sound Emulation'.",
+         "Toggles warp mode always during disk and tape loading. Mutes 'Drive Sound Emulation'.\n'True Drive Emulation' required!",
          {
             { "disabled", NULL },
             { "enabled", NULL },
@@ -1713,7 +1733,18 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_drive_true_emulation",
          "Media > True Drive Emulation",
-         "Loads much slower, but some games need it.",
+         "Loads much slower, but some games need it.\nRequired for 'JiffyDOS', 'Automatic Load Warp' and LED driver interface!",
+         {
+            { "disabled", NULL },
+            { "enabled", NULL },
+            { NULL, NULL },
+         },
+         "enabled"
+      },
+      {
+         "vice_virtual_device_traps",
+         "Media > Virtual Device Traps",
+         "Required for printer device, but causes loading issues on rare cases.",
          {
             { "disabled", NULL },
             { "enabled", NULL },
@@ -1732,6 +1763,19 @@ void retro_set_environment(retro_environment_t cb)
          },
          "disabled"
       },
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+      {
+         "vice_easyflash_write_protection",
+         "Media > EasyFlash Write Protection",
+         "Makes EasyFlash cartridges read only.",
+         {
+            { "disabled", NULL },
+            { "enabled", NULL },
+            { NULL, NULL },
+         },
+         "disabled"
+      },
+#endif
       {
          "vice_work_disk",
          "Media > Global Work Disk",
@@ -2292,6 +2336,19 @@ void retro_set_environment(retro_environment_t cb)
          "disabled"
       },
       {
+         "vice_sound_sample_rate",
+         "Audio > Output Sample Rate",
+         "Slightly higher quality or higher performance.",
+         {
+            { "22050", NULL },
+            { "44100", NULL },
+            { "48000", NULL },
+            { "96000", NULL },
+            { NULL, NULL },
+         },
+         "48000"
+      },
+      {
          "vice_drive_sound_emulation",
          "Audio > Drive Sound Emulation",
          "'True Drive Emulation' & D64/D71 disk image required.",
@@ -2349,24 +2406,11 @@ void retro_set_environment(retro_environment_t cb)
          "disabled"
       },
 #endif
-      {
-         "vice_sound_sample_rate",
-         "Audio > Output Sample Rate",
-         "Slightly higher quality or higher performance.",
-         {
-            { "22050", NULL },
-            { "44100", NULL },
-            { "48000", NULL },
-            { "96000", NULL },
-            { NULL, NULL },
-         },
-         "48000"
-      },
 #if !defined(__XPET__) && !defined(__XPLUS4__) && !defined(__XVIC__)
       {
          "vice_sid_engine",
          "Audio > SID Engine",
-         "'ReSID' is accurate but slower.",
+         "'ReSID' is accurate, 'ReSID-FP' is more accurate, 'FastSID' is the last resort.",
          {
             { "FastSID", NULL },
             { "ReSID", NULL },
@@ -2386,7 +2430,7 @@ void retro_set_environment(retro_environment_t cb)
             { "default", "Default" },
             { "6581", NULL },
             { "8580", NULL },
-            { "8580RD", "8580 ReSID + Digi Boost" },
+            { "8580RD", "8580 ReSID + digi boost" },
             { NULL, NULL },
          },
          "default"
@@ -2463,7 +2507,7 @@ void retro_set_environment(retro_environment_t cb)
       },
       {
          "vice_resid_filterbias",
-         "Audio > ReSID Filter Bias",
+         "Audio > ReSID Filter 6581 Bias",
          "",
          {
             { "-5000", NULL },
@@ -2520,6 +2564,20 @@ void retro_set_environment(retro_environment_t cb)
             { NULL, NULL },
          },
          "1500"
+      },
+#endif
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+      {
+         "vice_sfx_sound_expander",
+         "Audio > SFX Sound Expander",
+         "",
+         {
+            { "disabled", NULL },
+            { "3526", "YM3526" },
+            { "3812", "YM3812" },
+            { NULL, NULL },
+         },
+         "disabled"
       },
 #endif
 #if !defined(__XPET__) && !defined(__XCBM2__)
@@ -3252,6 +3310,23 @@ static void update_variables(void)
       core_opt.AttachDevice8Readonly = readonly;
    }
 
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+   var.key = "vice_easyflash_write_protection";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int writecrt = 0;
+
+      if (!strcmp(var.value, "disabled")) writecrt = 1;
+      else                                writecrt = 0;
+
+      if (retro_ui_finalized && core_opt.EasyFlashWriteCRT != writecrt)
+         log_resources_set_int("EasyFlashWriteCRT", writecrt);
+
+      core_opt.EasyFlashWriteCRT = writecrt;
+   }
+#endif
+
    var.key = "vice_work_disk";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -3272,6 +3347,22 @@ static void update_variables(void)
 
       if (work_disk_type != opt_work_disk_type || work_disk_unit != opt_work_disk_unit)
          request_update_work_disk = true;
+   }
+
+   var.key = "vice_virtual_device_traps";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (retro_ui_finalized)
+      {
+         if (!strcmp(var.value, "disabled") && core_opt.VirtualDevices)
+            log_resources_set_int("VirtualDevices", 0);
+         else if (!strcmp(var.value, "enabled") && !core_opt.VirtualDevices)
+            log_resources_set_int("VirtualDevices", 1);
+      }
+
+      if (!strcmp(var.value, "disabled")) core_opt.VirtualDevices = 0;
+      else                                core_opt.VirtualDevices = 1;
    }
 
    var.key = "vice_drive_true_emulation";
@@ -3431,7 +3522,7 @@ static void update_variables(void)
          log_resources_set_int("RAMBlock2", (vic_blocks & VIC_BLK2) ? 1 : 0);
          log_resources_set_int("RAMBlock3", (vic_blocks & VIC_BLK3) ? 1 : 0);
          log_resources_set_int("RAMBlock5", (vic_blocks & VIC_BLK5) ? 1 : 0);
-         machine_trigger_reset(MACHINE_RESET_MODE_HARD);
+         request_restart = true;
       }
 
       core_opt.VIC20Memory = vic20mem;
@@ -3483,10 +3574,7 @@ static void update_variables(void)
       else if (!strcmp(var.value, "VDC"))   c128columnkey = 0;
 
       if (retro_ui_finalized && core_opt.C128ColumnKey != c128columnkey)
-      {
          log_resources_set_int("C128ColumnKey", c128columnkey);
-         machine_trigger_reset(MACHINE_RESET_MODE_SOFT);
-      }
 
       core_opt.C128ColumnKey = c128columnkey;
    }
@@ -3635,6 +3723,31 @@ static void update_variables(void)
 
       core_opt.Model = model;
    }
+
+#if !defined(__XSCPU64__)
+   var.key = "vice_ram_expansion_unit";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int reusize = 0;
+
+      if (strcmp(var.value, "none"))
+         reusize = atoi(var.value);
+
+      if (retro_ui_finalized && core_opt.REUsize != reusize)
+      {
+         if (!reusize)
+            resources_set_int("REU", 0);
+         else
+         {
+            resources_set_int("REUsize", reusize);
+            resources_set_int("REU", 1);
+         }
+         request_restart = true;
+      }
+      core_opt.REUsize = reusize;
+   }
+#endif
 #endif
 
 #if !defined(__XPET__) && !defined(__XPLUS4__) && !defined(__XVIC__)
@@ -3690,9 +3803,9 @@ static void update_variables(void)
             log_resources_set_int("SidStereo", 0);
          else
          {
+            log_resources_set_int("SidStereoAddressStart", sid_extra);
             if (!core_opt.SidExtra)
                log_resources_set_int("SidStereo", 1);
-            log_resources_set_int("SidStereoAddressStart", sid_extra);
          }
       }
 
@@ -3769,6 +3882,29 @@ static void update_variables(void)
          log_resources_set_int("SidResid8580FilterBias", val);
 
       core_opt.SidResid8580FilterBias = val;
+   }
+#endif
+
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+   var.key = "vice_sfx_sound_expander";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int sfx_chip = atoi(var.value);
+
+      if (retro_ui_finalized && core_opt.SFXSoundExpanderChip != sfx_chip)
+      {
+         if (!sfx_chip)
+            log_resources_set_int("SFXSoundExpander", 0);
+         else
+         {
+            log_resources_set_int("SFXSoundExpanderChip", sfx_chip);
+            if (!core_opt.SFXSoundExpanderChip)
+               log_resources_set_int("SFXSoundExpander", 1);
+         }
+      }
+
+      core_opt.SFXSoundExpanderChip = sfx_chip;
    }
 #endif
 
@@ -4659,14 +4795,14 @@ static void update_variables(void)
    /* Audio options */
    option_display.visible = opt_audio_options_display;
 
+   option_display.key = "vice_sound_sample_rate";
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
    option_display.key = "vice_drive_sound_emulation";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__) || defined(__XVIC__) || defined(__XPLUS4__)
    option_display.key = "vice_audio_leak_emulation";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 #endif
-   option_display.key = "vice_sound_sample_rate";
-   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 #if !defined(__XPET__) && !defined(__XPLUS4__) && !defined(__XVIC__)
    option_display.key = "vice_sid_engine";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
@@ -4683,6 +4819,10 @@ static void update_variables(void)
    option_display.key = "vice_resid_filterbias";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
    option_display.key = "vice_resid_8580filterbias";
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+#endif
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+   option_display.key = "vice_sfx_sound_expander";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 #endif
 
@@ -4789,6 +4929,10 @@ void emu_reset(int type)
          break;
       case 1:
          machine_trigger_reset(MACHINE_RESET_MODE_SOFT);
+
+         /* Allow restarting PRGs with RUN */
+         if (strendswith(autostartString, "prg"))
+            autostart_autodetect(autostartString, NULL, 0, AUTOSTART_MODE_NONE);
          break;
       case 2:
          machine_trigger_reset(MACHINE_RESET_MODE_HARD);

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -49,7 +49,7 @@ char retro_key_state[RETROK_LAST] = {0};
 char retro_key_state_old[RETROK_LAST] = {0};
 static bool noautostart = false;
 static char* autostartString = NULL;
-static char full_path[RETRO_PATH_MAX] = {0};
+char full_path[RETRO_PATH_MAX] = {0};
 static char* core_options_legacy_strings = NULL;
 
 static snapshot_stream_t* snapshot_stream = NULL;
@@ -1671,9 +1671,9 @@ void retro_set_environment(retro_environment_t cb)
          "vice_jiffydos",
          "System > JiffyDOS",
 #if defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__)
-         "For D64/D71/D81 disk images only!\n'True Drive Emulation' required!\nROMs required in 'system/vice':\n- 'JiffyDOS_C64.bin'\n- 'JiffyDOS_1541-II.bin'\n- 'JiffyDOS_1571_repl310654.bin'\n- 'JiffyDOS_1581.bin'",
+         "'True Drive Emulation' & 1541/1571/1581 drive & ROMs required in 'system/vice':\n- 'JiffyDOS_C64.bin'\n- 'JiffyDOS_1541-II.bin'\n- 'JiffyDOS_1571_repl310654.bin'\n- 'JiffyDOS_1581.bin'",
 #elif defined(__X128__)
-         "For D64/D71/D81 disk images only!\n'True Drive Emulation' required!\nROMs required in 'system/vice':\n- 'JiffyDOS_C128.bin'\n- 'JiffyDOS_C64.bin' (GO64)\n- 'JiffyDOS_1541-II.bin'\n- 'JiffyDOS_1571_repl310654.bin'\n- 'JiffyDOS_1581.bin'",
+         "'True Drive Emulation' & 1541/1571/1581 drive & ROMs required in 'system/vice':\n- 'JiffyDOS_C128.bin'\n- 'JiffyDOS_C64.bin' (GO64)\n- 'JiffyDOS_1541-II.bin'\n- 'JiffyDOS_1571_repl310654.bin'\n- 'JiffyDOS_1581.bin'",
 #endif
          {
             { "disabled", NULL },
@@ -1686,7 +1686,7 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_read_vicerc",
          "System > Read 'vicerc'",
-         "Process 'system/vice/vicerc'. The config file can be used to set other options, such as cartridges.",
+         "Process first found 'vicerc' in this order:\n1. 'saves/[content].vicerc'\n2. 'saves/vicerc'\n3. 'system/vice/vicerc'",
          {
             { "disabled", NULL },
             { "enabled", NULL },

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -4931,7 +4931,7 @@ void emu_reset(int type)
          machine_trigger_reset(MACHINE_RESET_MODE_SOFT);
 
          /* Allow restarting PRGs with RUN */
-         if (strendswith(autostartString, "prg"))
+         if (autostartString != NULL && autostartString[0] != '\0' && strendswith(autostartString, "prg"))
             autostart_autodetect(autostartString, NULL, 0, AUTOSTART_MODE_NONE);
          break;
       case 2:

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -131,6 +131,8 @@ struct libretro_core_options {
    int UserportJoyType;
    int AutostartWarp;
    int AttachDevice8Readonly;
+   int EasyFlashWriteCRT;
+   int VirtualDevices;
    int DriveTrueEmulation;
    int DriveSoundEmulation;
    int AudioLeak;
@@ -143,6 +145,7 @@ struct libretro_core_options {
    int SidResidGain;
    int SidResidFilterBias;
    int SidResid8580FilterBias;
+   int SFXSoundExpanderChip;
    char ExternalPalette[RETRO_PATH_MAX];
    int ColorGamma;
    int ColorTint;
@@ -152,6 +155,8 @@ struct libretro_core_options {
 #if defined(__X128__)
    int C128ColumnKey;
    int Go64Mode;
+#elif defined(__X64__) || defined(__X64SC__)
+   int REUsize;
 #elif defined(__XVIC__)
    int VIC20Memory;
 #endif

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -800,55 +800,167 @@ void update_input(int disable_physical_cursor_keys)
 #endif
 }
 
+int process_keyboard_pass_through()
+{
+   unsigned process_key = 0;
+
+   /* Defaults */
+   int fire_button = RETRO_DEVICE_ID_JOYPAD_B;
+   int jump_button = -1;
+
+   /* Fire button */
+   switch (opt_retropad_options)
+   {
+      case 1:
+      case 3:
+         fire_button = RETRO_DEVICE_ID_JOYPAD_Y;
+         break;
+   }
+
+   /* Jump button */
+   switch (opt_retropad_options)
+   {
+      case 2:
+         jump_button = RETRO_DEVICE_ID_JOYPAD_A;
+         break;
+      case 3:
+         jump_button = RETRO_DEVICE_ID_JOYPAD_B;
+         break;
+   }
+   /* Null only with RetroPad */
+   if (vice_devices[0] == RETRO_DEVICE_JOYPAD)
+   {
+      if (mapper_keys[fire_button] || fire_button == turbo_fire_button)
+         fire_button = -1;
+
+      if (mapper_keys[jump_button] || jump_button == turbo_fire_button)
+         jump_button = -1;
+   }
+
+   /* Prevent RetroPad from generating keyboard key presses when RetroPad is controlled with keyboard */
+   switch (vice_devices[0])
+   {
+      case RETRO_DEVICE_JOYPAD:
+         if ((fire_button > -1       && input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, fire_button)) ||
+             (jump_button > -1       && input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, jump_button)) ||
+             (turbo_fire_button > -1 && input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, turbo_fire_button)) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_B]) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_Y]) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_A]) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_X]) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_L]) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_R]) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_L2]) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_R2]) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_L3]) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_R3]) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_SELECT]) ||
+             (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_START])
+            )
+            process_key = 2; /* Skip all keyboard input when RetroPad buttons are pressed */
+         else
+         if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) ||
+             input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) ||
+             input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) ||
+             input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)
+            )
+            process_key = 1; /* Skip cursor keys */
+         break;
+
+      case RETRO_DEVICE_VICE_JOYSTICK:
+         if ((fire_button > -1       && input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, fire_button)) ||
+             (jump_button > -1       && input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, jump_button))
+            )
+            process_key = 2; /* Skip all keyboard input when RetroPad buttons are pressed */
+         else
+         if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) ||
+             input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) ||
+             input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) ||
+             input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)
+            )
+            process_key = 1; /* Skip cursor keys */
+         break;
+   }
+
+   /* Fire button */
+   fire_button = RETRO_DEVICE_ID_JOYPAD_B;
+   switch (opt_retropad_options)
+   {
+      case 1:
+      case 3:
+         fire_button = RETRO_DEVICE_ID_JOYPAD_Y;
+         break;
+   }
+
+   /* Jump button */
+   jump_button = -1;
+   switch (opt_retropad_options)
+   {
+      case 2:
+         jump_button = RETRO_DEVICE_ID_JOYPAD_A;
+         break;
+      case 3:
+         jump_button = RETRO_DEVICE_ID_JOYPAD_B;
+         break;
+   }
+   /* Null only with RetroPad */
+   if (vice_devices[1] == RETRO_DEVICE_JOYPAD)
+   {
+      if (mapper_keys[fire_button] || fire_button == turbo_fire_button)
+         fire_button = -1;
+
+      if (mapper_keys[jump_button] || jump_button == turbo_fire_button)
+         jump_button = -1;
+   }
+
+   switch (vice_devices[1])
+   {
+      case RETRO_DEVICE_JOYPAD:
+         if ((fire_button > -1       && input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, fire_button)) ||
+             (jump_button > -1       && input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, jump_button)) ||
+             (turbo_fire_button > -1 && input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, turbo_fire_button)) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_B]) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_Y]) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_A]) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_X]) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_L]) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_R]) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_L2]) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_R2]) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_L3]) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_R3]) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_SELECT]) ||
+             (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) && mapper_keys[RETRO_DEVICE_ID_JOYPAD_START]) ||
+              input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) ||
+              input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) ||
+              input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) ||
+              input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)
+            )
+            process_key = 2; /* Skip all keyboard input from RetroPad 2 */
+         break;
+
+      case RETRO_DEVICE_VICE_JOYSTICK:
+         if ((fire_button > -1       && input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, fire_button)) ||
+             (jump_button > -1       && input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, jump_button)) ||
+              input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) ||
+              input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) ||
+              input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) ||
+              input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)
+            )
+            process_key = 2; /* Skip all keyboard input from RetroPad 2 */
+         break;
+   }
+
+   return process_key;
+}
+
 void retro_poll_event()
 {
-   /* If RetroPad is controlled with keyboard keys, then prevent RetroPad from generating keyboard key presses */
-   if (!opt_keyboard_pass_through && vice_devices[0] != RETRO_DEVICE_VICE_KEYBOARD &&
-      (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START)
-      ))
-      update_input(2); /* Skip all keyboard input when RetroPad buttons are pressed */
-
-   else if (!opt_keyboard_pass_through && vice_devices[0] != RETRO_DEVICE_VICE_KEYBOARD &&
-      (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) ||
-       input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)
-      ))
-      update_input(1); /* Process all inputs but disable cursor keys */
-
-   else if (!opt_keyboard_pass_through && vice_devices[1] != RETRO_DEVICE_VICE_KEYBOARD &&
-      (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L3) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R3) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT) ||
-       input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT)
-      ))
-      update_input(2); /* Skip all keyboard input from RetroPad 2 */
-
-   else
-      update_input(0); /* Process all inputs */
+   /* Keyboard pass-through */
+   unsigned process_key = 0;
+   if (!opt_keyboard_pass_through)
+      process_key = process_keyboard_pass_through();
+   update_input(process_key);
 
    /* retro joypad take control over keyboard joy */
    /* override keydown, but allow keyup, to prevent key sticking during keyboard use, if held down on opening keyboard */
@@ -972,8 +1084,12 @@ void retro_poll_event()
                fire_button = RETRO_DEVICE_ID_JOYPAD_Y;
                break;
          }
-         if (mapper_keys[fire_button] || fire_button == turbo_fire_button)
-            fire_button = -1;
+         /* Null only with RetroPad */
+         if (vice_devices[retro_port] == RETRO_DEVICE_JOYPAD)
+         {
+            if (mapper_keys[fire_button] || fire_button == turbo_fire_button)
+               fire_button = -1;
+         }
 
          if ((fire_button > -1 && input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, fire_button))
          || (opt_keyrah_keypad && vice_port < 3
@@ -1003,8 +1119,12 @@ void retro_poll_event()
                jump_button = RETRO_DEVICE_ID_JOYPAD_B;
                break;
          }
-         if (mapper_keys[jump_button] || jump_button == turbo_fire_button)
-            jump_button = -1;
+         /* Null only with RetroPad */
+         if (vice_devices[retro_port] == RETRO_DEVICE_JOYPAD)
+         {
+            if (mapper_keys[jump_button] || jump_button == turbo_fire_button)
+               jump_button = -1;
+         }
 
          if (jump_button > -1 && input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, jump_button))
          {
@@ -1027,7 +1147,7 @@ void retro_poll_event()
             j &= ~0x01;
 
          /* Turbo fire */
-         if (turbo_fire_button != -1)
+         if (vice_devices[retro_port] == RETRO_DEVICE_JOYPAD && turbo_fire_button != -1)
          {
             if (input_state_cb(retro_port, RETRO_DEVICE_JOYPAD, 0, turbo_fire_button))
             {

--- a/vice/src/arch/libretro/archdep.c
+++ b/vice/src/arch/libretro/archdep.c
@@ -67,7 +67,9 @@
 #include "../shared/archdep_atexit.c"
 #include "../shared/archdep_extra_title_text.c"
 
+#include "libretro-core.h"
 extern unsigned int opt_read_vicerc;
+extern char full_path[RETRO_PATH_MAX];
 
 static char *argv0 = NULL;
 static char *boot_path = NULL;
@@ -298,7 +300,22 @@ char *archdep_default_resource_file_name(void)
         return util_concat(home, "/.vice/vicerc", NULL);
     } else {
         if (opt_read_vicerc)
+        {
+            char content_vicerc[RETRO_PATH_MAX] = {0};
+            char content_basename[RETRO_PATH_MAX] = {0};
+            snprintf(content_basename, sizeof(content_basename), "%s", path_basename(full_path));
+            snprintf(content_basename, sizeof(content_basename), "%s", path_remove_extension(content_basename));
+            snprintf(content_vicerc, sizeof(content_vicerc), "%s%s%s.vicerc", SAVEDIR, FSDEV_DIR_SEP_STR, content_basename);
+            /* Process "saves/[content].vicerc" */
+            if (!ioutil_access(content_vicerc, IOUTIL_ACCESS_R_OK))
+               return util_concat(content_vicerc, NULL);
+            /* Process "saves/vicerc" */
+            snprintf(content_vicerc, sizeof(content_vicerc), "%s%svicerc", SAVEDIR, FSDEV_DIR_SEP_STR);
+            if (!ioutil_access(content_vicerc, IOUTIL_ACCESS_R_OK))
+               return util_concat(content_vicerc, NULL);
+            /* Process "system/vice/vicerc" */
             return util_concat(archdep_pref_path, FSDEV_DIR_SEP_STR, "vicerc", NULL);
+        }
         else
             return NULL;
     }

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -177,9 +177,9 @@ int ui_init_finalize(void)
 
    /* Sensible defaults */
    log_resources_set_int("Mouse", 1);
-   log_resources_set_int("AutostartPrgMode", 1);
-   log_resources_set_int("VirtualDevices", 1);
    log_resources_set_int("Printer4", 1);
+   log_resources_set_int("AutostartPrgMode", 1);
+   log_resources_set_int("AutostartDelayRandom", 0);
 
    /* Mute sound at startup to hide 6581 ReSID init pop, and set back to 100 in retro_run() after 3 frames */
    log_resources_set_int("SoundVolume", 0);
@@ -189,46 +189,48 @@ int ui_init_finalize(void)
    log_resources_set_int("CrtcStretchVertical", 0);
 #endif
 
-   /* Core options */
+   /*** Core options ***/
+
+   /* Video */
 #if defined(__XVIC__)
    if (!strcmp(core_opt.ExternalPalette, "default"))
       log_resources_set_int("VICExternalPalette", 0);
    else
    {
-      log_resources_set_int("VICExternalPalette", 1);
       log_resources_set_string("VICPaletteFile", core_opt.ExternalPalette);
+      log_resources_set_int("VICExternalPalette", 1);
    }
 #elif defined(__XPLUS4__)
    if (!strcmp(core_opt.ExternalPalette, "default"))
       log_resources_set_int("TEDExternalPalette", 0);
    else
    {
-      log_resources_set_int("TEDExternalPalette", 1);
       log_resources_set_string("TEDPaletteFile", core_opt.ExternalPalette);
+      log_resources_set_int("TEDExternalPalette", 1);
    }
 #elif defined(__XPET__)
    if (!strcmp(core_opt.ExternalPalette, "default"))
       log_resources_set_int("CrtcExternalPalette", 0);
    else
    {
-      log_resources_set_int("CrtcExternalPalette", 1);
       log_resources_set_string("CrtcPaletteFile", core_opt.ExternalPalette);
+      log_resources_set_int("CrtcExternalPalette", 1);
    }
 #elif defined(__XCBM2__)
    if (!strcmp(core_opt.ExternalPalette, "default"))
       log_resources_set_int("CrtcExternalPalette", 0);
    else
    {
-      log_resources_set_int("CrtcExternalPalette", 1);
       log_resources_set_string("CrtcPaletteFile", core_opt.ExternalPalette);
+      log_resources_set_int("CrtcExternalPalette", 1);
    }
 #else
    if (!strcmp(core_opt.ExternalPalette, "default"))
       log_resources_set_int("VICIIExternalPalette", 0);
    else
    {
-      log_resources_set_int("VICIIExternalPalette", 1);
       log_resources_set_string("VICIIPaletteFile", core_opt.ExternalPalette);
+      log_resources_set_int("VICIIExternalPalette", 1);
    }
 #endif
 
@@ -252,39 +254,27 @@ int ui_init_finalize(void)
    log_resources_set_int("TEDColorBrightness", core_opt.ColorBrightness);
 #endif
 
+   /* Input */
 #if !defined(__XCBM5x0__)
    if (core_opt.UserportJoyType == -1)
       log_resources_set_int("UserportJoy", 0);
    else
    {
-      log_resources_set_int("UserportJoy", 1);
       log_resources_set_int("UserportJoyType", core_opt.UserportJoyType);
+      log_resources_set_int("UserportJoy", 1);
    }
 #endif
 
-   log_resources_set_int("DriveTrueEmulation", core_opt.DriveTrueEmulation);
-   log_resources_set_int("AttachDevice8Readonly", core_opt.AttachDevice8Readonly);
+   /* Media */
    log_resources_set_int("AutostartWarp", core_opt.AutostartWarp);
-
-   if (core_opt.DriveSoundEmulation)
-   {
-      log_resources_set_int("DriveSoundEmulation", 1);
-      log_resources_set_int("DriveSoundEmulationVolume", core_opt.DriveSoundEmulation);
-   }
-   else
-      log_resources_set_int("DriveSoundEmulation", 0);
-
-   if (opt_autoloadwarp)
-      log_resources_set_int("DriveSoundEmulationVolume", 0);
-
-#if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__)
-   log_resources_set_int("VICIIAudioLeak", core_opt.AudioLeak);
-#elif defined(__XVIC__)
-   log_resources_set_int("VICAudioLeak", core_opt.AudioLeak);
-#elif defined(__XPLUS4__)
-   log_resources_set_int("TEDAudioLeak", core_opt.AudioLeak);
+   log_resources_set_int("DriveTrueEmulation", core_opt.DriveTrueEmulation);
+   log_resources_set_int("VirtualDevices", core_opt.VirtualDevices);
+   log_resources_set_int("AttachDevice8Readonly", core_opt.AttachDevice8Readonly);
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+   log_resources_set_int("EasyFlashWriteCRT", core_opt.EasyFlashWriteCRT);
 #endif
 
+   /* ROM */
 #if defined(__XSCPU64__)
    /* Replace kernal always from backup, because kernal loading replaces the embedded variable */
    memcpy(scpu64rom_scpu64_rom, scpu64rom_scpu64_rom_original, SCPU64_SCPU64_ROM_MAXSIZE);
@@ -343,6 +333,7 @@ int ui_init_finalize(void)
    }
 #endif
 
+   /* Model */
 #if defined(__XPET__)
    petmodel_set(core_opt.Model);
    keyboard_init();
@@ -360,6 +351,37 @@ int ui_init_finalize(void)
    c64model_set(core_opt.Model);
 #endif
 
+   /* Audio */
+   if (core_opt.DriveSoundEmulation)
+   {
+      log_resources_set_int("DriveSoundEmulationVolume", core_opt.DriveSoundEmulation);
+      log_resources_set_int("DriveSoundEmulation", 1);
+   }
+   else
+      log_resources_set_int("DriveSoundEmulation", 0);
+
+   if (opt_autoloadwarp)
+      log_resources_set_int("DriveSoundEmulationVolume", 0);
+
+#if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__)
+   log_resources_set_int("VICIIAudioLeak", core_opt.AudioLeak);
+#elif defined(__XVIC__)
+   log_resources_set_int("VICAudioLeak", core_opt.AudioLeak);
+#elif defined(__XPLUS4__)
+   log_resources_set_int("TEDAudioLeak", core_opt.AudioLeak);
+#endif
+
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+   if (core_opt.SFXSoundExpanderChip)
+   {
+      log_resources_set_int("SFXSoundExpanderChip", core_opt.SFXSoundExpanderChip);
+      log_resources_set_int("SFXSoundExpander", 1);
+   }
+   else
+      log_resources_set_int("SFXSoundExpander", 0);
+#endif
+
+   /* SID */
 #if !defined(__XPET__) && !defined(__XPLUS4__) && !defined(__XVIC__)
    if (core_opt.SidModel == 0xff)
       resources_set_int("SidEngine", core_opt.SidEngine);
@@ -375,19 +397,18 @@ int ui_init_finalize(void)
 
    if (core_opt.SidExtra)
    {
-      log_resources_set_int("SidStereo", 1);
       log_resources_set_int("SidStereoAddressStart", core_opt.SidExtra);
+      log_resources_set_int("SidStereo", 1);
    }
    else
       log_resources_set_int("SidStereo", 0);
 #endif
 
+   /* Misc model specific */
 #if defined(__X128__)
    log_resources_set_int("Go64Mode", core_opt.Go64Mode);
    log_resources_set_int("C128ColumnKey", core_opt.C128ColumnKey);
-#endif
-
-#if defined(__XVIC__)
+#elif defined(__XVIC__)
    log_resources_set_int("MegaCartNvRAMWriteBack", 1);
 
    unsigned int vic20mem = 0;
@@ -429,7 +450,16 @@ int ui_init_finalize(void)
    log_resources_set_int("RAMBlock2", (vic_blocks & VIC_BLK2) ? 1 : 0);
    log_resources_set_int("RAMBlock3", (vic_blocks & VIC_BLK3) ? 1 : 0);
    log_resources_set_int("RAMBlock5", (vic_blocks & VIC_BLK5) ? 1 : 0);
+#elif defined(__X64__) || defined(__X64SC__)
+   if (core_opt.REUsize)
+   {
+      log_resources_set_int("REUsize", core_opt.REUsize);
+      log_resources_set_int("REU", 1);
+   }
+   else
+      log_resources_set_int("REU", 0);
 #endif
+
    retro_ui_finalized = true;
    return 0;
 }

--- a/vice/src/c64/cart/reu.c
+++ b/vice/src/c64/cart/reu.c
@@ -650,6 +650,10 @@ static int reu_deactivate(void)
         return 0;
     }
 
+#ifdef __LIBRETRO__
+    log_message(reu_log, "REU unit uninstalled.");
+#endif
+
     if (!util_check_null_string(reu_filename)) {
         if (reu_write_image) {
             log_message(reu_log, "Writing REU image %s.", reu_filename);

--- a/vice/src/resources.c
+++ b/vice/src/resources.c
@@ -1168,25 +1168,31 @@ int resources_load(const char *fname)
 extern cmdline_option_ram_t *options;
 static char* disabled_resources[] =
 {
-    // Core options
-    "Mouse", "AutostartPrgMode", "VirtualDevices", "CrtcFilter", "CrtcStretchVertical",
+    /* Core options */
+    "Mouse", "AutostartPrgMode", "AutostartDelayRandom", "VirtualDevices", "CrtcFilter", "CrtcStretchVertical",
     "VICExternalPalette", "VICPaletteFile", "TEDExternalPalette", "TEDPaletteFile",
     "CrtcExternalPalette", "CrtcPaletteFile", "VICIIExternalPalette", "VICIIPaletteFile",
+    "VICColorGamma", "VICColorSaturation", "VICColorContrast", "VICColorBrightness", "VICColorTint",
+    "TEDColorGamma", "TEDColorSaturation", "TEDColorContrast", "TEDColorBrightness", "TEDColorTint",
     "VICIIColorGamma", "VICIIColorSaturation", "VICIIColorContrast", "VICIIColorBrightness", "VICIIColorTint",
-    "UserportJoy", "UserportJoyType", "DriveTrueEmulation", "DriveSoundEmulation", "DriveSoundEmulationVolume",
-    "AutostartWarp", "VICIIAudioLeak", "VICAudioLeak", "SidStereo", "SidStereoAddressStart",
+    "AutostartWarp", "AttachDevice8Readonly", "EasyFlashWriteCRT", "UserportJoy", "UserportJoyType",
+    "DriveTrueEmulation", "DriveSoundEmulation", "DriveSoundEmulationVolume",
+    "VICIIAudioLeak", "VICAudioLeak", "TEDAudioLeak", "SidStereo", "SidStereoAddressStart",
     "SidEngine", "SidModel", "SidResidSampling", "SidResidPassband", "SidResidGain", "SidResidFilterBias",
-    "SidResid8580Passband", "SidResid8580Gain", "SidResid8580FilterBias",
-    "Go64Mode", "C128ColumnKey", "RAMBlock0", "RAMBlock1", "RAMBlock2", "RAMBlock3", "RAMBlock5",
+    "SidResid8580Passband", "SidResid8580Gain", "SidResid8580FilterBias", "SFXSoundExpander", "SFXSoundExpanderChip",
+    "Go64Mode", "C128ColumnKey", "RAMBlock0", "RAMBlock1", "RAMBlock2", "RAMBlock3", "RAMBlock5", "REU", "REUsize",
     "Drive8Type", "WarpMode", "KeymapSymFile", "KeymapPosFile", "KeymapIndex",
 
-    // Frontend resources
+    /* Frontend resources */
     "SDLStatusbar", "ExitScreenshotName", "ExitScreenshotName1", "RefreshRate", "SoundRecordDeviceName", "SoundRecordDeviceArg",
     "SoundDeviceName", "Sound", "SoundSampleRate", "SoundBufferSize", "SoundFragmentSize", "SoundDeviceArg",
     "SoundSuspendTime", "SoundSpeedAdjustment", "SoundVolume", "SoundOutput", "MachineVideoStandard",
     "VICIIVideoCache", "VICIIDoubleScan", "VICIIHwScale", "VICIIDoubleSize", "VICIIBorderMode",
     "VICIIPALScanLineShade", "VICIIPALBlur", "VICIIPALOddLinePhase", "VICIIPALOddLineOffset", "VICIIFilter",
-    "EventSnapshotDir", "EventStartSnapshot", "EventEndSnapshot", "EventStartMode", "EventImageInclude"
+    "EventSnapshotDir", "EventStartSnapshot", "EventEndSnapshot", "EventStartMode", "EventImageInclude",
+
+    /* Stubbed resources */
+    "DebugCartEnable", "CPMCart", "MonitorServerAddress", "MonitorServer"
 };
 static int disabled_resources_num;
 static char *resources_get_description(const char *name)


### PR DESCRIPTION
New core options:
- Virtual Device Traps
  Closes #297 
- RAM Expansion Unit (C64)
- SFX Sound Expander (C64 & C128)
- EasyFlash Write Protection (C64 & C128)

--- 

Other:
- Per-content vicerc
  Closes #296 
   - Search `vicerc` first come first serve:
      1. `saves/[content].vicerc`
      2. `saves/vicerc`
      3. `system/vice/vicerc`
- Keyboard pass-through improvements:
  - Joystick device type no longer reserves all unused RetroPad button keys for blocking
  - RetroPad device type blocks fire/jump/turbofire buttons always and other buttons only when mapped
- Fixed crash when soft resetting without content
- Core option label tweaks