### PR TITLE
VKBD Optimisations

### DIFF
--- a/libretro/libretro-graph.c
+++ b/libretro/libretro-graph.c
@@ -8,79 +8,163 @@
 
 #include "font.i"
 
-unsigned short blend(unsigned short fg, unsigned short bg, unsigned int alpha)
-{
-   /* Split foreground into components */
-   unsigned fg_r = fg >> 11;
-   unsigned fg_g = (fg >> 5) & ((1u << 6) - 1);
-   unsigned fg_b = fg & ((1u << 5) - 1);
+static unsigned char *linesurf = NULL;
+static int linesurf_w          = 0;
+static int linesurf_h          = 0;
 
-   /* Split background into components */
-   unsigned bg_r = bg >> 11;
-   unsigned bg_g = (bg >> 5) & ((1u << 6) - 1);
-   unsigned bg_b = bg & ((1u << 5) - 1);
+static uint32_t *linesurf32    = NULL;
+static int linesurf32_w        = 0;
+static int linesurf32_h        = 0;
 
-   /* Alpha blend components */
-   unsigned out_r = (fg_r * alpha + bg_r * (255 - alpha)) / 255;
-   unsigned out_g = (fg_g * alpha + bg_g * (255 - alpha)) / 255;
-   unsigned out_b = (fg_b * alpha + bg_b * (255 - alpha)) / 255;
-
-   /* Pack result */
-   return (unsigned short) ((out_r << 11) | (out_g << 5) | out_b);
+#define BLEND_ALPHA25(fg, bg, out)                                   \
+{                                                                    \
+   unsigned short color_50 = ((fg + bg + ((fg ^ bg) & 0x821)) >> 1); \
+   (*(out)) = ((color_50 + bg + ((color_50 ^ bg) & 0x821)) >> 1);    \
 }
 
-uint32_t blend32(uint32_t fg, uint32_t bg, unsigned int alpha)
-{
-   /* Split foreground into components */
-   unsigned fg_r = (fg >> 16) & 0xFF;
-   unsigned fg_g = (fg >> 8) & 0xFF;
-   unsigned fg_b = (fg >> 0) & 0xFF;
-
-   /* Split background into components */
-   unsigned bg_r = (bg >> 16) & 0xFF;
-   unsigned bg_g = (bg >> 8) & 0xFF;
-   unsigned bg_b = (bg >> 0) & 0xFF;
-
-   /* Alpha blend components */
-   unsigned out_r = (fg_r * alpha + bg_r * (255 - alpha)) / 255;
-   unsigned out_g = (fg_g * alpha + bg_g * (255 - alpha)) / 255;
-   unsigned out_b = (fg_b * alpha + bg_b * (255 - alpha)) / 255;
-
-   /* Pack result */
-   return (uint32_t) ((out_r << 16) | (out_g << 8) | out_b);
+#define BLEND_ALPHA50(fg, bg, out)                    \
+{                                                     \
+   (*(out)) = ((fg + bg + ((fg ^ bg) & 0x821)) >> 1); \
 }
 
-void DrawFBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color, unsigned int alpha)
-{
-   int i, j, idx;
+#define BLEND_ALPHA75(fg, bg, out)                                   \
+{                                                                    \
+   unsigned short color_50 = ((fg + bg + ((fg ^ bg) & 0x821)) >> 1); \
+   (*(out)) = ((fg + color_50 + ((fg ^ color_50) & 0x821)) >> 1);    \
+}
 
-   for (i=x; i<x+dx; i++)
+#define BLEND32_ALPHA25(fg, bg, out)                                \
+{                                                                   \
+   uint32_t color_50 = ((fg + bg + ((fg ^ bg) & 0x10101)) >> 1);    \
+   (*(out)) = ((color_50 + bg + ((color_50 ^ bg) & 0x10101)) >> 1); \
+}
+
+#define BLEND32_ALPHA50(fg, bg, out)                    \
+{                                                       \
+   (*(out)) = ((fg + bg + ((fg ^ bg) & 0x10101)) >> 1); \
+}
+
+#define BLEND32_ALPHA75(fg, bg, out)                                \
+{                                                                   \
+   uint32_t color_50 = ((fg + bg + ((fg ^ bg) & 0x10101)) >> 1);    \
+   (*(out)) = ((fg + color_50 + ((fg ^ color_50) & 0x10101)) >> 1); \
+}
+
+void DrawFBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color, libretro_graph_alpha_t alpha)
+{
+   int i, j;
+
+   switch (alpha)
    {
-      for (j=y; j<y+dy; j++)
-      {
-         idx = i+j*retrow;
-         if (alpha < 255)
-            buffer[idx] = blend(color, buffer[idx], alpha);
-         else
-            buffer[idx] = color;
-      }
+      case GRAPH_ALPHA_0:
+         /* Do nothing - buffer is already the
+          * correct colour */
+         break;
+      case GRAPH_ALPHA_25:
+         for (j=y; j<y+dy; j++)
+         {
+            unsigned short *buf_ptr = buffer + (j * retrow) + x;
+            for (i=x; i<x+dx; i++)
+            {
+               BLEND_ALPHA25(color, *buf_ptr, buf_ptr);
+               buf_ptr++;
+            }
+         }
+         break;
+      case GRAPH_ALPHA_50:
+         for (j=y; j<y+dy; j++)
+         {
+            unsigned short *buf_ptr = buffer + (j * retrow) + x;
+            for (i=x; i<x+dx; i++)
+            {
+               BLEND_ALPHA50(color, *buf_ptr, buf_ptr);
+               buf_ptr++;
+            }
+         }
+         break;
+      case GRAPH_ALPHA_75:
+         for (j=y; j<y+dy; j++)
+         {
+            unsigned short *buf_ptr = buffer + (j * retrow) + x;
+            for (i=x; i<x+dx; i++)
+            {
+               BLEND_ALPHA75(color, *buf_ptr, buf_ptr);
+               buf_ptr++;
+            }
+         }
+         break;
+      case GRAPH_ALPHA_100:
+      default:
+         for (j=y; j<y+dy; j++)
+         {
+            unsigned short *buf_ptr = buffer + (j * retrow) + x;
+            for (i=x; i<x+dx; i++)
+            {
+               *buf_ptr = color;
+               buf_ptr++;
+            }
+         }
+         break;
    }
 }
 
-void DrawFBoxBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color, unsigned int alpha)
+void DrawFBoxBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color, libretro_graph_alpha_t alpha)
 {
-   int i, j, idx;
+   int i, j;
 
-   for (i=x; i<x+dx; i++)
+   color = color & 0xFFFFFF;
+
+   switch (alpha)
    {
-      for (j=y; j<y+dy; j++)
-      {
-         idx = i+j*retrow;
-         if (alpha < 255)
-            buffer[idx] = blend32(color, buffer[idx], alpha);
-         else
-            buffer[idx] = color;
-      }
+      case GRAPH_ALPHA_0:
+         /* Do nothing - buffer is already the
+          * correct colour */
+         break;
+      case GRAPH_ALPHA_25:
+         for (j=y; j<y+dy; j++)
+         {
+            uint32_t *buf_ptr = buffer + (j * retrow) + x;
+            for (i=x; i<x+dx; i++)
+            {
+               BLEND32_ALPHA25(color, *buf_ptr, buf_ptr);
+               buf_ptr++;
+            }
+         }
+         break;
+      case GRAPH_ALPHA_50:
+         for (j=y; j<y+dy; j++)
+         {
+            uint32_t *buf_ptr = buffer + (j * retrow) + x;
+            for (i=x; i<x+dx; i++)
+            {
+               BLEND32_ALPHA50(color, *buf_ptr, buf_ptr);
+               buf_ptr++;
+            }
+         }
+         break;
+      case GRAPH_ALPHA_75:
+         for (j=y; j<y+dy; j++)
+         {
+            uint32_t *buf_ptr = buffer + (j * retrow) + x;
+            for (i=x; i<x+dx; i++)
+            {
+               BLEND32_ALPHA75(color, *buf_ptr, buf_ptr);
+               buf_ptr++;
+            }
+         }
+         break;
+      case GRAPH_ALPHA_100:
+      default:
+         for (j=y; j<y+dy; j++)
+         {
+            uint32_t *buf_ptr = buffer + (j * retrow) + x;
+            for (i=x; i<x+dx; i++)
+            {
+               *buf_ptr = color;
+               buf_ptr++;
+            }
+         }
+         break;
    }
 }
 
