### PR TITLE
Update .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,11 +10,17 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/vita-static.yml'
   - project: 'libretro-infrastructure/ci-templates'
+    file: '/ctr-static.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/wii-static.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ngc-static.yml'
+  - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
   - project: 'libretro-infrastructure/ci-templates'
     file: '/windows-x64-mingw.yml'
   - project: 'libretro-infrastructure/ci-templates'
-    file: '/dingux-i386.yml'
+    file: '/dingux-mips32.yml'
   - project: 'libretro-infrastructure/ci-templates'
     file: '/android-jni.yml'
 
@@ -27,47 +33,62 @@ stages:
 # Desktop
 libretro-build-linux-x64:
   extends:
-    - .core-defs
     - .libretro-linux-x64-make-default
+    - .core-defs
 
 libretro-build-windows-x64:
   extends:
-    - .core-defs
     - .libretro-windows-x64-mingw-make-default
-
-libretro-build-dingux-i386:
-  extends:
     - .core-defs
-    - .libretro-dingux-i386-make-default
+
+libretro-build-dingux-mips32:
+  extends:
+    - .libretro-dingux-mips32-make-default
+    - .core-defs
 
 # Android
 android-armeabi-v7a:
   extends:
-    - .core-defs
     - .libretro-android-jni-armeabi-v7a
+    - .core-defs
 
 android-arm64-v8a:
   extends:
-    - .core-defs
     - .libretro-android-jni-arm64-v8a
+    - .core-defs
 
 android-x86_64:
   extends:
-    - .core-defs
     - .libretro-android-jni-x86_64
+    - .core-defs
     
 android-x86:
   extends:
-    - .core-defs
     - .libretro-android-jni-x86
+    - .core-defs
 
 # Static
 libretro-build-libnx-aarch64:
   extends:
-    - .core-defs
     - .libretro-libnx-static-retroarch-master
+    - .core-defs
 
 libretro-build-vita:
   extends:
-    - .core-defs
     - .libretro-vita-static-retroarch-master
+    - .core-defs
+
+libretro-build-ctr:
+  extends:
+    - .libretro-ctr-static-retroarch-master
+    - .core-defs
+
+libretro-build-wii:
+  extends:
+    - .libretro-wii-static-retroarch-master
+    - .core-defs
+
+libretro-build-ngc:
+  extends:
+    - .libretro-ngc-static-retroarch-master
+    - .core-defs


### PR DESCRIPTION
This PR makes the following changes to `.gitlab-ci.yml`:

- The ordering of the `.core-defs` entries has been corrected

- The dingux target has been renamed from `dingux-i386` to `dingux-mips32`

- 3DS, Wii and NGC targets have been added