### PR TITLE
Autoloadwarp options, Cartridge scanner option

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -658,6 +658,11 @@ static int process_cmdline(const char* argv)
 #endif
 
 #if defined(__XVIC__)
+        /* Pretend to launch cartridge if using core option cartridge while launching
+         * without content, because XVIC does not care about CartridgeFile resource */
+        if (string_is_empty(argv) && !string_is_empty(core_opt.CartridgeFile))
+            argv = core_opt.CartridgeFile;
+
         if (strendswith(argv, ".20"))
             Add_Option("-cart2");
         else if (strendswith(argv, ".40"))
@@ -1495,8 +1500,75 @@ void retro_set_led(unsigned led)
    led_state_cb(0, led);
 }
 
+void retro_set_paths(void)
+{
+   const char *system_dir = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir) && system_dir)
+   {
+      strlcpy(retro_system_directory,
+              system_dir,
+              sizeof(retro_system_directory));
+   }
+
+   const char *content_dir = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY, &content_dir) && content_dir)
+   {
+      strlcpy(retro_content_directory,
+              content_dir,
+              sizeof(retro_content_directory));
+   }
+
+   /* Paths are first run in retro_set_environment(), but saves will not yet be correct then,
+    * therefore re-run in retro_init() and replace when necessary */
+   if (string_is_empty(retro_save_directory) || !strcmp(retro_save_directory, retro_system_directory))
+   {
+      const char *save_dir = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &save_dir) && save_dir)
+      {
+         /* If save directory is defined use it, otherwise use system directory */
+         strlcpy(retro_save_directory,
+                 string_is_empty(save_dir) ? retro_system_directory : save_dir,
+                 sizeof(retro_save_directory));
+      }
+      else
+      {
+         /* Make retro_save_directory the same in case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY is not implemented by the frontend */
+         strlcpy(retro_save_directory,
+                 retro_system_directory,
+                 sizeof(retro_save_directory));
+      }
+   }
+
+   if (string_is_empty(retro_system_directory))
+   {
+#if defined(ANDROID)
+      strlcpy(retro_system_directory, "/mnt/sdcard", sizeof(retro_system_directory));
+#elif defined(VITA)
+      strlcpy(retro_system_directory, "ux0:/data", sizeof(retro_system_directory));
+#elif defined(__SWITCH__)
+      strlcpy(retro_system_directory, "/", sizeof(retro_system_directory));
+#else
+      strlcpy(retro_system_directory, ".", sizeof(retro_system_directory));
+#endif
+   }
+
+   /* Temp directory for ZIPs and NIB->G64 conversions */
+   snprintf(retro_temp_directory, sizeof(retro_temp_directory), "%s%s%s",
+            retro_save_directory, FSDEV_DIR_SEP_STR, "TEMP");
+
+   /* Use system directory for data files such as JiffyDOS and keymaps */
+   snprintf(retro_system_data_directory, sizeof(retro_system_data_directory), "%s%s%s",
+            retro_system_directory, FSDEV_DIR_SEP_STR, "vice");
+   if (!path_is_directory(retro_system_data_directory))
+      archdep_mkdir(retro_system_data_directory, 0);
+}
+
 void retro_set_environment(retro_environment_t cb)
 {
+   environ_cb = cb;
+   retro_set_paths();
+
+   /* Controller ports */
    static const struct retro_controller_description p1_controllers[] = {
       { "Joystick", RETRO_DEVICE_VICE_JOYSTICK },
       { "Keyboard", RETRO_DEVICE_VICE_KEYBOARD },
@@ -1531,6 +1603,9 @@ void retro_set_environment(retro_environment_t cb)
       { NULL, 0 }
    };
 
+   cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports);
+
+   /* Core options */
    static struct retro_core_option_definition core_options[] =
    {
 #if defined(__XVIC__)
@@ -1788,6 +1863,18 @@ void retro_set_environment(retro_environment_t cb)
          },
          "autostart"
       },
+#if !defined(__XPET__)
+      /* Sublabel and options filled dynamically in retro_set_environment() */
+      {
+         "vice_cartridge",
+         "Media > Cartridge",
+         "",
+         {
+            { NULL, NULL },
+         },
+         NULL
+      },
+#endif
       {
          "vice_autostart",
          "Media > Autostart",
@@ -3040,7 +3127,7 @@ void retro_set_environment(retro_environment_t cb)
                      core_options[i].values[j].label = retro_keys[j + hotkeys_skipped + 1].label;
                }
                ++j;
