### PR TITLE
Light pen/gun, Misc fixes

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -155,6 +155,7 @@ SOURCES_C += \
 	$(RETRODEP)/c64ui.c \
 	$(RETRODEP)/console.c \
 	$(RETRODEP)/joy.c \
+	$(RETRODEP)/lightpendrv.c \
 	$(RETRODEP)/kbd.c \
 	$(RETRODEP)/main.c \
 	$(RETRODEP)/mousedrv.c \

--- a/include/config.h
+++ b/include/config.h
@@ -77,8 +77,11 @@
 #define HAVE_MKSTEMP 1
 #endif
 
-/* Enable 1351 mouse support */
+/* Enable mouse support */
 #define HAVE_MOUSE 1
+
+/* Enable lightpen support */
+#define HAVE_LIGHTPEN 1
 
 /* FastSID */
 #define HAVE_FASTSID

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1166,6 +1166,9 @@ static void autodetect_drivetype(int unit)
                 set_drive_type = DISK_IMAGE_TYPE_D64;
             else if (diskimg->type == DISK_IMAGE_TYPE_G71)
                 set_drive_type = DISK_IMAGE_TYPE_D71;
+            /* Force 1541 to 1541-II */
+            else if (diskimg->type == DRIVE_TYPE_1541)
+                set_drive_type = DRIVE_TYPE_1541II;
             else
                 set_drive_type = diskimg->type;
 
@@ -1177,6 +1180,7 @@ static void autodetect_drivetype(int unit)
                 log_cb(RETRO_LOG_ERROR, "Failed to set drive type.\n");
 
             /* Change from 1581 to 1541 will not detect disk properly without reattaching (?!) */
+            file_system_detach_disk(unit, 0);
             file_system_attach_disk(unit, 0, attached_image);
 
             /* Don't bother with drive sound muting when autoloadwarp is on */

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -138,6 +138,7 @@ bool opt_keyboard_pass_through = false;
 unsigned int opt_keyboard_keymap = KBD_INDEX_POS;
 unsigned int opt_retropad_options = 0;
 unsigned int opt_joyport_type = 0;
+int opt_joyport_pointer_color = -1;
 unsigned int opt_dpadmouse_speed = 6;
 unsigned int opt_mouse_speed = 100;
 unsigned int opt_analogmouse = 0;
@@ -2366,6 +2367,23 @@ void retro_set_environment(retro_environment_t cb)
          },
          "16bit"
       },
+      {
+         "vice_joyport_pointer_color",
+         "Video > Light Pen/Gun Pointer Color",
+         "Color for light guns and pens.",
+         {
+            { "disabled", NULL },
+            { "black", "Black" },
+            { "white", "White" },
+            { "red", "Red" },
+            { "green", "Green" },
+            { "blue", "Blue" },
+            { "yellow", "Yellow" },
+            { "purple", "Purple" },
+            { NULL, NULL },
+         },
+         "blue"
+      },
 #if defined(__XVIC__)
       {
          "vice_vic20_external_palette",
@@ -2376,7 +2394,7 @@ void retro_set_environment(retro_environment_t cb)
             { "colodore_vic", "Colodore" },
             { "mike-pal", "Mike (PAL)" },
             { "mike-ntsc", "Mike (NTSC)" },
-            { "vice", "Vice" },
+            { "vice", "VICE" },
             { NULL, NULL },
          },
          "colodore_vic"
@@ -3330,6 +3348,12 @@ void retro_set_environment(retro_environment_t cb)
             { "8", "Mouse (SmartMouse)" },
             { "9", "Mouse (Micromys)" },
             { "10", "Koalapad" },
+            { "11", "Light Pen (Up trigger)" },
+            { "12", "Light Pen (Left trigger)" },
+            { "13", "Light Pen (Datel)" },
+            { "16", "Light Pen (Inkwell)" },
+            { "14", "Light Gun (Magnum Light Phaser)" },
+            { "15", "Light Gun (Stack Light Rifle)" },
             { NULL, NULL },
          },
          "1"