@@ -263,11 +347,10 @@ void DrawlineBmp(unsigned short *buffer, int x1, int y1, int x2, int y2, unsigne
 void Draw_string(unsigned short *surf, signed short int x, signed short int y,
       const char *string, unsigned short maxstrlen,
       unsigned short xscale, unsigned short yscale,
-      unsigned short fg, unsigned short bg, unsigned int alpha)
+      unsigned short fg, unsigned short bg, libretro_graph_alpha_t alpha, bool draw_bg)
 {
    int k, strlen;
    int xrepeat, yrepeat;
-   unsigned char *linesurf;
    signed short int ypixel;
    unsigned short *yptr; 
    int col, bit;
@@ -279,10 +362,28 @@ void Draw_string(unsigned short *surf, signed short int x, signed short int y,
       return;
 
    /* Pseudo transparency for now */
-   if (alpha < 255)
+   switch (alpha)
    {
-      fg = blend(fg, ((bg == 0) ? 0xFFFF : bg), alpha);
-      bg = 0;
+      case GRAPH_ALPHA_0:
+         fg = ((bg == 0) ? 0xFFFF : bg);
+         bg = 0;
+         break;
+      case GRAPH_ALPHA_25:
+         BLEND_ALPHA25(fg, ((bg == 0) ? 0xFFFF : bg), &fg);
+         bg = 0;
+         break;
+      case GRAPH_ALPHA_50:
+         BLEND_ALPHA50(fg, ((bg == 0) ? 0xFFFF : bg), &fg);
+         bg = 0;
+         break;
+      case GRAPH_ALPHA_75:
+         BLEND_ALPHA75(fg, ((bg == 0) ? 0xFFFF : bg), &fg);
+         bg = 0;
+         break;
+      case GRAPH_ALPHA_100:
+      default:
+         bg = draw_bg ? bg : 0;
+         break;
    }
 
    for (strlen = 0; strlen < maxstrlen && string[strlen]; strlen++) {}
@@ -294,7 +395,16 @@ void Draw_string(unsigned short *surf, signed short int x, signed short int y,
    if ((surfw + x) > retrow)
       return;
 
-   linesurf = (unsigned char*)malloc(sizeof(unsigned short)*surfw*surfh);
+   if ((linesurf_w < surfw) || (linesurf_h < surfh))
+   {
+      if (linesurf)
+         free(linesurf);
+
+      linesurf   = (unsigned char*)malloc(sizeof(unsigned short)*surfw*surfh);
+      linesurf_w = surfw;
+      linesurf_h = surfh;
+   }
+
    yptr = (unsigned short *)&linesurf[0];
 
    /* Skip the 8th row */
@@ -321,20 +431,23 @@ void Draw_string(unsigned short *surf, signed short int x, signed short int y,
    yptr = (unsigned short*)&linesurf[0];
 
    for (yrepeat = y; yrepeat < y+surfh; yrepeat++)
+   {
+      unsigned short *surf_ptr = surf + (yrepeat * retrow) + x;
       for (xrepeat = x; xrepeat < x+surfw; xrepeat++, yptr++)
-         if (*yptr != 0) surf[xrepeat+yrepeat*retrow] = *yptr;
-
-   free(linesurf);
+      {
+         if (*yptr != 0) *surf_ptr = *yptr;
+         surf_ptr++;
+      }
+   }
 }
 
 void Draw_string32(uint32_t *surf, signed short int x, signed short int y,
       const char *string, unsigned short maxstrlen,
       unsigned short xscale, unsigned short yscale,
-      uint32_t fg, uint32_t bg, unsigned int alpha)
+      uint32_t fg, uint32_t bg, libretro_graph_alpha_t alpha, bool draw_bg)
 {
    int k, strlen;
    int xrepeat, yrepeat;
-   uint32_t *linesurf;
    signed short int ypixel;
    uint32_t *yptr;
    int col, bit;
@@ -346,10 +459,31 @@ void Draw_string32(uint32_t *surf, signed short int x, signed short int y,
       return;
 
    /* Pseudo transparency for now */
-   if (alpha < 255)
+   switch (alpha)
    {
-      fg = blend32(fg, ((bg == 0) ? 0xFFFFFFFF : bg), alpha);
-      bg = 0;
+      case GRAPH_ALPHA_0:
+         fg = ((bg == 0) ? 0xFFFFFFFF : bg);
+         bg = 0;
+         break;
+      case GRAPH_ALPHA_25:
+         fg = fg & 0xFFFFFF;
+         BLEND32_ALPHA25(fg, ((bg == 0) ? 0xFFFFFF : bg & 0xFFFFFF), &fg);
+         bg = 0;
+         break;
+      case GRAPH_ALPHA_50:
+         fg = fg & 0xFFFFFF;
+         BLEND32_ALPHA50(fg, ((bg == 0) ? 0xFFFFFF : bg & 0xFFFFFF), &fg);
+         bg = 0;
+         break;
+      case GRAPH_ALPHA_75:
+         fg = fg & 0xFFFFFF;
+         BLEND32_ALPHA75(fg, ((bg == 0) ? 0xFFFFFF : bg & 0xFFFFFF), &fg);
+         bg = 0;
+         break;
+      case GRAPH_ALPHA_100:
+      default:
+         bg = draw_bg ? bg : 0;
+         break;
    }
 
    for (strlen = 0; strlen < maxstrlen && string[strlen]; strlen++) {}
@@ -361,8 +495,17 @@ void Draw_string32(uint32_t *surf, signed short int x, signed short int y,
    if ((surfw + x) > retrow)
       return;
 
-   linesurf = (uint32_t *)malloc(sizeof(uint32_t)*surfw*surfh);
-   yptr = (uint32_t *)&linesurf[0];
+   if ((linesurf32_w < surfw) || (linesurf32_h < surfh))
+   {
+      if (linesurf32)
+         free(linesurf32);
+
+      linesurf32   = (uint32_t *)malloc(sizeof(uint32_t)*surfw*surfh);
+      linesurf32_w = surfw;
+      linesurf32_h = surfh;
+   }
+
+   yptr = (uint32_t *)&linesurf32[0];
 
    /* Skip the 8th row */
    surfh -= 1;
@@ -385,17 +528,21 @@ void Draw_string32(uint32_t *surf, signed short int x, signed short int y,
             *yptr = yptr[-surfw];
    }
 
-   yptr = (uint32_t *)&linesurf[0];
+   yptr = (uint32_t *)&linesurf32[0];
 
    for (yrepeat = y; yrepeat < y+surfh; yrepeat++)
+   {
+      uint32_t *surf_ptr = surf + (yrepeat * retrow) + x;
       for (xrepeat = x; xrepeat < x+surfw; xrepeat++, yptr++)
-         if (*yptr != 0) surf[xrepeat+yrepeat*retrow] = *yptr;
-
-   free(linesurf);
+      {
+         if (*yptr != 0) *surf_ptr = *yptr;
+         surf_ptr++;
+      }
+   }
 }
 
 void Draw_text(unsigned short *buffer, int x, int y,
-      unsigned short fgcol, unsigned short bgcol, unsigned int alpha,
+      unsigned short fgcol, unsigned short bgcol, libretro_graph_alpha_t alpha, bool draw_bg,
       int scalex, int scaley, int max, char *string, ...)
 {
    char text[256];
@@ -409,7 +556,7 @@ void Draw_text(unsigned short *buffer, int x, int y,
    va_end(ap);
 
 #if 0
-   Draw_string(buffer, x, y, text, max, scalex, scaley, fgcol, bgcol, alpha);
+   Draw_string(buffer, x, y, text, max, scalex, scaley, fgcol, bgcol, alpha, draw_bg);
 #else
    char c;
    char s[2] = {0};
@@ -425,19 +572,19 @@ void Draw_text(unsigned short *buffer, int x, int y,
       if (c & -0x80)
       {
          snprintf(s, sizeof(s), "%c", c & 0x7f);
-         Draw_string(buffer, x+(i*charwidth*scalex), y, s, 1, scalex, scaley, bgcol, fgcol, alpha);
+         Draw_string(buffer, x+(i*charwidth*scalex), y, s, 1, scalex, scaley, bgcol, fgcol, alpha, draw_bg);
       }
       else
       {
          snprintf(s, sizeof(s), "%c", c);
-         Draw_string(buffer, x+(i*charwidth*scalex), y, s, 1, scalex, scaley, fgcol, bgcol, alpha);
+         Draw_string(buffer, x+(i*charwidth*scalex), y, s, 1, scalex, scaley, fgcol, bgcol, alpha, draw_bg);
       }
    }
 #endif
 }
 
 void Draw_text32(uint32_t *buffer, int x, int y,
-      uint32_t fgcol, uint32_t bgcol, unsigned int alpha,
+      uint32_t fgcol, uint32_t bgcol, libretro_graph_alpha_t alpha, bool draw_bg,
       int scalex, int scaley, int max, char *string,...)
 {
    char text[256];
@@ -451,7 +598,7 @@ void Draw_text32(uint32_t *buffer, int x, int y,
    va_end(ap);
 
 #if 0
-   Draw_string32(buffer, x, y, text, max, scalex, scaley, fgcol, bgcol, alpha);
+   Draw_string32(buffer, x, y, text, max, scalex, scaley, fgcol, bgcol, alpha, draw_bg);
 #else
    char c;
    char s[2] = {0};
@@ -467,13 +614,29 @@ void Draw_text32(uint32_t *buffer, int x, int y,
       if (c & -0x80)
       {
          snprintf(s, sizeof(s), "%c", c & 0x7f);
-         Draw_string32(buffer, x+(i*charwidth*scalex), y, s, 1, scalex, scaley, bgcol, fgcol, alpha);
+         Draw_string32(buffer, x+(i*charwidth*scalex), y, s, 1, scalex, scaley, bgcol, fgcol, alpha, draw_bg);
       }
       else
       {
          snprintf(s, sizeof(s), "%c", c);
-         Draw_string32(buffer, x+(i*charwidth*scalex), y, s, 1, scalex, scaley, fgcol, bgcol, alpha);
+         Draw_string32(buffer, x+(i*charwidth*scalex), y, s, 1, scalex, scaley, fgcol, bgcol, alpha, draw_bg);
       }
    }
 #endif
+}
+
+void LibretroGraphFree(void)
+{
+   if (linesurf)
+      free(linesurf);
+   linesurf = NULL;
+
+   if (linesurf32)
+      free(linesurf32);
+   linesurf32 = NULL;
+
+   linesurf_w   = 0;
+   linesurf_h   = 0;
+   linesurf32_w = 0;
+   linesurf32_h = 0;
 }

--- a/libretro/libretro-graph.h
+++ b/libretro/libretro-graph.h
@@ -7,25 +7,35 @@ typedef struct
    int dx, dy;
 } box;
 
-extern void DrawFBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color, unsigned int alpha);
-extern void DrawFBoxBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color, unsigned int alpha);
+typedef enum {
+   GRAPH_ALPHA_0 = 0,
+   GRAPH_ALPHA_25,
+   GRAPH_ALPHA_50,
+   GRAPH_ALPHA_75,
+   GRAPH_ALPHA_100
+} libretro_graph_alpha_t;
 
-extern void DrawBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
-extern void DrawBoxBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
+void DrawFBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color, libretro_graph_alpha_t alpha);
+void DrawFBoxBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color, libretro_graph_alpha_t alpha);
 
-extern void DrawPointBmp(unsigned short *buffer, int x, int y, unsigned short color);
+void DrawBoxBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
+void DrawBoxBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
 
-extern void DrawHlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
-extern void DrawHlineBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
-extern void DrawHline(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
+void DrawPointBmp(unsigned short *buffer, int x, int y, unsigned short color);
 
-extern void DrawVlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
-extern void DrawlineBmp(unsigned short *buffer, int x1, int y1, int x2, int y2, unsigned short color);
+void DrawHlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
+void DrawHlineBmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
+void DrawHline(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
 
-extern void Draw_string(unsigned short *surf, signed short int x, signed short int y, const char *string, unsigned short int maxstrlen, unsigned short int xscale, unsigned short int yscale, unsigned short int fg, unsigned short int bg, unsigned int alpha);
-extern void Draw_string32(uint32_t *surf, signed short int x, signed short int y, const char *string, unsigned short int maxstrlen, unsigned short int xscale, unsigned short int yscale, uint32_t fg, uint32_t bg, unsigned int alpha);
+void DrawVlineBmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
+void DrawlineBmp(unsigned short *buffer, int x1, int y1, int x2, int y2, unsigned short color);
 
-extern void Draw_text(unsigned short *buffer, int x, int y, unsigned short fgcol, unsigned short int bgcol, unsigned int alpha, int scalex, int scaley, int max, char *string, ...);
-extern void Draw_text32(uint32_t *buffer, int x, int y, uint32_t fgcol, uint32_t bgcol, unsigned int alpha, int scalex, int scaley, int max, char *string, ...);
+void Draw_string(unsigned short *surf, signed short int x, signed short int y, const char *string, unsigned short int maxstrlen, unsigned short int xscale, unsigned short int yscale, unsigned short int fg, unsigned short int bg, libretro_graph_alpha_t alpha, bool draw_bg);
+void Draw_string32(uint32_t *surf, signed short int x, signed short int y, const char *string, unsigned short int maxstrlen, unsigned short int xscale, unsigned short int yscale, uint32_t fg, uint32_t bg, libretro_graph_alpha_t alpha, bool draw_bg);
+
+void Draw_text(unsigned short *buffer, int x, int y, unsigned short fgcol, unsigned short int bgcol, libretro_graph_alpha_t alpha, bool draw_bg, int scalex, int scaley, int max, char *string, ...);
+void Draw_text32(uint32_t *buffer, int x, int y, uint32_t fgcol, uint32_t bgcol, libretro_graph_alpha_t alpha, bool draw_bg, int scalex, int scaley, int max, char *string, ...);
+
+void LibretroGraphFree(void);
 
 #endif /* LIBRETRO_GRAPH_H */

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -7,7 +7,7 @@ bool retro_vkbd_transparent = true;
 extern bool retro_capslock;
 extern int vkflag[10];
 extern unsigned int opt_vkbd_theme;
-extern unsigned int opt_vkbd_alpha;
+extern libretro_graph_alpha_t opt_vkbd_alpha;
 extern unsigned int zoom_mode_id;
 
 int RGB(int r, int g, int b)
@@ -40,34 +40,34 @@ void print_vkbd(unsigned short int *pixels)
    int page              = 0;
    uint16_t *pix         = &pixels[0];
 
-   int XKEY              = 0;
-   int YKEY              = 0;
-   int XTEXT             = 0;
-   int YTEXT             = 0;
-   int XOFFSET           = 0;
-   int XPADDING          = 0;
-   int YOFFSET           = 0;
-   int YPADDING          = 0;
-   int XKEYSPACING       = 1;
-   int YKEYSPACING       = 1;
-   int ALPHA             = opt_vkbd_alpha;
-   int BKG_ALPHA         = ALPHA;
-   int BKG_PADDING_X     = 0;
-   int BKG_PADDING_Y     = 0;
-   int BKG_COLOR         = 0;
-   int BKG_COLOR_NORMAL  = 0;
-   int BKG_COLOR_ALT     = 0;
-   int BKG_COLOR_EXTRA   = 0;
-   int BKG_COLOR_EXTRA2  = 0;
-   int BKG_COLOR_SEL     = 0;
-   int BKG_COLOR_ACTIVE  = 0;
-   int FONT_MAX          = 3;
-   int FONT_WIDTH        = 1;
-   int FONT_HEIGHT       = 1;
-   int FONT_COLOR        = 0;
-   int FONT_COLOR_NORMAL = 0;
-   int FONT_COLOR_SEL    = 0;
-   int FONT_ALPHA        = 0;
+   int XKEY                          = 0;
+   int YKEY                          = 0;
+   int XTEXT                         = 0;
+   int YTEXT                         = 0;
+   int XOFFSET                       = 0;
+   int XPADDING                      = 0;
+   int YOFFSET                       = 0;
+   int YPADDING                      = 0;
+   int XKEYSPACING                   = 1;
+   int YKEYSPACING                   = 1;
+   libretro_graph_alpha_t ALPHA      = opt_vkbd_alpha;
+   libretro_graph_alpha_t BKG_ALPHA  = ALPHA;
+   int BKG_PADDING_X                 = 0;
+   int BKG_PADDING_Y                 = 0;
+   int BKG_COLOR                     = 0;
+   int BKG_COLOR_NORMAL              = 0;
+   int BKG_COLOR_ALT                 = 0;
+   int BKG_COLOR_EXTRA               = 0;
+   int BKG_COLOR_EXTRA2              = 0;
+   int BKG_COLOR_SEL                 = 0;
+   int BKG_COLOR_ACTIVE              = 0;
+   int FONT_MAX                      = 3;
+   int FONT_WIDTH                    = 1;
+   int FONT_HEIGHT                   = 1;
+   int FONT_COLOR                    = 0;
+   int FONT_COLOR_NORMAL             = 0;
+   int FONT_COLOR_SEL                = 0;
+   libretro_graph_alpha_t FONT_ALPHA = 0;
 
    switch (opt_vkbd_theme)
    {
@@ -214,10 +214,20 @@ void print_vkbd(unsigned short int *pixels)
    vkbd_y_max = YOFFSET + YBASEKEY + (YSIDE * VKBDY);
 
    /* Opacity */
-   BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : 255;
-   FONT_ALPHA = 255 - BKG_ALPHA;
-   FONT_ALPHA = (FONT_ALPHA < 60) ? 60 : FONT_ALPHA;
-   FONT_ALPHA = (FONT_ALPHA > 120) ? 120 : FONT_ALPHA;
+   BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : GRAPH_ALPHA_100;
+   switch (BKG_ALPHA)
+   {
+      case GRAPH_ALPHA_0:
+      case GRAPH_ALPHA_25:
+      case GRAPH_ALPHA_50:
+         FONT_ALPHA = GRAPH_ALPHA_50;
+         break;
+      case GRAPH_ALPHA_75:
+      case GRAPH_ALPHA_100:
+      default:
+         FONT_ALPHA = GRAPH_ALPHA_25;
+         break;
+   }
 
    /* Alternate color keys */
    int alt_keys[] =
@@ -255,7 +265,7 @@ void print_vkbd(unsigned short int *pixels)
       {
          /* Default key color */
          BKG_COLOR = BKG_COLOR_NORMAL;
-         BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : 255;
+         BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : GRAPH_ALPHA_100;
 
          /* Reset key color */
          if (vkeys[(y * VKBDX) + x].value == -2)
@@ -302,7 +312,20 @@ void print_vkbd(unsigned short int *pixels)
          {
             FONT_COLOR = FONT_COLOR_NORMAL;
             BKG_COLOR  = BKG_COLOR_ACTIVE;
-            BKG_ALPHA  = (BKG_ALPHA < 200) ? 200 : BKG_ALPHA;
+
+            switch (BKG_ALPHA)
+            {
+               case GRAPH_ALPHA_0:
+               case GRAPH_ALPHA_25:
+               case GRAPH_ALPHA_50:
+                  BKG_ALPHA = GRAPH_ALPHA_75;
+                  break;
+               case GRAPH_ALPHA_75:
+               case GRAPH_ALPHA_100:
+               default:
+                  /* Do nothing */
+                  break;
+            }
          }
 
          /* Key background */
@@ -321,27 +344,27 @@ void print_vkbd(unsigned short int *pixels)
                         (FONT_COLOR_SEL == RGB(250, 250, 250) ? XTEXT+FONT_WIDTH : XTEXT-FONT_WIDTH),
                         (FONT_COLOR_SEL == RGB(250, 250, 250) ? YTEXT+FONT_WIDTH : YTEXT-FONT_WIDTH),
                         (FONT_COLOR_SEL == RGB(250, 250, 250) ? RGB(100, 100, 100) : RGB(50, 50, 50)),
-                        BKG_COLOR, FONT_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                        BKG_COLOR, FONT_ALPHA, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                         (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
          else
             Draw_text(pix,
                       (FONT_COLOR_SEL == RGB(250, 250, 250) ? XTEXT+FONT_WIDTH : XTEXT-FONT_WIDTH),
                       (FONT_COLOR_SEL == RGB(250, 250, 250) ? YTEXT+FONT_WIDTH : YTEXT-FONT_WIDTH),
                       (FONT_COLOR_SEL == RGB(250, 250, 250) ? RGB(100, 100, 100) : RGB(50, 50, 50)),
-                      BKG_COLOR, FONT_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                      BKG_COLOR, FONT_ALPHA, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                       (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
 
          /* Key text */
          if (pix_bytes == 4)
          {
             Draw_text32((uint32_t *)pix,
-                        XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, 250, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                        XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, GRAPH_ALPHA_100, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                         (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
          }
          else
          {
             Draw_text(pix,
-                      XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, 250, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                      XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, GRAPH_ALPHA_100, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                       (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
          }
       }
@@ -360,7 +383,8 @@ void print_vkbd(unsigned short int *pixels)
    YTEXT = YOFFSET + YBASETEXT + BKG_PADDING_Y + (vkey_pos_y * YSIDE);
 
    /* Opacity */
-   BKG_ALPHA = (retro_vkbd_transparent) ? 220 : 250;
+   BKG_ALPHA = (retro_vkbd_transparent) ?
+         ((BKG_ALPHA == GRAPH_ALPHA_100) ? GRAPH_ALPHA_100 : GRAPH_ALPHA_75) : GRAPH_ALPHA_100;
 
    /* Pressed key color */
    if (vkflag[RETRO_DEVICE_ID_JOYPAD_B] && (vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].value == vkey_sticky1 ||
@@ -385,14 +409,14 @@ void print_vkbd(unsigned short int *pixels)
    if (pix_bytes == 4)
    {
       Draw_text32((uint32_t *)pix,
-                  XTEXT, YTEXT, FONT_COLOR, 0, BKG_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                  XTEXT, YTEXT, FONT_COLOR, 0, GRAPH_ALPHA_100, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                   (!shifted) ? vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].normal
                              : vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].shift);
    }
    else
    {
       Draw_text(pix,
-                XTEXT, YTEXT, FONT_COLOR, 0, BKG_ALPHA, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                XTEXT, YTEXT, FONT_COLOR, 0, GRAPH_ALPHA_100, false, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
                 (!shifted) ? vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].normal
                            : vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].shift);
    }

--- a/vice/src/arch/libretro/uistatusbar.c
+++ b/vice/src/arch/libretro/uistatusbar.c
@@ -577,9 +577,9 @@ void uistatusbar_draw(void)
     }
 
     if (pix_bytes == 2)
-        DrawFBoxBmp(retro_bmp, bkg_x, bkg_y, bkg_width, bkg_height, 0, 255);
+        DrawFBoxBmp(retro_bmp, bkg_x, bkg_y, bkg_width, bkg_height, 0, GRAPH_ALPHA_100);
     else
-        DrawFBoxBmp32((uint32_t *)retro_bmp, bkg_x, bkg_y, bkg_width, bkg_height, 0, 255);
+        DrawFBoxBmp32((uint32_t *)retro_bmp, bkg_x, bkg_y, bkg_width, bkg_height, 0, GRAPH_ALPHA_100);
 
     if (imagename_timer == 0)
         display_joyport();
@@ -660,8 +660,8 @@ void uistatusbar_draw(void)
         /* Output */
         snprintf(s, sizeof(s), "%c", c);
         if (pix_bytes == 2)
-            Draw_text(retro_bmp, x_char, y, color_f_16, color_b_16, 255, 1, 1, 10, s);
+            Draw_text(retro_bmp, x_char, y, color_f_16, color_b_16, GRAPH_ALPHA_100, true, 1, 1, 10, s);
         else
-            Draw_text32((uint32_t *)retro_bmp, x_char, y, color_f_32, color_b_32, 255, 1, 1, 10, s);
+            Draw_text32((uint32_t *)retro_bmp, x_char, y, color_f_32, color_b_32, GRAPH_ALPHA_100, true, 1, 1, 10, s);
     }
 }


### PR DESCRIPTION
This PR optimises the VKBD code as follows:

- Pixel blending is now performed using blargg's packed pixel mixing method (http://blargg.8bitalley.com/info/rgb_mixing.html)

- Array access in several hot loops has been replaced with more efficient pointer manipulation

- Dynamic memory allocation in `Draw_string()`/`Draw_string32()` has been minimised by using global static buffers which are only resized when the required dimensions increase

This reduces the performance overheads of rendering the VKBD by the following amounts (using default settings):

- 16 bit mode: 69%

- 32 bit mode: 74%

The only downside is that the VKBD now has limited/fixed transparency settings: 100%, 75%, 50%, 25%, 0%

I believe that this is sufficient for most users, however, and the performance gain more than makes up for any loss in configurability :)