-            };
+            }
          }
          else
          {
@@ -3059,16 +3146,58 @@ void retro_set_environment(retro_environment_t cb)
                   core_options[i].values[j].label = retro_keys[j].label;
 
                ++j;
-            };
+            }
          }
          core_options[i].values[j].value = NULL;
          core_options[i].values[j].label = NULL;
-      };
+      }
+      else if (!strcmp(core_options[i].key, "vice_cartridge"))
+      {
+         j = 0;
+         core_options[i].values[0].value = "none";
+         core_options[i].values[0].label = "disabled";
+         ++j;
+
+         DIR *cart_dir;
+         struct dirent *cart_dirp;
+
+         char machine_directory[RETRO_PATH_MAX] = {0};
+         snprintf(machine_directory, sizeof(machine_directory), "%s%s%s",
+               retro_system_data_directory, FSDEV_DIR_SEP_STR, machine_name);
+
+         /* Scan system/vice/machine directory for cartridges */
+         cart_dir = opendir(machine_directory);
+         while ((cart_dirp = readdir(cart_dir)) != NULL && j < RETRO_NUM_CORE_OPTION_VALUES_MAX - 1)
+         {
+             /* Blacklisted */
+             if (!strcmp(cart_dirp->d_name, "scpu-dos-1.4.bin") ||
+                 !strcmp(cart_dirp->d_name, "scpu-dos-2.04.bin"))
+                 continue;
+
+             if (dc_get_image_type(cart_dirp->d_name) == DC_IMAGE_TYPE_MEM)
+             {
+                 char cart_path[RETRO_PATH_MAX] = {0};
+                 char cart_label[50] = {0};
+                 snprintf(cart_path, sizeof(cart_path), "%s", cart_dirp->d_name);
+                 snprintf(cart_label, sizeof(cart_label), "%s", path_remove_extension(cart_dirp->d_name));
+
+                 core_options[i].values[j].value = strdup(cart_path);
+                 core_options[i].values[j].label = strdup(cart_label);
+                 ++j;
+             }
+         }
+         closedir(cart_dir);
+
+         core_options[i].values[j].value = NULL;
+         core_options[i].values[j].label = NULL;
+
+         /* Info sublabel */
+         char info[100] = {0};
+         snprintf(info, sizeof(info), "Cartridge images go in 'system/vice/%s'.\nChanging while running resets the system!", machine_name);
+         core_options[i].info = strdup(info);
+      }
       ++i;
    }
-
-   environ_cb = cb;
-   cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports);
 
    unsigned version = 0;
    if (!cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version))
@@ -3158,6 +3287,38 @@ static void update_variables(void)
 
 #ifdef RETRO_DEBUG
    log_cb(RETRO_LOG_INFO, "Updating variables, UI finalized = %d\n", retro_ui_finalized);
+#endif
+
+#if !defined(__XPET__)
+   var.key = "vice_cartridge";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      char cart_full[RETRO_PATH_MAX] = {0};
+
+      if (!strcmp(var.value, "none"))
+         snprintf(cart_full, sizeof(cart_full), "");
+      else
+         snprintf(cart_full, sizeof(cart_full), "%s%s%s%s%s",
+               retro_system_data_directory, FSDEV_DIR_SEP_STR, machine_name, FSDEV_DIR_SEP_STR, var.value);
+
+      if (retro_ui_finalized && strcmp(core_opt.CartridgeFile, cart_full))
+      {
+         if (!strcmp(cart_full, ""))
+            cartridge_detach_image(-1);
+         else
+#if defined(__XVIC__)
+            cartridge_attach_image(vic20_autodetect_cartridge_type(cart_full), cart_full);
+#elif defined(__XPLUS4__)
+            cartridge_attach_image(CARTRIDGE_PLUS4_DETECT, cart_full);
+#else
+            cartridge_attach_image(0, cart_full);
+#endif
+         request_restart = true;
+      }
+
+      sprintf(core_opt.CartridgeFile, "%s", cart_full);
+   }
 #endif
 
    var.key = "vice_autostart";
@@ -5125,62 +5286,11 @@ void retro_init(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &log))
       log_cb = log.log;
 
