### PR TITLE
Save disk hotkey, VKBD cleanups

### DIFF
--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -169,6 +169,9 @@ extern unsigned int opt_statusbar;
 extern unsigned int cur_port;
 extern unsigned int retro_region;
 
+extern bool retro_message;
+extern char retro_message_msg[1024];
+
 enum
 {
    RUNSTATE_FIRST_START = 0,

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -349,6 +349,19 @@ bool dc_add_file_int(dc_storage* dc, char* filename, char* label, char* disk_lab
       return true;
    }
 
+   /* Determine if tape or disk fliplist from first entry */
+   if (dc->unit != -1 && !string_is_empty(dc->files[0]))
+   {
+      if (dc_get_image_type(dc->files[0]) == DC_IMAGE_TYPE_TAPE)
+         dc->unit = 1;
+      else if (dc_get_image_type(dc->files[0]) == DC_IMAGE_TYPE_FLOPPY)
+         dc->unit = 8;
+      else if (dc_get_image_type(dc->files[0]) == DC_IMAGE_TYPE_MEM)
+         dc->unit = 0;
+      else
+         dc->unit = 8;
+   }
+
    return false;
 }
 
@@ -367,19 +380,6 @@ bool dc_add_file(dc_storage* dc, const char* filename, const char* label, const 
    for (index = 0; index < dc->count; index++)
       if (!strcmp(dc->files[index], filename))
          return true;
-
-   /* Determine if tape or disk fliplist from first entry */
-   if (dc->unit != -1)
-   {
-      if (dc_get_image_type(dc->files[0]) == DC_IMAGE_TYPE_TAPE)
-         dc->unit = 1;
-      else if (dc_get_image_type(dc->files[0]) == DC_IMAGE_TYPE_FLOPPY)
-         dc->unit = 8;
-      else if (dc_get_image_type(dc->files[0]) == DC_IMAGE_TYPE_MEM)
-         dc->unit = 0;
-      else
-         dc->unit = 8;
-   }
 
    /* Get 'name' - just the filename without extension
     * > It would be nice to make use of the image label
@@ -703,6 +703,9 @@ static bool dc_add_m3u_save_disk(
 bool dc_save_disk_toggle(dc_storage* dc, bool file_check, bool select)
 {
    if (!dc)
+      return false;
+
+   if (dc->unit != 8)
       return false;
 
    if (file_check)

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -40,25 +40,6 @@ int tape_deinstall(void)
 #include <stdlib.h>
 #include <string.h>
 
-#define COMMENT             '#'
-#define M3U_SAVEDISK        "#SAVEDISK:"
-#define M3U_SAVEDISK_LABEL  "Save Disk"
-#define M3U_PATH_DELIM      '|'
-
-#define M3U_SPECIAL_COMMAND "#COMMAND:"
-#define M3U_NONSTD_LABEL    "#LABEL:"
-#define M3U_EXTSTD_LABEL    "#EXTINF:"  /* Title should be following comma */
-#define VFL_UNIT_ENTRY      "UNIT "
-
-#define MAX_LABEL_LEN       27          /* Max of disk (27) and tape (24) */
-
-#define D64_NAME_POS        0x16590     /* Sector 18/0, offset 0x90 */
-#define D64_FULL_NAME_LEN   27          /* Including id, dos version and paddings */
-#define D64_NAME_LEN        16
-
-#define T64_NAME_POS        40
-#define T64_NAME_LEN        24
-
 #undef  DISK_LABEL_RELAXED              /* Use label even if it doesn't look sane (mostly for testing) */
 #undef  DISK_LABEL_FORBID_SHIFTED       /* Reject label if has shifted chars */
 
@@ -67,6 +48,8 @@ static const char flip_file_header[] = "# Vice fliplist file";
 extern char retro_save_directory[RETRO_PATH_MAX];
 extern char retro_temp_directory[RETRO_PATH_MAX];
 extern bool retro_disk_set_image_index(unsigned index);
+extern bool retro_disk_set_eject_state(bool ejected);
+extern char full_path[RETRO_PATH_MAX];
 extern int runstate;
 
 extern retro_log_printf_t log_cb;
@@ -371,12 +354,19 @@ bool dc_add_file_int(dc_storage* dc, char* filename, char* label, char* disk_lab
 
 bool dc_add_file(dc_storage* dc, const char* filename, const char* label, const char* disk_label, const char* program)
 {
+   unsigned index = 0;
+
    /* Verify */
    if (dc == NULL)
       return false;
 
    if (!filename || (*filename == '\0'))
       return false;
+
+   /* Dupecheck */
+   for (index = 0; index < dc->count; index++)
+      if (!strcmp(dc->files[index], filename))
+         return true;
 
    /* Determine if tape or disk fliplist from first entry */
    if (dc->unit != -1)
@@ -608,7 +598,8 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
 static bool dc_add_m3u_save_disk(
       dc_storage* dc,
       const char* m3u_file, const char* save_dir,
-      const char* disk_name, unsigned int index)
+      const char* disk_name, unsigned int index,
+      bool file_check)
 {
    bool save_disk_exists                     = false;
    const char *m3u_file_name                 = NULL;
@@ -635,7 +626,8 @@ static bool dc_add_m3u_save_disk(
 
    /* Get m3u file name without extension */
    snprintf(m3u_file_name_no_ext, sizeof(m3u_file_name_no_ext),
-         "%s", path_remove_extension((char*)m3u_file_name));
+         "%s", m3u_file_name);
+   path_remove_extension(m3u_file_name_no_ext);
 
    if (*m3u_file_name_no_ext == '\0')
       return false;
@@ -653,6 +645,9 @@ static bool dc_add_m3u_save_disk(
     * it differs from 'disk_name'. This is quite
     * fiddly, however - perhaps it can be added later... */
    save_disk_exists = path_is_valid(save_disk_path);
+
+   if (file_check)
+      return save_disk_exists;
 
    /* ...if not, create a new one */
    if (!save_disk_exists)
@@ -681,11 +676,13 @@ static bool dc_add_m3u_save_disk(
          snprintf(volume_name, sizeof(volume_name), "%s %u",
                M3U_SAVEDISK_LABEL, index);
 
-      snprintf(format_name, sizeof(format_name), "%s", string_to_lower(volume_name));
+      snprintf(format_name, sizeof(format_name), "%s",
+            string_to_lower(volume_name));
       charset_petconvstring((uint8_t*)format_name, 0);
 
       /* Create save disk */
-      save_disk_exists = !vdrive_internal_create_format_disk_image(save_disk_path, format_name, DISK_IMAGE_TYPE_D64);
+      save_disk_exists = !vdrive_internal_create_format_disk_image(
+            save_disk_path, format_name, DISK_IMAGE_TYPE_D64);
    }
 
    /* If save disk exists/was created, add it to the list */
@@ -701,6 +698,54 @@ static bool dc_add_m3u_save_disk(
    }
 
    return false;
+}
+
+bool dc_save_disk_toggle(dc_storage* dc, bool file_check, bool select)
+{
+   if (!dc)
+      return false;
+
+   if (file_check)
+      return dc_add_m3u_save_disk(dc, full_path, retro_save_directory, NULL, 0, true);
+
+   dc_add_m3u_save_disk(dc, full_path, retro_save_directory, NULL, 0, false);
+   if (select)
+   {
+      unsigned save_disk_index = 0;
+      unsigned index = 0;
+      char save_disk_label[64] = {0};
+
+      snprintf(save_disk_label, 64, "%s %u",
+            M3U_SAVEDISK_LABEL, 0);
+
+      /* Scan for save disk index */
+      for (index = 0; index < dc->count; index++)
+         if (!strcmp(dc->labels[index], save_disk_label))
+            save_disk_index = index;
+
+      /* Remember previous index */
+      if (dc->index != save_disk_index)
+         dc->index_prev = dc->index;
+
+      /* Switch index */
+      if (save_disk_index == dc->index)
+         dc->index = dc->index_prev;
+      else
+         dc->index = save_disk_index;
+
+      /* Cycle disk tray */
+      retro_disk_set_eject_state(true);
+      retro_disk_set_eject_state(false);
+
+      /* Widget notification */
+      snprintf(retro_message_msg, sizeof(retro_message_msg),
+               "%d/%d - %s",
+               dc->index+1, dc->count, path_basename(dc->labels[dc->index]));
+      retro_message = true;
+   }
+   else
+      log_cb(RETRO_LOG_INFO, "Save Disk 0 appended\n");
+   return true;
 }
 
 void dc_parse_list(dc_storage* dc, const char* list_file, bool is_vfl, const char* save_dir)
@@ -828,7 +873,8 @@ void dc_parse_list(dc_storage* dc, const char* list_file, bool is_vfl, const cha
          /* Add save disk, creating it if necessary */
          if (dc_add_m3u_save_disk(
                dc, list_file, save_dir,
-               disk_name, save_disk_index))
+               disk_name, save_disk_index,
+               false))
                save_disk_index++;
 
          /* Clean up */

--- a/libretro/libretro-dc.h
+++ b/libretro/libretro-dc.h
@@ -21,6 +21,25 @@
 
 #include <stdbool.h>
 
+#define COMMENT             '#'
+#define M3U_SAVEDISK        "#SAVEDISK:"
+#define M3U_SAVEDISK_LABEL  "Save Disk"
+#define M3U_PATH_DELIM      '|'
+
+#define M3U_SPECIAL_COMMAND "#COMMAND:"
+#define M3U_NONSTD_LABEL    "#LABEL:"
+#define M3U_EXTSTD_LABEL    "#EXTINF:"  /* Title should be following comma */
+#define VFL_UNIT_ENTRY      "UNIT "
+
+#define MAX_LABEL_LEN       27          /* Max of disk (27) and tape (24) */
+
+#define D64_NAME_POS        0x16590     /* Sector 18/0, offset 0x90 */
+#define D64_FULL_NAME_LEN   27          /* Including id, dos version and paddings */
+#define D64_NAME_LEN        16
+
+#define T64_NAME_POS        40
+#define T64_NAME_LEN        24
+
 /* See which looks best in most cases and tweak (or make configurable) */
 #define DISK_LABEL_MODE_ASCII              1 /* Convert to ascii - unshifted chars are lowercase */
 #define DISK_LABEL_MODE_UPPERCASE          2 /* All characters are always uppercase */
@@ -57,6 +76,7 @@ struct dc_storage
    int index;
    bool eject_state;
    bool replace;
+   unsigned index_prev;
 };
 
 typedef struct dc_storage dc_storage;
@@ -69,5 +89,6 @@ void dc_reset(dc_storage* dc);
 bool dc_replace_file(dc_storage* dc, int index, const char* filename);
 bool dc_remove_file(dc_storage* dc, int index);
 enum dc_image_type dc_get_image_type(const char* filename);
+bool dc_save_disk_toggle(dc_storage* dc, bool file_check, bool select);
 
 #endif /* LIBRETRO_DC_H */

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -69,6 +69,7 @@ extern unsigned int retro_devices[RETRO_DEVICES];
 static unsigned retro_key_state[RETROK_LAST] = {0};
 static int16_t joypad_bits[RETRO_DEVICES];
 extern bool libretro_supports_bitmasks;
+extern dc_storage *dc;
 
 /* Core options */
 extern unsigned int opt_retropad_options;
@@ -102,6 +103,7 @@ enum EMU_FUNCTIONS
    EMU_STATUSBAR,
    EMU_JOYPORT,
    EMU_RESET,
+   EMU_SAVE_DISK,
    EMU_ASPECT_RATIO,
    EMU_ZOOM_MODE,
    EMU_TURBO_FIRE,
@@ -195,6 +197,9 @@ void emu_function(int function)
          snprintf(statusbar_text, 56, "%c Turbo Fire %-42s",
                (' ' | 0x80), (retro_turbo_fire) ? "ON" : "OFF");
          imagename_timer = 50;
+         break;
+      case EMU_SAVE_DISK:
+         dc_save_disk_toggle(dc, false, true);
          break;
       case EMU_WARP_MODE:
          retro_warpmode = (retro_warpmode) ? 0 : 1;
@@ -790,7 +795,10 @@ void update_input(int disable_physical_cursor_keys)
                   emu_function(EMU_RESET);
                   break;
                case -3:
-                  emu_function(EMU_STATUSBAR);
+                  if (retro_capslock)
+                     emu_function(EMU_SAVE_DISK);
+                  else
+                     emu_function(EMU_STATUSBAR);
                   break;
                case -4:
                   if (retro_capslock)

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -162,12 +162,12 @@ void print_vkbd(unsigned short int *pixels)
    int XBASEKEY = (XPADDING > 0) ? (XPADDING / 2) : 0;
    int YBASEKEY = (YPADDING > 0) ? (YPADDING / 2) : 0;
 
-   int XBASETEXT = ((XPADDING > 0) ? (XPADDING / 2) : 0) + (XSIDE / 2);
+   int XBASETEXT = XBASEKEY + (XSIDE / 2);
    int YBASETEXT = YBASEKEY + (YSIDE / 2);
 
    /* Coordinates */
-   vkbd_x_min = XBASEKEY + XKEYSPACING;
-   vkbd_x_max = -XBASEKEY + retrow - XKEYSPACING;
+   vkbd_x_min = XOFFSET + XBASEKEY + XKEYSPACING;
+   vkbd_x_max = XOFFSET - XBASEKEY - XKEYSPACING + retrow;
    vkbd_y_min = YOFFSET + YBASEKEY + YKEYSPACING;
    vkbd_y_max = YOFFSET + YBASEKEY + (YSIDE * VKBDY);
 
@@ -250,16 +250,16 @@ void print_vkbd(unsigned short int *pixels)
          }
 
          /* Key centering */