@@ -4690,6 +4714,25 @@ static void update_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       opt_joyport_type = atoi(var.value);
+
+      /* Light guns/pens only possible in port 1 */
+      if (opt_joyport_type > 10)
+         cur_port = 1;
+   }
+
+   var.key = "vice_joyport_pointer_color";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if      (!strcmp(var.value, "disabled")) opt_joyport_pointer_color = -1;
+      else if (!strcmp(var.value, "black"))    opt_joyport_pointer_color = 0;
+      else if (!strcmp(var.value, "white"))    opt_joyport_pointer_color = 1;
+      else if (!strcmp(var.value, "red"))      opt_joyport_pointer_color = 2;
+      else if (!strcmp(var.value, "green"))    opt_joyport_pointer_color = 3;
+      else if (!strcmp(var.value, "blue"))     opt_joyport_pointer_color = 4;
+      else if (!strcmp(var.value, "yellow"))   opt_joyport_pointer_color = 5;
+      else if (!strcmp(var.value, "cyan"))     opt_joyport_pointer_color = 6;
+      else if (!strcmp(var.value, "purple"))   opt_joyport_pointer_color = 7;
    }
 
    var.key = "vice_analogmouse_deadzone";
@@ -5289,6 +5332,8 @@ static void update_variables(void)
    option_display.key = "vice_statusbar";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
    option_display.key = "vice_gfx_colors";
+   environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
+   option_display.key = "vice_joyport_pointer_color";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__) || defined(__XVIC__) || defined(__XPLUS4__)
    option_display.key = "vice_zoom_mode";

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -183,6 +183,7 @@ enum
 /* Functions */
 extern long retro_ticks(void);
 extern void reload_restart(void);
+extern int RGB(int r, int g, int b);
 
 /* VICE options */
 struct vice_core_options

--- a/libretro/libretro-graph.c
+++ b/libretro/libretro-graph.c
@@ -268,7 +268,13 @@ void draw_hline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t c
    }
 }
 
-
+void draw_vline(int x, int y, int dx, int dy, uint32_t color)
+{
+   if (pix_bytes == 4)
+      draw_vline_bmp32((uint32_t *)retro_bmp, x, y, dx, dy, color);
+   else
+      draw_vline_bmp(retro_bmp, x, y, dx, dy, color);
+}
 
 void draw_vline_bmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color)
 {
@@ -280,7 +286,20 @@ void draw_vline_bmp(unsigned short *buffer, int x, int y, int dx, int dy, unsign
    {
       idx = x+j*retrow;
       buffer[idx] = color;
-   }	
+   }
+}
+
+void draw_vline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color)
+{
+   int i, j, idx;
+
+   (void)i;
+
+   for (j=y; j<y+dy; j++)
+   {
+      idx = x+j*retrow;
+      buffer[idx] = color;
+   }
 }
 
 void draw_line_bmp(unsigned short *buffer, int x1, int y1, int x2, int y2, unsigned short color)

--- a/libretro/libretro-graph.h
+++ b/libretro/libretro-graph.h
@@ -29,8 +29,9 @@ void draw_hline(int x, int y, int dx, int dy, uint32_t color);
 void draw_hline_bmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
 void draw_hline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
 
+void draw_vline(int x, int y, int dx, int dy, uint32_t color);
 void draw_vline_bmp(unsigned short *buffer, int x, int y, int dx, int dy, unsigned short color);