-   const char *system_dir = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_dir) && system_dir)
-   {
-      strlcpy(retro_system_directory,
-              system_dir,
-              sizeof(retro_system_directory));
-   }
-
-   const char *content_dir = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY, &content_dir) && content_dir)
-   {
-      strlcpy(retro_content_directory,
-              content_dir,
-              sizeof(retro_content_directory));
-   }
-
-   const char *save_dir = NULL;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &save_dir) && save_dir)
-   {
-      /* If save directory is defined use it, otherwise use system directory */
-      strlcpy(retro_save_directory,
-              string_is_empty(save_dir) ? retro_system_directory : save_dir,
-              sizeof(retro_save_directory));
-   }
-   else
-   {
-      /* Make retro_save_directory the same in case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY is not implemented by the frontend */
-      strlcpy(retro_save_directory,
-              retro_system_directory,
-              sizeof(retro_save_directory));
-   }
-
-   if (string_is_empty(retro_system_directory))
-   {
-#if defined(ANDROID)
-      strlcpy(retro_system_directory, "/mnt/sdcard", sizeof(retro_system_directory));
-#elif defined(VITA)
-      strlcpy(retro_system_directory, "ux0:/data", sizeof(retro_system_directory));
-#elif defined(__SWITCH__)
-      strlcpy(retro_system_directory, "/", sizeof(retro_system_directory));
-#else
-      strlcpy(retro_system_directory, ".", sizeof(retro_system_directory));
-#endif
-   }
-
-   /* Temp directory for ZIPs and NIB->G64 conversions */
-   snprintf(retro_temp_directory, sizeof(retro_temp_directory), "%s%s%s", retro_save_directory, FSDEV_DIR_SEP_STR, "TEMP");
+   retro_set_paths();
 
    /* Clean ZIP temp */
    if (!string_is_empty(retro_temp_directory) && path_is_directory(retro_temp_directory))
       remove_recurse(retro_temp_directory);
-
-   /* Use system directory for data files such as C64/.vpl etc. */
-   snprintf(retro_system_data_directory, sizeof(retro_system_data_directory), "%s%svice", retro_system_directory, FSDEV_DIR_SEP_STR);
-   if (!path_is_directory(retro_system_data_directory))
-      archdep_mkdir(retro_system_data_directory, 0);
 
    /* Disk Control interface */
    dc = dc_create();
@@ -5860,6 +5970,9 @@ bool retro_load_game(const struct retro_game_info *info)
       else
          return false;
    }
+   else
+      /* Empty cmdline processing required for VIC-20 core option cartridges on startup */
+      process_cmdline("");
 
    pre_main();
 

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -210,6 +210,9 @@ struct libretro_core_options
    int ColorSaturation;
    int ColorContrast;
    int ColorBrightness;
+#if !defined(__XPET__)
+   char CartridgeFile[RETRO_PATH_MAX];
+#endif
 #if defined(__X128__)
    int C128ColumnKey;
    int Go64Mode;

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -148,6 +148,10 @@ extern int vkbd_y_max;
 #define STATUSBAR_BASIC   0x04
 #define STATUSBAR_MINIMAL 0x08
 
+/* Autoloadwarp */
+#define AUTOLOADWARP_DISK 0x01
+#define AUTOLOADWARP_TAPE 0x02
+
 /* Variables */
 extern int cpuloop;
 extern int retroXS;

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -169,7 +169,8 @@ int ui_init_finalize(void)
 {
    /* Dump machine specific defaults for 'vicerc' usage, if not already dumped */
    char resources_dump_path[RETRO_PATH_MAX] = {0};
-   snprintf(resources_dump_path, sizeof(resources_dump_path), "%s%s%s%s", retro_system_data_directory, FSDEV_DIR_SEP_STR, "vicerc-dump-", machine_get_name());
+   snprintf(resources_dump_path, sizeof(resources_dump_path), "%s%s%s%s",
+         retro_system_data_directory, FSDEV_DIR_SEP_STR, "vicerc-dump-", machine_get_name());
    if (!util_file_exists(resources_dump_path))
       resources_dump(resources_dump_path);
 
@@ -456,6 +457,12 @@ int ui_init_finalize(void)
    }
    else
       log_resources_set_int("REU", 0);
+#endif
+
+#if !defined(__XPET__)
+   /* Cartridge */
+   if (strcmp(core_opt.CartridgeFile, ""))
+      log_resources_set_string("CartridgeFile", core_opt.CartridgeFile);
 #endif
 
    retro_ui_finalized = true;

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -358,7 +358,7 @@ int ui_init_finalize(void)
    else
       log_resources_set_int("DriveSoundEmulation", 0);
 
-   if (opt_autoloadwarp)
+   if (opt_autoloadwarp & AUTOLOADWARP_DISK)
       log_resources_set_int("DriveSoundEmulationVolume", 0);
 
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__)

--- a/vice/src/arch/libretro/uistatusbar.c
+++ b/vice/src/arch/libretro/uistatusbar.c
@@ -45,7 +45,8 @@
 
 extern unsigned int opt_joyport_type;
 extern unsigned int mouse_value[2 + 1];
