### PR TITLE
Makefile: fix common flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ endif
 ifeq ($(DEBUG), 1)
    COMMONFLAGS += -O0 -g
 else
-   COMMONFLAGS += -O3 -DNDEBUG -Wno-format
+   COMMONFLAGS += -O3 -DNDEBUG -Wno-format -Wno-format-security
    LDFLAGS     += -s
 endif
 


### PR DESCRIPTION
Wno-format was added to common flags recently. In this case it is also necessary to add -Wno-format-security or gcc  ≥ 8 will stop otherwise:

| cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
| cc1plus: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]