-void draw_vline_bmp(unsigned short *buffer, int x1, int y1, int x2, int y2, unsigned short color);
+void draw_vline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
 
 void draw_string(unsigned short *surf, unsigned short int x, unsigned short int y,
       const char *string, unsigned short int maxstrlen,

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -2,6 +2,7 @@
 #include "libretro-core.h"
 #include "libretro-mapper.h"
 #include "libretro-vkbd.h"
+#include "libretro-graph.h"
 
 #include "archdep.h"
 #include "joystick.h"
@@ -88,6 +89,7 @@ extern dc_storage *dc;
 extern unsigned int opt_retropad_options;
 extern unsigned int opt_joyport_type;
 static int opt_joyport_type_prev = -1;
+extern int opt_joyport_pointer_color;
 extern unsigned int opt_dpadmouse_speed;
 extern unsigned int opt_analogmouse;
 extern unsigned int opt_analogmouse_deadzone;
@@ -109,6 +111,42 @@ unsigned int turbo_fire_button = 0;
 unsigned int turbo_pulse = 6;
 unsigned int turbo_state[RETRO_DEVICES] = {0};
 unsigned int turbo_toggle[RETRO_DEVICES] = {0};
+
+int retro_ui_get_pointer_state(int *px, int *py, unsigned int *pbuttons)
+{
+   if (retro_vkbd)
+      return 0;
+
+   *pbuttons = input_state_cb(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_PRESSED);
+
+   *px = input_state_cb(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_X);
+   *py = input_state_cb(0, RETRO_DEVICE_POINTER, 0, RETRO_DEVICE_ID_POINTER_Y);
+   *px = (int)((*px + 0x7fff) * retrow / 0xffff);
+   *py = (int)((*py + 0x7fff) * retroh / 0xffff);
+
+   if (opt_joyport_pointer_color > -1)
+   {
+      unsigned pointer_color = 0;
+      switch (opt_joyport_pointer_color)
+      {
+         case 0: pointer_color = RGB(  0,   0,   0); break; /* Black */
+         case 1: pointer_color = RGB(255, 255, 255); break; /* White */
+         case 2: pointer_color = RGB(255,   0,   0); break; /* Red */
+         case 3: pointer_color = RGB(  0, 255,   0); break; /* Green */
+         case 4: pointer_color = RGB(  0,   0, 255); break; /* Blue */
+         case 5: pointer_color = RGB(255, 255,   0); break; /* Yellow */
+         case 6: pointer_color = RGB(  0, 255, 255); break; /* Cyan */
+         case 7: pointer_color = RGB(255,   0, 255); break; /* Purple */
+      }
+
+      draw_hline(*px - 2, *py, 2, 1, pointer_color);
+      draw_hline(*px + 1, *py, 2, 1, pointer_color);
+      draw_vline(*px, *py - 2, 1, 2, pointer_color);
+      draw_vline(*px, *py + 1, 1, 2, pointer_color);
+   }
+
+   return 1;
+}
 
 enum EMU_FUNCTIONS
 {

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -375,7 +375,7 @@ void print_vkbd(void)
                         : vkeys[(vkey_pos_y * VKBDX) + vkey_pos_x + page].shift);
 
 #ifdef POINTER_DEBUG
-   draw_hline(pointer_x, pointer_y, 1, 1, RGB565(255, 0, 255));
+   draw_hline(pointer_x, pointer_y, 1, 1, RGB(255, 0, 255));
 #endif
 }
 

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -11,6 +11,8 @@ extern unsigned int opt_vkbd_theme;
 extern libretro_graph_alpha_t opt_vkbd_alpha;
 extern unsigned int zoom_mode_id;
 
+extern int tape_enabled;
+extern int tape_counter;
 extern int tape_control;
 
 int RGB(int r, int g, int b)
