### PR TITLE
Crash and warning fixes

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3277,27 +3277,30 @@ void retro_set_environment(retro_environment_t cb)
                retro_system_data_directory, FSDEV_DIR_SEP_STR, machine_name);
 
          /* Scan system/vice/machine directory for cartridges */
-         cart_dir = opendir(machine_directory);
-         while ((cart_dirp = readdir(cart_dir)) != NULL && j < RETRO_NUM_CORE_OPTION_VALUES_MAX - 1)
+         if (path_is_directory(machine_directory))
          {
-             /* Blacklisted */
-             if (!strcmp(cart_dirp->d_name, "scpu-dos-1.4.bin") ||
-                 !strcmp(cart_dirp->d_name, "scpu-dos-2.04.bin"))
-                 continue;
+            cart_dir = opendir(machine_directory);
+            while ((cart_dirp = readdir(cart_dir)) != NULL && j < RETRO_NUM_CORE_OPTION_VALUES_MAX - 1)
+            {
+                /* Blacklisted */
+                if (!strcmp(cart_dirp->d_name, "scpu-dos-1.4.bin") ||
+                    !strcmp(cart_dirp->d_name, "scpu-dos-2.04.bin"))
+                    continue;
 
-             if (dc_get_image_type(cart_dirp->d_name) == DC_IMAGE_TYPE_MEM)
-             {
-                 char cart_path[RETRO_PATH_MAX] = {0};
-                 char cart_label[50] = {0};
-                 snprintf(cart_path, sizeof(cart_path), "%s", cart_dirp->d_name);
-                 snprintf(cart_label, sizeof(cart_label), "%s", path_remove_extension(cart_dirp->d_name));
+                if (dc_get_image_type(cart_dirp->d_name) == DC_IMAGE_TYPE_MEM)
+                {
+                    char cart_value[RETRO_PATH_MAX] = {0};
+                    char cart_label[50] = {0};
+                    snprintf(cart_value, sizeof(cart_value), "%s", cart_dirp->d_name);
+                    snprintf(cart_label, sizeof(cart_label), "%s", path_remove_extension(cart_dirp->d_name));
 
-                 core_options[i].values[j].value = strdup(cart_path);
-                 core_options[i].values[j].label = strdup(cart_label);
-                 ++j;
-             }
+                    core_options[i].values[j].value = strdup(cart_value);
+                    core_options[i].values[j].label = strdup(cart_label);
+                    ++j;
+                }
+            }
+            closedir(cart_dir);
          }
-         closedir(cart_dir);
 
          core_options[i].values[j].value = NULL;
          core_options[i].values[j].label = NULL;

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3411,7 +3411,7 @@ static void update_variables(void)
       char cart_full[RETRO_PATH_MAX] = {0};
 
       if (!strcmp(var.value, "none"))
-         snprintf(cart_full, sizeof(cart_full), "");
+         snprintf(cart_full, sizeof(cart_full), "%s", "");
       else
          snprintf(cart_full, sizeof(cart_full), "%s%s%s%s%s",
                retro_system_data_directory, FSDEV_DIR_SEP_STR, machine_name, FSDEV_DIR_SEP_STR, var.value);

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -586,7 +586,7 @@ static int process_cmdline(const char* argv)
         /* ZIP + NIB vars, use the same temp directory for single NIBs */
         char zip_basename[RETRO_PATH_MAX] = {0};
         snprintf(zip_basename, sizeof(zip_basename), "%s", path_basename(full_path));
-        snprintf(zip_basename, sizeof(zip_basename), "%s", path_remove_extension(zip_basename));
+        path_remove_extension(zip_basename);
 
         char nib_input[RETRO_PATH_MAX] = {0};
         char nib_output[RETRO_PATH_MAX] = {0};
@@ -747,7 +747,7 @@ static int process_cmdline(const char* argv)
                     case CARTRIDGE_VIC20_MEGACART:
                         snprintf(cartmega_temp, sizeof(cartmega_temp), "%s", argv);
                         snprintf(cartmega_temp, sizeof(cartmega_temp), "%s", path_basename(cartmega_temp));