-extern bool opt_autoloadwarp;
+extern unsigned int opt_autoloadwarp;
+extern unsigned int retro_warpmode;
 extern int retro_warp_mode_enabled();
 extern int request_model_set;
 extern int RGB(int r, int g, int b);
@@ -462,12 +463,22 @@ static void display_tape(void)
     if (drive_enabled)
         return;
 
-    if (opt_autoloadwarp && tape_enabled)
+    if (tape_enabled && (opt_autoloadwarp & AUTOLOADWARP_TAPE || retro_warp_mode_enabled()) && !retro_warpmode)
     {
         if (tape_control && tape_motor && !retro_warp_mode_enabled())
+        {
             resources_set_int("WarpMode", 1);
-        else if ((!tape_control || !tape_motor) && retro_warp_mode_enabled())
+#if 0
+            printf("Tape Warp ON\n");
+#endif
+        }
+        else if ((!tape_control || !tape_motor) && retro_warp_mode_enabled() || !(opt_autoloadwarp & AUTOLOADWARP_TAPE))
+        {
             resources_set_int("WarpMode", 0);
+#if 0
+            printf("Tape Warp OFF\n");
+#endif
+        }
     }
 
     if (tape_enabled)

--- a/vice/src/drive/drive.c
+++ b/vice/src/drive/drive.c
@@ -752,6 +752,7 @@ static void drive_led_update(drive_t *drive, drive_t *drive0)
 
 #ifdef __LIBRETRO__
 #include <stdbool.h>
+#include "libretro-core.h"
 extern unsigned int opt_autoloadwarp;
 extern unsigned int retro_warpmode;
 extern int retro_warp_mode_enabled();
@@ -793,15 +794,19 @@ void drive_update_ui_status(void)
                                        drive->current_half_track + (drive->side * DRIVE_HALFTRACKS_1571));
             }
 #ifdef __LIBRETRO__
-            if (opt_autoloadwarp && !retro_warpmode && !retro_disk_get_eject_state())
+            if (opt_autoloadwarp & AUTOLOADWARP_DISK && !retro_warpmode && !retro_disk_get_eject_state())
             {
                 drive_half_track = drive->current_half_track;
-                //printf("track:%2d prev:%2d led:%d timer:%2d\n", drive_half_track, drive_half_track_prev, drive->led_status, warpmode_counter);
+#if 0
+                printf("track:%2d prev:%2d led:%d timer:%2d\n", drive_half_track, drive_half_track_prev, drive->led_status, warpmode_counter);
+#endif
                 if ((drive_half_track != drive_half_track_prev || drive->led_status != 0) && !retro_warp_mode_enabled())
                 {
                     warpmode_counter = 0;
                     resources_set_int("WarpMode", 1);
-                    //printf("warp on\n");
+#if 0
+                    printf("Disk Warp ON\n");
+#endif
                 }
                 else if (drive_half_track == drive_half_track_prev && drive->led_status == 0 && retro_warp_mode_enabled())
                 {
@@ -809,7 +814,9 @@ void drive_update_ui_status(void)
                     if (warpmode_counter > 19)
                     {
                         resources_set_int("WarpMode", 0);
-                        //printf("warp off\n");
+#if 0
+                        printf("Disk Warp OFF\n");
+#endif
                     }
                 }
                 else

--- a/vice/src/keyboard.c
+++ b/vice/src/keyboard.c
@@ -1762,7 +1762,7 @@ void keyboard_init(void)
 #ifdef __LIBRETRO__
     libretro_keyboard();
     load_keymap_ok = 0;
-    // Only load files with user-defined maps
+    /* Only load files with user-defined maps */
     if (opt_keyboard_keymap > KBD_INDEX_POS)
     {
         load_keymap_ok = 1;

--- a/vice/src/resources.c
+++ b/vice/src/resources.c
@@ -1209,7 +1209,7 @@ static char *resources_get_description(const char *name)
 
 static char *string_resource_item(int num, const char *delim)
 {
-    // Skip core optionized & frontend resources
+    /* Skip core optionized & frontend resources */
     for (int d = 0; d < disabled_resources_num; d++)
     {
         if (!strcmp(resources[num].name, disabled_resources[d]))


### PR DESCRIPTION
- 2 new options for Autoload warp: "Disk only" & "Tape only"
- Dynamic core option for cartridge selection
  - Machine specific system dir `system/vice/C64` etc will be scanned for cart ROMs