-         BKG_PADDING_X     = BKG_PADDING_X_DEFAULT;
-         BKG_PADDING_Y     = BKG_PADDING_Y_DEFAULT;
+         BKG_PADDING_X = BKG_PADDING_X_DEFAULT;
+         BKG_PADDING_Y = BKG_PADDING_Y_DEFAULT;
          if (!shifted && strlen(vkeys[(y * VKBDX) + x + page].normal) > 1)
             BKG_PADDING_X = BKG_PADDING(strlen(vkeys[(y * VKBDX) + x + page].normal));
          else if (shifted && strlen(vkeys[(y * VKBDX) + x + page].shift) > 1)
             BKG_PADDING_X = BKG_PADDING(strlen(vkeys[(y * VKBDX) + x + page].shift));
 
          /* Key positions */
-         XKEY  = XBASEKEY + (x * XSIDE) + XOFFSET;
-         XTEXT = XBASETEXT + BKG_PADDING_X + (x * XSIDE) + XOFFSET;
+         XKEY  = XOFFSET + XBASEKEY + (x * XSIDE);
+         XTEXT = XOFFSET + XBASETEXT + BKG_PADDING_X + (x * XSIDE);
          YKEY  = YOFFSET + YBASEKEY + (y * YSIDE);
          YTEXT = YOFFSET + YBASETEXT + BKG_PADDING_Y + (y * YSIDE);
 