-                        snprintf(cartmega_temp, sizeof(cartmega_temp), "%s", path_remove_extension(cartmega_temp));
+                        path_remove_extension(cartmega_temp);
                         snprintf(cartmega_nvram, sizeof(cartmega_nvram), "%s%s%s%s",
                                  retro_save_directory, FSDEV_DIR_SEP_STR, cartmega_temp, ".nvr");
                         Add_Option("-mcnvramfile");
@@ -756,21 +756,21 @@ static int process_cmdline(const char* argv)
                         break;
                     case -1: /* Separate ROM combination shenanigans, Gamebase style */
                         snprintf(cart_2000, sizeof(cart_2000), "%s", argv);
-                        snprintf(cart_2000, sizeof(cart_2000), "%s", path_remove_extension(cart_2000));
+                        path_remove_extension(cart_2000);
                         snprintf(cart_2000, sizeof(cart_2000), "%s", string_replace_substring((const char*)cart_2000, "-2000", ""));
                         snprintf(cart_2000, sizeof(cart_2000), "%s", string_replace_substring((const char*)cart_2000, "-6000", ""));
                         snprintf(cart_2000, sizeof(cart_2000), "%s", string_replace_substring((const char*)cart_2000, "-a000", ""));
                         snprintf(cart_2000, sizeof(cart_2000), "%s%s%s", cart_2000, "-2000", ".prg");
 
                         snprintf(cart_6000, sizeof(cart_6000), "%s", argv);
-                        snprintf(cart_6000, sizeof(cart_6000), "%s", path_remove_extension(cart_6000));
+                        path_remove_extension(cart_6000);
                         snprintf(cart_6000, sizeof(cart_6000), "%s", string_replace_substring((const char*)cart_6000, "-2000", ""));
                         snprintf(cart_6000, sizeof(cart_6000), "%s", string_replace_substring((const char*)cart_6000, "-6000", ""));
                         snprintf(cart_6000, sizeof(cart_6000), "%s", string_replace_substring((const char*)cart_6000, "-a000", ""));
                         snprintf(cart_6000, sizeof(cart_6000), "%s%s%s", cart_6000, "-6000", ".prg");
 
                         snprintf(cart_A000, sizeof(cart_A000), "%s", argv);
-                        snprintf(cart_A000, sizeof(cart_A000), "%s", path_remove_extension(cart_A000));
+                        path_remove_extension(cart_A000);
                         snprintf(cart_A000, sizeof(cart_A000), "%s", string_replace_substring((const char*)cart_A000, "-2000", ""));
                         snprintf(cart_A000, sizeof(cart_A000), "%s", string_replace_substring((const char*)cart_A000, "-6000", ""));
                         snprintf(cart_A000, sizeof(cart_A000), "%s", string_replace_substring((const char*)cart_A000, "-a000", ""));
@@ -813,28 +813,28 @@ static int process_cmdline(const char* argv)
                         }
 
                         snprintf(cart_2000, sizeof(cart_2000), "%s", argv);
-                        snprintf(cart_2000, sizeof(cart_2000), "%s", path_remove_extension(cart_2000));
+                        path_remove_extension(cart_2000);
                         snprintf(cart_2000, sizeof(cart_2000), "%s", string_replace_substring((const char*)cart_2000, "[4000]", "[2000]"));
                         snprintf(cart_2000, sizeof(cart_2000), "%s", string_replace_substring((const char*)cart_2000, "[6000]", "[2000]"));
                         snprintf(cart_2000, sizeof(cart_2000), "%s", string_replace_substring((const char*)cart_2000, "[A000]", "[2000]"));
                         snprintf(cart_2000, sizeof(cart_2000), "%s%s", cart_2000, ".crt");
 
                         snprintf(cart_4000, sizeof(cart_4000), "%s", argv);
