### PR TITLE
VIC-20 compatibility, Warp tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This allows:
 External ROM files required in `system/vice`:
 
 | Filename                         | Size   | MD5                              |
-|----------------------------------|--------|----------------------------------|
+|----------------------------------|-------:|----------------------------------|
 | **JiffyDOS_C64.bin**             |  8 192 | be09394f0576cf81fa8bacf634daf9a2 |
 | **JiffyDOS_C128.bin**            | 16 384 | cbbd1bbcb5e4fd8046b6030ab71fc021 |
 | **JiffyDOS_1541-II.bin**         | 16 384 | 1b1e985ea5325a1f46eb7fd9681707bf |
@@ -173,7 +173,7 @@ xvic -memory 20 "/path/to/rom/some-8k-game.d64"
 
 **VIC-20 memory expansion can be set with filename tags or directory matching:**
 
-- `some game (8k).prg` or `/8k/some game.prg`
+- `some game (8k).prg` or `some game [8k].prg` or `/8k/some game.prg`
 - `vicdoom (35k).d64`
 
 ## Latest features

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -6020,11 +6020,16 @@ void retro_run(void)
 
    /* Main loop with Warp Mode maximizing without too much input lag */
    unsigned int frame_max = retro_warp_mode_enabled() ? retro_refresh : 1;
+   unsigned int frame_time = 0;
    for (int frame_count = 0; frame_count < frame_max; ++frame_count)
    {
+      frame_time = GetTicks();
       while (cpuloop)
          maincpu_mainloop_retro();
       cpuloop = 1;
+
+      if (frame_max > 1)
+         frame_max = 1000000 / (retro_refresh / 5) / (GetTicks() - frame_time);
    }
 
    /* LED interface */

--- a/vice/src/autostart.c
+++ b/vice/src/autostart.c
@@ -744,6 +744,11 @@ static void advance_loadingtape(void)
 {
     switch (check("READY.", AUTOSTART_WAIT_BLINK)) {
         case YES:
+#ifdef __LIBRETRO__
+            /* Kludge required for T64s */
+            if (opt_autostart)
+               keyboard_key_released(RETROK_LCTRL);
+#endif
             disable_warp_if_was_requested();
             autostart_finish();
             autostart_done();


### PR DESCRIPTION
- Better handling of TOSEC tags for VIC-20
- Warp Mode tries to take host horsepower into consideration for reducing lag
- Fixed T64 autostart from keeping `C=` pressed indefinitely