### PR TITLE
Warp Mode speed boost

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1446,8 +1446,8 @@ void reload_restart(void)
     /* Clear request */
     request_reload_restart = false;
 
-    /* Stop datasette */
-    datasette_control(DATASETTE_CONTROL_STOP);
+    /* Reset Datasette */
+    datasette_control(DATASETTE_CONTROL_RESET);
 
     /* Cleanup after previous content and reset resources */
     initcmdline_cleanup();
@@ -5001,10 +5001,13 @@ static void update_variables(void)
 
 void emu_reset(int type)
 {
-   /* Always stop datasette or autostart from tape will fail */
-   datasette_control(DATASETTE_CONTROL_STOP);
+   /* Reset LED */
+   retro_set_led(0);
 
-   /* Always disable Warp */
+   /* Reset Datasette or autostart from tape will fail */
+   datasette_control(DATASETTE_CONTROL_RESET);
+
+   /* Disable Warp */
    resources_set_int("WarpMode", 0);
 
    /* Changing opt_read_vicerc requires reloading */

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1921,13 +1921,13 @@ void retro_set_environment(retro_environment_t cb)
       {
          "vice_virtual_device_traps",
          "Media > Virtual Device Traps",
-         "Required for printer device, but causes loading issues on rare cases.",
+         "Required for printer device, but causes loading issues on rare cases. Enabled forcefully by disabling 'True Drive Emulation'.",
          {
             { "disabled", NULL },
             { "enabled", NULL },
             { NULL, NULL },
          },
-         "enabled"
+         "disabled"
       },
       {
          "vice_floppy_write_protection",
@@ -3454,6 +3454,15 @@ static void update_variables(void)
       /* Silently restore sounds when TDE and DSE is enabled */
       if (retro_ui_finalized && core_opt.DriveSoundEmulation && core_opt.DriveTrueEmulation)
          resources_set_int("DriveSoundEmulationVolume", core_opt.DriveSoundEmulation);
+
+      /* Forcefully enable Virtual Device Traps if TDE is disabled,
+       * otherwise floppy access does not work at all */
+      if (!core_opt.DriveTrueEmulation && !core_opt.VirtualDevices)
+      {
+         core_opt.VirtualDevices = 1;
+         if (retro_ui_finalized)
+            log_resources_set_int("VirtualDevices", core_opt.VirtualDevices);
+      }
    }
 
    var.key = "vice_drive_sound_emulation";

--- a/vice/src/arch/libretro/ui.c
+++ b/vice/src/arch/libretro/ui.c
@@ -174,14 +174,14 @@ int ui_init_finalize(void)
    if (!util_file_exists(resources_dump_path))
       resources_dump(resources_dump_path);
 
+   /* Mute sound at startup to hide 6581 ReSID init pop, and set back to 100 in retro_run() after 3 frames */
+   resources_set_int("SoundVolume", 0);
+
    /* Sensible defaults */
    log_resources_set_int("Mouse", 1);
    log_resources_set_int("Printer4", 1);
    log_resources_set_int("AutostartPrgMode", 1);
    log_resources_set_int("AutostartDelayRandom", 0);
-
-   /* Mute sound at startup to hide 6581 ReSID init pop, and set back to 100 in retro_run() after 3 frames */
-   log_resources_set_int("SoundVolume", 0);
 
 #if defined(__XCBM2__) || defined(__XPET__)
    log_resources_set_int("CrtcFilter", 0);

--- a/vice/src/arch/libretro/uistatusbar.c
+++ b/vice/src/arch/libretro/uistatusbar.c
@@ -47,6 +47,7 @@ extern unsigned int opt_joyport_type;
 extern unsigned int mouse_value[2 + 1];
 extern unsigned int opt_autoloadwarp;
 extern unsigned int retro_warpmode;
+extern void retro_set_led(unsigned);
 extern int retro_warp_mode_enabled();
 extern int request_model_set;
 extern int RGB(int r, int g, int b);
@@ -462,6 +463,9 @@ static void display_tape(void)
 
     if (drive_enabled)
         return;
+
+    if (tape_enabled)
+        retro_set_led((tape_control && tape_motor) ? 1 : 0);
 
     if (tape_enabled && (opt_autoloadwarp & AUTOLOADWARP_TAPE || retro_warp_mode_enabled()) && !retro_warpmode)
     {

--- a/vice/src/sound.c
+++ b/vice/src/sound.c
@@ -59,6 +59,11 @@
 #include "math.h"
 #include "ui.h"
 
+#ifdef __LIBRETRO__
+#include "sid.h"
+#include "libretro-core.h"
+extern void sound_volume_counter_reset(void);
+#endif
 
 static log_t sound_log = LOG_ERR;
 
@@ -1655,6 +1660,15 @@ void sound_set_warp_mode(int value)
 {
     warp_mode_enabled = value;
 
+#ifdef __LIBRETRO__
+    if (core_opt.SidEngine != SID_ENGINE_FASTSID)
+    {
+        resources_set_int("SidEngine", (value) ? SID_ENGINE_FASTSID : core_opt.SidEngine);
+        /* 6581 init pop muting */
+        if (!value)
+            sound_volume_counter_reset();
+    }
+#endif
     if (value) {
         sound_suspend();
     } else {


### PR DESCRIPTION
- Substantially faster warping by forcing SID to FastSID during warp
   - Random tape load time drops from 50sec to 36sec
- Virtual Device Traps disabled by default, due to causing more harm than good
   - Always enabled if TDE is disabled, otherwise disk drives won't work at all
- LED blinking also for tape access