@@ -251,6 +253,8 @@ void print_vkbd(void)
    {
       for (y = 0; y < VKBDY; y++)
       {
+         char text_str[4] = {0};
+
          /* Skip selected key */
          if (((vkey_pos_y * VKBDX) + vkey_pos_x + page) == ((y * VKBDX) + x + page))
             continue;
@@ -283,7 +287,9 @@ void print_vkbd(void)
          /* Key centering */
          BKG_PADDING_X = BKG_PADDING_X_DEFAULT;
          BKG_PADDING_Y = BKG_PADDING_Y_DEFAULT;
-         if (!shifted && strlen(vkeys[(y * VKBDX) + x + page].normal) > 1)
+         if (tape_enabled && !shifted && vkeys[(y * VKBDX) + x + page].value == -15) /* Datasette Reset */
+            BKG_PADDING_X = BKG_PADDING(3);
+         else if (!shifted && strlen(vkeys[(y * VKBDX) + x + page].normal) > 1)
             BKG_PADDING_X = BKG_PADDING(strlen(vkeys[(y * VKBDX) + x + page].normal));
          else if (shifted && strlen(vkeys[(y * VKBDX) + x + page].shift) > 1)
             BKG_PADDING_X = BKG_PADDING(strlen(vkeys[(y * VKBDX) + x + page].shift));
@@ -331,9 +337,15 @@ void print_vkbd(void)
                    BKG_COLOR, BKG_ALPHA);
 
          /* Key text */
+         if (tape_enabled && !shifted && vkeys[(y * VKBDX) + x + page].value == -15) /* Datasette Reset */
+            snprintf(text_str, sizeof(text_str), "%03d", tape_counter);
+         else
+            snprintf(text_str, sizeof(text_str), "%s",
+               (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
+
          draw_text(XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, GRAPH_ALPHA_25,
                    (text_outline) ? GRAPH_BG_OUTLINE : GRAPH_BG_SHADOW, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
-                   (!shifted) ? vkeys[(y * VKBDX) + x + page].normal : vkeys[(y * VKBDX) + x + page].shift);
+                   text_str);
       }
    }
 

--- a/retrodep/lightpendrv.c
+++ b/retrodep/lightpendrv.c
@@ -1,0 +1,70 @@
+/*
+ * lightpendrv.c - Lightpen driver for SDL UI.
+ *
+ * Written by
+ *  Hannu Nuotio <hannu.nuotio@tut.fi>
+ *
+ * This file is part of VICE, the Versatile Commodore Emulator.
+ * See README for copyright notice.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ *  02111-1307  USA.
+ *
+ */
+
+#include "vice.h"
+#include "types.h"
+
+#include <stdio.h>
+
+#include "machine.h"
+#include "lightpen.h"
+#include "lightpendrv.h"
+#include "videoarch.h"
+
+#include "libretro-core.h"
+extern int retro_ui_get_pointer_state(int *px, int *py, unsigned int *pbuttons);
+
+/* ------------------------------------------------------------------ */
+/* External interface */
+
+void retro_lightpen_update(void)
+{
+    int x, y, screen_num;
+    unsigned int buttons;
+
+    if (!lightpen_enabled) {
+        return;
+    }
+    
+    if (!retro_ui_get_pointer_state(&x, &y, &buttons)) {
+        x = y = -1;
+        buttons = 0;
+    }
+
+#ifdef RETRO_DEBUG
+    fprintf(stderr, "%s : x = %i, y = %i, buttons = %02x\n", __func__, x, y, buttons);
+#endif
+
+    screen_num = 0;
+
+    /* HACK: In x128, the VDC window is 0, but sdl/video.c uses the canvas
+       init order (which for some reason is the reverse) for enumeration. */
+    if (machine_class == VICE_MACHINE_C128) {
+        screen_num ^= 1;
+    }
+
+    lightpen_update(screen_num, x, y, (int)buttons);
+}

--- a/retrodep/lightpendrv.h
+++ b/retrodep/lightpendrv.h
@@ -1,0 +1,35 @@
+/*
+ * lightpendrv.h - Lightpen driver for SDL UI.
+ *
+ * Written by
+ *  Hannu Nuotio <hannu.nuotio@tut.fi>
+ *
+ * This file is part of VICE, the Versatile Commodore Emulator.
+ * See README for copyright notice.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ *  02111-1307  USA.
+ *
+ */
+
+#ifndef VICE_LIGHTPENDRV_H
+#define VICE_LIGHTPENDRV_H
+
+#include "vice.h"
+#include "types.h"
+
+extern void retro_lightpen_update(void);
+
+#endif

--- a/retrodep/uistatusbar.c
+++ b/retrodep/uistatusbar.c
@@ -130,8 +130,11 @@ static void display_joyport(void)
     sprintf(joy1, "%s", "1");
     sprintf(joy2, "%s", "2");
 
