### PR TITLE
Datasette volume, 'vicerc' tunings

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,23 @@ External ROM files required in `system/vice`:
 | **JiffyDOS_1571_repl310654.bin** | 32 768 | 41c6cc528e9515ffd0ed9b180f8467c0 |
 | **JiffyDOS_1581.bin**            | 32 768 | 20b6885c6dc2d42c38754a365b043d71 |
 
+## Custom vicerc
+
+Custom configs can be used globally and per-content for accessing VICE options that do not exist as core options.
+
+Config files are processed first found in this order:
+1. `saves/[content].vicerc`
+2. `saves/vicerc`
+3. `system/vice/vicerc`
+
+All available options are dumped in `system/vice/vicerc-dump-[corename]` for copy-pasteing to actual config.
+
+Options must be after the correct `[corename]` block, for example x64 fast:
+```
+[C64]
+GMod2FlashWrite=0
+```
+
 ## Command file operation
 
 VICE command line options are supported by placing the desired command line in a text file with `.cmd` file extension. The command line format is as documented in the [VICE manual](http://vice-emu.sourceforge.net/vice_6.html).

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -130,6 +130,7 @@ unsigned int opt_supercpu_kernal = 0;
 #endif
 static unsigned int sound_volume_counter = 3;
 unsigned int opt_audio_leak_volume = 0;
+int opt_datasette_sound_volume = 0;
 unsigned int opt_statusbar = 0;
 unsigned int opt_reset_type = 0;
 bool opt_keyrah_keypad = false;
@@ -2597,6 +2598,7 @@ void retro_set_environment(retro_environment_t cb)
             { "90%", NULL },
             { "95%", NULL },
             { "100%", NULL },
+            { "-1", "100% + Mute" },
             { NULL, NULL },
          },
          "disabled"
@@ -3764,20 +3766,15 @@ static void update_variables(void)
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      int val = atoi(var.value) * 20;
+      int val = atoi(var.value);
+      opt_datasette_sound_volume = val;
 
       if (retro_ui_finalized && vice_opt.DatasetteSound != val)
       {
          if (!strcmp(var.value, "disabled"))
-         {
             log_resources_set_int("DatasetteSound", 0);
-            log_resources_set_int("DatasetteSoundVolume", 0);
-         }
          else
-         {
             log_resources_set_int("DatasetteSound", 1);
-            log_resources_set_int("DatasetteSoundVolume", val);
-         }
       }
 
       vice_opt.DatasetteSound = val;

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3544,13 +3544,13 @@ void retro_set_environment(retro_environment_t cb)
 
 int log_resources_set_int(const char *name, int value)
 {
-    log_cb(RETRO_LOG_INFO, "Resource: %s => %d\n", name, value);
+    log_cb(RETRO_LOG_INFO, "Set resource: %s => %d\n", name, value);
     return resources_set_int(name, value);
 }
 
 int log_resources_set_string(const char *name, const char* value)
 {
-    log_cb(RETRO_LOG_INFO, "Resource: %s => \"%s\"\n", name, value);
+    log_cb(RETRO_LOG_INFO, "Set resource: %s => \"%s\"\n", name, value);
     return resources_set_string(name, value);
 }
 

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -767,7 +767,8 @@ void update_input(unsigned disable_keys)
       /* Press Return, RetroPad Start */
       i = RETRO_DEVICE_ID_JOYPAD_START;
       if (!vkflag[i] && mapper_keys[i] >= 0 && ((joypad_bits[0] & (1 << i)) ||
-                                                (joypad_bits[1] & (1 << i))))
+                                                (joypad_bits[1] & (1 << i)))
+                                            && !input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_RETURN))
       {
          vkflag[i] = 1;
          kbd_handle_keydown(RETROK_RETURN);

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -365,10 +365,7 @@ int ui_init_finalize(void)
       log_resources_set_int("DriveSoundEmulationVolume", 0);
 
    if (vice_opt.DatasetteSound)
-   {
-      log_resources_set_int("DatasetteSoundVolume", vice_opt.DatasetteSound);
       log_resources_set_int("DatasetteSound", 1);
-   }
    else
       log_resources_set_int("DatasetteSound", 0);
 

--- a/vice/src/resources.c
+++ b/vice/src/resources.c
@@ -1111,6 +1111,10 @@ int resources_read_item_from_file(FILE *f)
         return -1;
     }
 
+#ifdef __LIBRETRO__
+    char* token = strtok((char*)buf, " ### ");
+#endif
+
     resname_len = (int)(arg_ptr - buf);
     arg_ptr++;
     arg_len = strlen(arg_ptr);
@@ -1134,9 +1138,15 @@ int resources_read_item_from_file(FILE *f)
 
         switch (r->type) {
             case RES_INTEGER:
+#ifdef __LIBRETRO__
+                log_message(LOG_DEFAULT, "Read resource: %s => %d", r->name, atoi(arg_ptr));
+#endif
                 result = (*r->set_func_int)(atoi(arg_ptr), r->param);
                 break;
             case RES_STRING:
+#ifdef __LIBRETRO__
+                log_message(LOG_DEFAULT, "Read resource: %s => \"%s\"", r->name, arg_ptr);
+#endif
                 result = (*r->set_func_string)(arg_ptr, r->param);
                 break;
             default:
@@ -1312,7 +1322,8 @@ static char *string_resource_item(int num, const char *delim)
     switch (resources[num].type) {
         case RES_INTEGER:
             v = (resource_value_t) uint_to_void_ptr(*(int *)resources[num].value_ptr);
-            line = lib_msprintf("%s=%d ### %s%s", resources[num].name, vice_ptr_to_int(v), resources_get_description(resources[num].name), delim);
+            line = lib_msprintf("%s=%d ### %s%s", resources[num].name, vice_ptr_to_int(v),
+                                resources_get_description(resources[num].name), delim);
             break;
         case RES_STRING:
             v = *resources[num].value_ptr;
@@ -1320,7 +1331,8 @@ static char *string_resource_item(int num, const char *delim)
                 line = lib_msprintf("%s=\"%s\" ### %s%s", resources[num].name, (char *)v,
                                     resources_get_description(resources[num].name), delim);
             } else {
-                line = lib_msprintf("%s= ### %s%s", resources[num].name, resources_get_description(resources[num].name), delim);
+                line = lib_msprintf("%s= ### %s%s", resources[num].name,
+                                    resources_get_description(resources[num].name), delim);
             }
             break;
         default:


### PR DESCRIPTION
- Fixed Datasette volume (ARM defaults `char` to unsigned, and one char needs to be signed)
   Closes #378 
- Altered `vicerc` parsing to not mind the added ` ### description stuff`
- Added `vicerc` information to README
  Closes #380 
- Prevent duplicate VKBD press when keyboard Return is RetroPad Start 
