### PR TITLE
Autoloadwarp + autostart + warp adjustments

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -4570,6 +4570,10 @@ static void update_variables(void)
       if (!strcmp(var.value, "disabled")) opt_jiffydos = 0;
       else                                opt_jiffydos = 1;
 
+      /* Forcefully disable JiffyDOS if TDE is disabled */
+      if (!core_opt.DriveTrueEmulation)
+         opt_jiffydos = 0;
+
       if (!opt_jiffydos_allow)
          opt_jiffydos = 0;
 

--- a/vice/src/autostart.c
+++ b/vice/src/autostart.c
@@ -74,6 +74,12 @@
 #include "vdrive-bam.h"
 #include "vice-event.h"
 
+#ifdef __LIBRETRO__
+#include "keyboard.h"
+#include "libretro.h"
+extern unsigned int opt_autostart;
+#endif
+
 #ifdef DEBUG_AUTOSTART
 #define DBG(_x_)        log_debug _x_
 #else
@@ -749,6 +755,20 @@ static void advance_loadingtape(void)
         case NOT_YET:
             /* leave autostart and disable warp if ROM area was left */
             check_rom_area();
+#ifdef __LIBRETRO__
+            if (!opt_autostart)
+                break;
+            switch (check("FOUND ", AUTOSTART_NOWAIT_BLINK)) {
+                case YES:
+                    keyboard_key_pressed(RETROK_LCTRL);
+                    break;
+                case NO:
+                    keyboard_key_released(RETROK_LCTRL);
+                    break;
+                case NOT_YET:
+                    break;
+            }
+#endif
             break;
     }
 }


### PR DESCRIPTION
- Autoloadwarp with disks adjusted to not get stuck with games that for some reason leave the drive LED on always
- Added silent press of `C=` key at `FOUND` prompt when autostarting tapes
- Automatically disable JiffyDOS if True Drive Emulation is disabled
- Internal warping simplified