+    /* Lightpen/gun */
+    if (opt_joyport_type > 10 && cur_port == 1)
+        sprintf(tmpstr, "L%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
     /* Mouse */
-    if (opt_joyport_type > 2 && cur_port == 1)
+    else if (opt_joyport_type > 2 && cur_port == 1)
         sprintf(tmpstr, "M%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
     /* Paddles */
     else if (opt_joyport_type == 2 && cur_port == 1)
@@ -140,8 +143,11 @@ static void display_joyport(void)
     else
         sprintf(tmpstr, "J%s%3s ", joy1, joystick_value_human(joystick_value[1], 0));
 
+    /* Lightpen/gun */
+    if (opt_joyport_type > 10 && cur_port == 2)
+        sprintf(tmpstr + strlen(tmpstr), "L%s%3s ", joy2, joystick_value_human(mouse_value[2], 1));
     /* Mouse */
-    if (opt_joyport_type > 2 && cur_port == 2)
+    else if (opt_joyport_type > 2 && cur_port == 2)
         sprintf(tmpstr + strlen(tmpstr), "M%s%3s ", joy2, joystick_value_human(mouse_value[2], 1));
     /* Paddles */
     else if (opt_joyport_type == 2 && cur_port == 2)
@@ -153,8 +159,11 @@ static void display_joyport(void)
     char joy1[2];
     sprintf(joy1, "%s", "1");
 
+    /* Lightpen/gun */
+    if (opt_joyport_type > 10)
+        sprintf(tmpstr, "L%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
     /* Mouse */
-    if (opt_joyport_type > 2)
+    else if (opt_joyport_type > 2)
        sprintf(tmpstr, "M%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
     /* Paddles */
     else if (opt_joyport_type == 2)

--- a/retrodep/uistatusbar.c
+++ b/retrodep/uistatusbar.c
@@ -471,10 +471,10 @@ void ui_display_drive_current_image(unsigned int unit_number, unsigned int drive
 
 /* Tape related UI */
 
-static int tape_counter = 0;
-static int tape_enabled = 0;
-static int tape_motor = 0;
+int tape_enabled = 0;
 int tape_control = 0;
+int tape_counter = 0;
+static int tape_motor = 0;
 
 static void display_tape(void)
 {

--- a/retrodep/vsyncarch.c
+++ b/retrodep/vsyncarch.c
@@ -6,6 +6,7 @@
 #include "vice.h"
 
 #include "kbdbuf.h"
+#include "lightpendrv.h"
 #include "ui.h"
 #include "uistatusbar.h"
 #include "vsyncapi.h"
@@ -70,6 +71,7 @@ void vsyncarch_presync(void)
     }
 
     retro_renderloop = 0;
+    retro_lightpen_update();
 }
 
 void vsyncarch_postsync(void)

--- a/vice/src/drive/drive.c
+++ b/vice/src/drive/drive.c
@@ -80,6 +80,7 @@ extern unsigned int opt_autoloadwarp;
 extern unsigned int retro_warpmode;
 extern int retro_warp_mode_enabled();
 extern bool retro_disk_get_eject_state();
+extern unsigned int vice_led_state[3];
 static int warpmode_counter_ledon = 0;
 static int warpmode_counter_ledoff = 0;
 static int drive_half_track_prev = 0;
@@ -855,7 +856,7 @@ void drive_update_ui_status(void)
             {
                 int warp = -1;
                 int drive_half_track = drive0->current_half_track;
-                int drive_led_status = drive0->led_status;
+                int drive_led_status = vice_led_state[1];
 
                 if ((drive_half_track != drive_half_track_prev) && !retro_warp_mode_enabled())
                 {


### PR DESCRIPTION
Major:
- More joyport types: Light pens and guns
   - Only mouse + touch control for now

Bonus 3.5 regression fixes:
- Force drive autodetect to 1541-II to prevent unwanted type changes, because change resets the drive, and if a game (Metal Gear) has programmed the drive, disk change will break the game
- Autoloadwarp can't trust LED status that is given to it, because some games (Hostages) will fluctuate PWM enough for the LED to go on and off, causing warp to get stuck, bypassing the very safety measure that is trying to prevent warp from getting stuck (!)

Regular bonus:
- Datasette counter also to VKBD, so that statusbar isn't required for Datasette usage