-                        snprintf(cart_4000, sizeof(cart_4000), "%s", path_remove_extension(cart_4000));
+                        path_remove_extension(cart_4000);
                         snprintf(cart_4000, sizeof(cart_4000), "%s", string_replace_substring((const char*)cart_4000, "[2000]", "[4000]"));
                         snprintf(cart_4000, sizeof(cart_4000), "%s", string_replace_substring((const char*)cart_4000, "[6000]", "[4000]"));
                         snprintf(cart_4000, sizeof(cart_4000), "%s", string_replace_substring((const char*)cart_4000, "[A000]", "[4000]"));
                         snprintf(cart_4000, sizeof(cart_4000), "%s%s", cart_4000, ".crt");
 
                         snprintf(cart_6000, sizeof(cart_6000), "%s", argv);
-                        snprintf(cart_6000, sizeof(cart_6000), "%s", path_remove_extension(cart_6000));
+                        path_remove_extension(cart_6000);
                         snprintf(cart_6000, sizeof(cart_6000), "%s", string_replace_substring((const char*)cart_6000, "[2000]", "[6000]"));
                         snprintf(cart_6000, sizeof(cart_6000), "%s", string_replace_substring((const char*)cart_6000, "[4000]", "[6000]"));
                         snprintf(cart_6000, sizeof(cart_6000), "%s", string_replace_substring((const char*)cart_6000, "[A000]", "[6000]"));
                         snprintf(cart_6000, sizeof(cart_6000), "%s%s", cart_6000, ".crt");
 
                         snprintf(cart_A000, sizeof(cart_A000), "%s", argv);
-                        snprintf(cart_A000, sizeof(cart_A000), "%s", path_remove_extension(cart_A000));
+                        path_remove_extension(cart_A000);
                         snprintf(cart_A000, sizeof(cart_A000), "%s", string_replace_substring((const char*)cart_A000, "[2000]", "[A000]"));
                         snprintf(cart_A000, sizeof(cart_A000), "%s", string_replace_substring((const char*)cart_A000, "[4000]", "[A000]"));
                         snprintf(cart_A000, sizeof(cart_A000), "%s", string_replace_substring((const char*)cart_A000, "[6000]", "[A000]"));
@@ -882,19 +882,19 @@ static int process_cmdline(const char* argv)
                         }
 
                         snprintf(cart_2000, sizeof(cart_2000), "%s", argv);
-                        snprintf(cart_2000, sizeof(cart_2000), "%s", path_remove_extension(cart_2000));
+                        path_remove_extension(cart_2000);
                         snprintf(cart_2000, sizeof(cart_2000), "%s", string_replace_substring((const char*)cart_2000, "$6000", "$2000"));
                         snprintf(cart_2000, sizeof(cart_2000), "%s", string_replace_substring((const char*)cart_2000, "$A000", "$2000"));
                         snprintf(cart_2000, sizeof(cart_2000), "%s%s", cart_2000, ".20");
 
                         snprintf(cart_6000, sizeof(cart_6000), "%s", argv);
-                        snprintf(cart_6000, sizeof(cart_6000), "%s", path_remove_extension(cart_6000));
+                        path_remove_extension(cart_6000);
                         snprintf(cart_6000, sizeof(cart_6000), "%s", string_replace_substring((const char*)cart_6000, "$2000", "$6000"));
                         snprintf(cart_6000, sizeof(cart_6000), "%s", string_replace_substring((const char*)cart_6000, "$A000", "$6000"));
                         snprintf(cart_6000, sizeof(cart_6000), "%s%s", cart_6000, ".60");
 
                         snprintf(cart_A000, sizeof(cart_A000), "%s", argv);
