### PR TITLE
Drive type + JiffyDOS fix, Maximum SIDs

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2616,7 +2616,7 @@ void retro_set_environment(retro_environment_t cb)
          },
          "20%"
       },
-#if !defined(__X64DTV__)
+#if !defined(__XSCPU64__) && !defined(__X64DTV__)
       {
          "vice_datasette_sound",
          "Audio > Datasette Sound",
@@ -3039,7 +3039,7 @@ void retro_set_environment(retro_environment_t cb)
          },
          "disabled"
       },
-#if !defined(__X64DTV__)
+#if !defined(__XSCPU64__) && !defined(__X64DTV__)
       {
          "vice_datasette_hotkeys",
          "Input > Datasette Hotkeys",
@@ -3117,7 +3117,7 @@ void retro_set_environment(retro_environment_t cb)
          "---"
       },
 #endif
-#if !defined(__X64DTV__)
+#if !defined(__XSCPU64__) && !defined(__X64DTV__)
       /* Datasette controls */
       {
          "vice_mapper_datasette_toggle_hotkeys",
@@ -3599,7 +3599,7 @@ int log_resources_set_int(const char *name, int value)
    return resources_set_int(name, value);
 }
 
-int log_resources_set_string(const char *name, const char* value)
+int log_resources_set_string(const char *name, const char *value)
 {
    log_cb(RETRO_LOG_INFO, "Set resource: %s => \"%s\"\n", name, value);
    return resources_set_string(name, value);
@@ -3813,7 +3813,7 @@ static void update_variables(void)
          resources_set_int("DriveSoundEmulationVolume", 0);
    }
 
-#if !defined(__X64DTV__)
+#if !defined(__XSCPU64__) && !defined(__X64DTV__)
    var.key = "vice_datasette_sound";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -5230,7 +5230,7 @@ static void update_variables(void)
       mapper_keys[RETRO_MAPPER_WARP_MODE] = retro_keymap_id(var.value);
    }
 
-#if !defined(__X64DTV__)
+#if !defined(__XSCPU64__) && !defined(__X64DTV__)
    var.key = "vice_datasette_hotkeys";
    var.value = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -5346,7 +5346,7 @@ static void update_variables(void)
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
    option_display.key = "vice_mapper_warp_mode";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
-#if !defined(__X64DTV__)
+#if !defined(__XSCPU64__) && !defined(__X64DTV__)
    option_display.key = "vice_mapper_datasette_toggle_hotkeys";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
    option_display.key = "vice_mapper_datasette_start";
@@ -5366,7 +5366,7 @@ static void update_variables(void)
 
    option_display.key = "vice_drive_sound_emulation";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
-#if !defined(__X64DTV__)
+#if !defined(__XSCPU64__) && !defined(__X64DTV__)
    option_display.key = "vice_datasette_sound";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 #endif

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1197,10 +1197,9 @@ static void autodetect_drivetype(int unit)
          /* Also happens when toggling TDE */
          switch (set_drive_type)
          {
-            case DISK_IMAGE_TYPE_G64:
-            case DISK_IMAGE_TYPE_G71:
-            case DISK_IMAGE_TYPE_D64:
-            case DISK_IMAGE_TYPE_D71:
+            case DRIVE_TYPE_1541:
+            case DRIVE_TYPE_1541II:
+            case DRIVE_TYPE_1571:
                resources_set_int("DriveSoundEmulationVolume", vice_opt.DriveSoundEmulation);
                break;
             default:
@@ -1285,7 +1284,7 @@ void update_work_disk()
          {
             log_cb(RETRO_LOG_INFO, "Work disk '%s' detached from drive #%d\n", attached_image, 8);
             file_system_detach_disk(8, 0);
-            log_resources_set_int("Drive8Type", DRIVE_TYPE_1541);
+            log_resources_set_int("Drive8Type", DRIVE_TYPE_DEFAULT);
             display_current_image(attached_image, false);
          }
       }