@@ -342,8 +342,8 @@ void print_vkbd(unsigned short int *pixels)
       BKG_PADDING_X = BKG_PADDING(strlen(vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].shift));
 
    /* Selected key position */
-   XKEY  = XBASEKEY + (vkey_pos_x * XSIDE) + XOFFSET;
-   XTEXT = XBASETEXT + BKG_PADDING_X + (vkey_pos_x * XSIDE) + XOFFSET;
+   XKEY  = XOFFSET + XBASEKEY + (vkey_pos_x * XSIDE);
+   XTEXT = XOFFSET + XBASETEXT + BKG_PADDING_X + (vkey_pos_x * XSIDE);
    YKEY  = YOFFSET + YBASEKEY + (vkey_pos_y * YSIDE);
    YTEXT = YOFFSET + YBASETEXT + BKG_PADDING_Y + (vkey_pos_y * YSIDE);
 

--- a/libretro/libretro-vkbd.h
+++ b/libretro/libretro-vkbd.h
@@ -100,7 +100,7 @@ static retro_vkeys vkeys[VKBDX * VKBDY] =
    { ":"  ,"["   ,RETROK_SEMICOLON},
    { ";"  ,"]"   ,RETROK_QUOTE},
    { "="  ,"="   ,RETROK_BACKSLASH},
-   { "STB","STB" ,-3}, /* Statusbar */
+   { "STB","SVD" ,-3}, /* Statusbar / Save disk */
 
    /* 55 */
    { {24} ,{24}  ,RETROK_LCTRL},


### PR DESCRIPTION
A new VKBD hotkey under ShiftLock+Statusbar (STB): Save Disk (SVD)
- First press creates the disk if it does not exist, changes DC index and cycles eject
- Second press changes back to the previous disk

The created disk is automatically appended to DC at next run.

Plus bonus cleanups.