-                        snprintf(cart_A000, sizeof(cart_A000), "%s", path_remove_extension(cart_A000));
+                        path_remove_extension(cart_A000);
                         snprintf(cart_A000, sizeof(cart_A000), "%s", string_replace_substring((const char*)cart_A000, "$2000", "$A000"));
                         snprintf(cart_A000, sizeof(cart_A000), "%s", string_replace_substring((const char*)cart_A000, "$6000", "$A000"));
                         snprintf(cart_A000, sizeof(cart_A000), "%s%s", cart_A000, ".a0");

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -479,7 +479,7 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
       /* ZIP + NIB vars, use the same temp directory for single NIBs */
       char zip_basename[RETRO_PATH_MAX] = {0};
       snprintf(zip_basename, sizeof(zip_basename), "%s", path_basename(full_path_replace));
-      snprintf(zip_basename, sizeof(zip_basename), "%s", path_remove_extension(zip_basename));
+      path_remove_extension(zip_basename);
 
       char nib_input[RETRO_PATH_MAX] = {0};
       char nib_output[RETRO_PATH_MAX] = {0};
@@ -923,7 +923,7 @@ void dc_parse_list(dc_storage* dc, const char* list_file, bool is_vfl, const cha
             /* ZIP + NIB vars, use the same temp directory for single NIBs */
             char zip_basename[RETRO_PATH_MAX] = {0};
             snprintf(zip_basename, sizeof(zip_basename), "%s", path_basename(full_path));
-            snprintf(zip_basename, sizeof(zip_basename), "%s", path_remove_extension(zip_basename));
+            path_remove_extension(zip_basename);
 
             char nib_input[RETRO_PATH_MAX] = {0};
             char nib_output[RETRO_PATH_MAX] = {0};

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -152,7 +152,7 @@ void emu_function(int function)
          /* Lock current port */
          cur_port_locked = true;
          /* Statusbar notification */
-         snprintf(statusbar_text, 56, "%c Port %-50d",
+         snprintf(statusbar_text, 56, "%c Port %-48d",
                (' ' | 0x80), cur_port);
          imagename_timer = 50;
          break;
@@ -169,7 +169,7 @@ void emu_function(int function)
          /* Lock aspect ratio */
          opt_aspect_ratio_locked = true;
          /* Statusbar notification */
-         snprintf(statusbar_text, 56, "%c Pixel Aspect %-50s",
+         snprintf(statusbar_text, 56, "%c Pixel Aspect %-40s",
                (' ' | 0x80), (opt_aspect_ratio == 1) ? "PAL" : (opt_aspect_ratio == 2) ? "NTSC" : "1:1");
          imagename_timer = 50;
          break;
@@ -186,7 +186,7 @@ void emu_function(int function)
          /* Lock turbo fire */
          turbo_fire_locked = true;
          /* Statusbar notification */
-         snprintf(statusbar_text, 56, "%c Turbo Fire %-50s",
+         snprintf(statusbar_text, 56, "%c Turbo Fire %-42s",
                (' ' | 0x80), (retro_turbo_fire) ? "ON" : "OFF");
          imagename_timer = 50;
          break;

--- a/vice/src/arch/libretro/archdep.c
+++ b/vice/src/arch/libretro/archdep.c
@@ -299,7 +299,7 @@ char *archdep_default_resource_file_name(void)
             if (!string_is_empty(full_path))
             {
                snprintf(content_basename, sizeof(content_basename), "%s", path_basename(full_path));
-               snprintf(content_basename, sizeof(content_basename), "%s", path_remove_extension(content_basename));
+               path_remove_extension(content_basename);
                snprintf(content_vicerc, sizeof(content_vicerc), "%s%s%s.vicerc", SAVEDIR, FSDEV_DIR_SEP_STR, content_basename);
                /* Process "saves/[content].vicerc" */
                if (!ioutil_access(content_vicerc, IOUTIL_ACCESS_R_OK))


### PR DESCRIPTION
Major problems found on Linux that do not exist in Windows:
- The way `path_remove_extension()` was used was doing the job twice in Linux, causing empty paths
- `opendir()` on a non-existent directory is a bad idea in Linux, but harmless in Windows

Closes #338 

And some other minor warnings removed.