@@ -6557,8 +6556,11 @@ static void save_trap(uint16_t addr, void *success)
 {
    int save_disks;
    int drive_type;
+   /* Only do 'save_disks' with the usual suspect which has disk swapping needs
+    * It does not really save disk data, but filename instead,
+    * for syncing disk index on state load */
    resources_get_int("Drive8Type", &drive_type);
-   save_disks = (drive_type == 1541) ? 1 : 0;
+   save_disks = (drive_type == DRIVE_TYPE_1541II) ? 1 : 0;
 
    /* params: stream, save_roms, save_disks, event_mode */
    if (machine_write_snapshot_to_stream(snapshot_stream, 0, save_disks, 0) >= 0)

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -183,6 +183,7 @@ enum
 /* Functions */
 extern long retro_ticks(void);
 extern void reload_restart(void);
+extern void emu_reset(int type);
 extern int RGB(int r, int g, int b);
 
 /* VICE options */

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -242,34 +242,42 @@ struct vice_cart_info
 
 /* VICE includes */
 #if defined(__X64__) || defined(__X64SC__)
+#define DRIVE_TYPE_DEFAULT 1542
 #include "c64.h"
 #include "c64mem.h"
 #include "c64model.h"
 #elif defined(__XSCPU64__)
+#define DRIVE_TYPE_DEFAULT 1542
 #include "scpu64.h"
 #include "scpu64mem.h"
 #include "c64model.h"
 #elif defined(__X64DTV__)
+#define DRIVE_TYPE_DEFAULT 0
 #include "c64dtv.h"
 #include "c64dtvmem.h"
 #include "c64dtvmodel.h"
 #elif defined(__X128__)
+#define DRIVE_TYPE_DEFAULT 1571
 #include "c128.h"
 #include "c128mem.h"
 #include "c128model.h"
 #elif defined(__XVIC__)
+#define DRIVE_TYPE_DEFAULT 1540
 #include "vic20.h"
 #include "vic20mem.h"
 #include "vic20model.h"
 #include "vic20cart.h"
 #include "vic20-generic.h"
 #elif defined(__XPLUS4__)
+#define DRIVE_TYPE_DEFAULT 1551
 #include "plus4.h"
 #include "plus4model.h"
 #elif defined(__XCBM2__) || defined(__XCBM5x0__)
+#define DRIVE_TYPE_DEFAULT 2031
 #include "cbm2.h"
 #include "cbm2model.h"
 #elif defined(__XPET__)
+#define DRIVE_TYPE_DEFAULT 2031
 #include "pet.h"
 #include "petmodel.h"
 #endif

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -1109,7 +1109,7 @@ void dc_parse_list(dc_storage* dc, const char* list_file, bool is_vfl, const cha
             case 8:
                /* Detach & disable tape, enable drive 8 */
                tape_deinstall();
-               log_resources_set_int("Drive8Type", DRIVE_TYPE_1541);
+               log_resources_set_int("Drive8Type", DRIVE_TYPE_DEFAULT);
                break;
 
             case 0:

--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -33,5 +33,6 @@ char* path_join_dup(const char* basedir, const char* filename);
 
 /* VICE helpers */
 extern int log_resources_set_int(const char *name, int value);
+extern int log_resources_set_string(const char *name, const char *value);
 
 #endif /* LIBRETRO_GLUE_H */

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -96,7 +96,6 @@ extern unsigned int opt_analogmouse_deadzone;
 extern float opt_analogmouse_speed;
 bool datasette_hotkeys = false;
 
-extern void emu_reset(int type);
 extern unsigned int zoom_mode_id;
 extern int zoom_mode_id_prev;
 extern unsigned int opt_zoom_mode_id;

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -428,13 +428,19 @@ int ui_init_finalize(void)
    log_resources_set_int("SidResid8580Gain", vice_opt.SidResidGain);
    log_resources_set_int("SidResid8580FilterBias", vice_opt.SidResid8580FilterBias);
 
-   if (vice_opt.SidExtra)
+   int sid_stereo;
+   resources_get_int("SidStereo", &sid_stereo);
+   /* Do not override if SidStereo is set in vicerc */
+   if (sid_stereo == 0)
    {
-      log_resources_set_int("Sid2AddressStart", vice_opt.SidExtra);
-      log_resources_set_int("SidStereo", 1);
+      if (vice_opt.SidExtra)
+      {
+         log_resources_set_int("Sid2AddressStart", vice_opt.SidExtra);
+         log_resources_set_int("SidStereo", 1);
+      }
+      else
+         log_resources_set_int("SidStereo", 0);
    }
-   else
-      log_resources_set_int("SidStereo", 0);
 #else
    log_resources_set_int("SidEngine", 0);
 #endif

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -312,6 +312,7 @@ int ui_init_finalize(void)
    }
 #endif
 
+   /* JiffyDOS */
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
    /* Replace kernal always from backup, because kernal loading replaces the embedded variable */
 #if defined(__X64__) || defined(__X64SC__)
@@ -323,6 +324,16 @@ int ui_init_finalize(void)
    char tmp_str[RETRO_PATH_MAX] = {0};
    if (opt_jiffydos)
    {
+      int drive_type;
+      resources_get_int("Drive8Type", &drive_type);
+
+      snprintf(tmp_str, sizeof(tmp_str), "%s%c%s", retro_system_data_directory, FSDEV_DIR_SEP_CHR, "JiffyDOS_1541-II.bin");
+      log_resources_set_string("DosName1541ii", (const char*)tmp_str);
+      snprintf(tmp_str, sizeof(tmp_str), "%s%c%s", retro_system_data_directory, FSDEV_DIR_SEP_CHR, "JiffyDOS_1571_repl310654.bin");
+      log_resources_set_string("DosName1571", (const char*)tmp_str);
+      snprintf(tmp_str, sizeof(tmp_str), "%s%c%s", retro_system_data_directory, FSDEV_DIR_SEP_CHR, "JiffyDOS_1581.bin");
+      log_resources_set_string("DosName1581", (const char*)tmp_str);
+
 #if defined(__X64__) || defined(__X64SC__)
       snprintf(tmp_str, sizeof(tmp_str), "%s%c%s", retro_system_data_directory, FSDEV_DIR_SEP_CHR, "JiffyDOS_C64.bin");
       log_resources_set_string("KernalName", (const char*)tmp_str);
@@ -332,24 +343,23 @@ int ui_init_finalize(void)
       snprintf(tmp_str, sizeof(tmp_str), "%s%c%s", retro_system_data_directory, FSDEV_DIR_SEP_CHR, "JiffyDOS_C128.bin");
       log_resources_set_string("KernalIntName", (const char*)tmp_str);
 #endif
-      snprintf(tmp_str, sizeof(tmp_str), "%s%c%s", retro_system_data_directory, FSDEV_DIR_SEP_CHR, "JiffyDOS_1541-II.bin");
-      log_resources_set_string("DosName1541", (const char*)tmp_str);
-      snprintf(tmp_str, sizeof(tmp_str), "%s%c%s", retro_system_data_directory, FSDEV_DIR_SEP_CHR, "JiffyDOS_1571_repl310654.bin");
-      log_resources_set_string("DosName1571", (const char*)tmp_str);
-      snprintf(tmp_str, sizeof(tmp_str), "%s%c%s", retro_system_data_directory, FSDEV_DIR_SEP_CHR, "JiffyDOS_1581.bin");
-      log_resources_set_string("DosName1581", (const char*)tmp_str);
+
+#if defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__)
+      /* 1541-II ROM will not work unless drive type is set back to whatever it already is ?! */
+      log_resources_set_int("Drive8Type", drive_type);
+#endif
    }
    else
    {
+      log_resources_set_string("DosName1541ii", "d1541II");
+      log_resources_set_string("DosName1571", "dos1571");
+      log_resources_set_string("DosName1581", "dos1581");
 #if defined(__X64__) || defined(__X64SC__)
       log_resources_set_string("KernalName", "kernal");
 #elif defined(__X128__)
       log_resources_set_string("Kernal64Name", "kernal64");
       log_resources_set_string("KernalIntName", "kernal");
 #endif
-      log_resources_set_string("DosName1541", "dos1541");
-      log_resources_set_string("DosName1571", "dos1571");
-      log_resources_set_string("DosName1581", "dos1581");
    }
 #endif
 

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -393,10 +393,12 @@ int ui_init_finalize(void)
    if (opt_autoloadwarp & AUTOLOADWARP_DISK)
       log_resources_set_int("DriveSoundEmulationVolume", 0);
 
+#if !defined(__XSCPU64__) && !defined(__X64DTV__)
    if (vice_opt.DatasetteSound)
       log_resources_set_int("DatasetteSound", 1);
    else
       log_resources_set_int("DatasetteSound", 0);
+#endif
 
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__)
    log_resources_set_int("VICIIAudioLeak", vice_opt.AudioLeak);

--- a/vice/src/sound.h
+++ b/vice/src/sound.h
@@ -65,8 +65,6 @@
 #ifdef __LIBRETRO__
 #define SOUND_SAMPLE_RATE 48000
 #define SOUND_SAMPLE_BUFFER_SIZE 20
-#define SOUND_CHANNELS_MAX 2
-#define SOUND_SIDS_MAX 2
 
 #else
 
@@ -78,10 +76,10 @@
 #define SOUND_SAMPLE_BUFFER_SIZE 26
 #endif
 
-#define SOUND_CHANNELS_MAX 2
-#define SOUND_SIDS_MAX 8
 #endif /* __LIBRETRO__ */
 
+#define SOUND_CHANNELS_MAX 2
+#define SOUND_SIDS_MAX 8
 #define SOUND_CHIPS_MAX 20
 
 


### PR DESCRIPTION
Drive type related fixes:
- Savestate + disc control index sync with D64 multidisks
- JiffyDOS with D64s

Other:
- Removed useless SID limitation and prevented `SidStereo` in `vicerc` from being overwritten with the core option
- Removed unusable core options from SuperCPU
