### PR TITLE
Input additions

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -6576,6 +6576,16 @@ static void load_trap(uint16_t addr, void *success)
    load_trap_happened = 1;
 }
 
+static void retro_unserialize_post(void)
+{
+   /* Disable warp */
+   resources_set_int("WarpMode", 0);
+   /* Dismiss possible restart request */
+   request_restart = false;
+   /* Sync Disc Control index for D64 multidisks */
+   dc_sync_index();
+}
+
 size_t retro_serialize_size(void)
 {
    long snapshot_size = 0;
@@ -6662,8 +6672,7 @@ bool retro_unserialize(const void *data_, size_t size)
       }
       if (success)
       {
-         resources_set_int("WarpMode", 0);
-         dc_sync_index();
+         retro_unserialize_post();
          return true;
       }
       log_cb(RETRO_LOG_INFO, "Failed to unserialize snapshot\n");

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2876,6 +2876,19 @@ void retro_set_environment(retro_environment_t cb)
       },
 #if !defined(__XPET__) && !defined(__XCBM2__)
       {
+         "vice_analogmouse",
+         "Input > Analog Stick Mouse",
+         "Override analog stick remappings when non-joysticks are used. 'OFF' controls mouse/paddles with both analogs when remappings are empty.",
+         {
+            { "disabled", NULL },
+            { "left", "Left Analog" },
+            { "right", "Right Analog" },
+            { "both", "Both Analogs" },
+            { NULL, NULL },
+         },
+         "left"
+      },
+      {
          "vice_analogmouse_deadzone",
          "Input > Analog Stick Mouse Deadzone",
          "",
@@ -4802,6 +4815,16 @@ static void update_variables(void)
       else if (!strcmp(var.value, "yellow"))   opt_joyport_pointer_color = 5;
       else if (!strcmp(var.value, "cyan"))     opt_joyport_pointer_color = 6;
       else if (!strcmp(var.value, "purple"))   opt_joyport_pointer_color = 7;
+   }
+
+   var.key = "vice_analogmouse";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if      (!strcmp(var.value, "disabled")) opt_analogmouse = 0;
+      else if (!strcmp(var.value, "left"))     opt_analogmouse = 1;
+      else if (!strcmp(var.value, "right"))    opt_analogmouse = 2;
+      else if (!strcmp(var.value, "both"))     opt_analogmouse = 3;
    }
 
    var.key = "vice_analogmouse_deadzone";

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -63,6 +63,7 @@ static void retro_mouse_move(int x, int y)
 
 /* Core flags */
 int mapper_keys[RETRO_MAPPER_LAST] = {0};
+static int mapper_flag[3][128] = {0};
 int vkflag[10] = {0};
 int retro_capslock = false;
 unsigned int cur_port = 2;
@@ -609,6 +610,22 @@ void update_input(unsigned disable_keys)
                   mouse_speed[j] |= MOUSE_SPEED_SLOWER;
                else if (mapper_keys[i] == MOUSE_FASTER)
                   mouse_speed[j] |= MOUSE_SPEED_FASTER;
+               else if (mapper_keys[i] == JOYSTICK_FIRE)
+                  mapper_flag[cur_port][JOYPAD_FIRE] = 1;
+               else if (mapper_keys[i] == JOYSTICK_FIRE2)
+                  mapper_flag[cur_port][JOYPAD_FIRE2] = 1;
+               else if (mapper_keys[i] == JOYSTICK_FIRE3)
+                  mapper_flag[cur_port][JOYPAD_FIRE3] = 1;
+               else if (mapper_keys[i] == OTHERJOY_FIRE)
+                  mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_FIRE] = 1;
+               else if (mapper_keys[i] == OTHERJOY_UP)
+                  mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_N] = 1;
+               else if (mapper_keys[i] == OTHERJOY_DOWN)
+                  mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_S] = 1;
+               else if (mapper_keys[i] == OTHERJOY_LEFT)
+                  mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_W] = 1;
+               else if (mapper_keys[i] == OTHERJOY_RIGHT)
+                  mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_E] = 1;
                else if (mapper_keys[i] == TOGGLE_VKBD)
                   emu_function(EMU_VKBD);
                else if (mapper_keys[i] == TOGGLE_STATUSBAR)
@@ -654,6 +671,22 @@ void update_input(unsigned disable_keys)
                   mouse_speed[j] &= ~MOUSE_SPEED_SLOWER;
                else if (mapper_keys[i] == MOUSE_FASTER)
                   mouse_speed[j] &= ~MOUSE_SPEED_FASTER;
+               else if (mapper_keys[i] == JOYSTICK_FIRE)
+                  mapper_flag[cur_port][JOYPAD_FIRE] = 0;
+               else if (mapper_keys[i] == JOYSTICK_FIRE2)
+                  mapper_flag[cur_port][JOYPAD_FIRE2] = 0;
+               else if (mapper_keys[i] == JOYSTICK_FIRE3)
+                  mapper_flag[cur_port][JOYPAD_FIRE3] = 0;
+               else if (mapper_keys[i] == OTHERJOY_FIRE)
+                  mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_FIRE] = 0;
+               else if (mapper_keys[i] == OTHERJOY_UP)
+                  mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_N] = 0;
+               else if (mapper_keys[i] == OTHERJOY_DOWN)
+                  mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_S] = 0;
+               else if (mapper_keys[i] == OTHERJOY_LEFT)
+                  mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_W] = 0;
+               else if (mapper_keys[i] == OTHERJOY_RIGHT)
+                  mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_E] = 0;
                else if (mapper_keys[i] == TOGGLE_VKBD)
                   ; /* nop */
                else if (mapper_keys[i] == TOGGLE_STATUSBAR)
@@ -1178,10 +1211,12 @@ void retro_poll_event()
                   )
                )
             )
+         || (vice_port < 3 && mapper_flag[vice_port][JOYPAD_N])
          )
-            joy_value |= (!retro_vkbd) ? 0x01 : joy_value;
-         else if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_UP)))
-            joy_value &= ~0x01;
+            joy_value |= (!retro_vkbd) ? JOYPAD_N : joy_value;
+         else if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_UP))
+              && (vice_port < 3 && !mapper_flag[vice_port][JOYPAD_N]))
+            joy_value &= ~JOYPAD_N;
 
          /* Down */
          if (((joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_DOWN))
@@ -1199,10 +1234,12 @@ void retro_poll_event()
                   )
                )
             )
+         || (vice_port < 3 && mapper_flag[vice_port][JOYPAD_S])
          )
-            joy_value |= (!retro_vkbd) ? 0x02 : joy_value;
-         else if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_DOWN)))
-            joy_value &= ~0x02;
+            joy_value |= (!retro_vkbd) ? JOYPAD_S : joy_value;
+         else if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_DOWN))
+              && (vice_port < 3 && !mapper_flag[vice_port][JOYPAD_S]))
+            joy_value &= ~JOYPAD_S;
 
          /* Left */
          if (((joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_LEFT))
@@ -1220,10 +1257,12 @@ void retro_poll_event()
                   )
                )
             )
+         || (vice_port < 3 && mapper_flag[vice_port][JOYPAD_W])
          )
-            joy_value |= (!retro_vkbd) ? 0x04 : joy_value;
-         else if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_LEFT)))
-            joy_value &= ~0x04;
+            joy_value |= (!retro_vkbd) ? JOYPAD_W : joy_value;
+         else if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_LEFT))
+              && (vice_port < 3 && !mapper_flag[vice_port][JOYPAD_W]))
+            joy_value &= ~JOYPAD_W;
 
          /* Right */
          if (((joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT))
@@ -1241,10 +1280,12 @@ void retro_poll_event()
                   )
                )
             )
+         || (vice_port < 3 && mapper_flag[vice_port][JOYPAD_E])
          )
-            joy_value |= (!retro_vkbd) ? 0x08 : joy_value;
-         else if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT)))
-            joy_value &= ~0x08;
+            joy_value |= (!retro_vkbd) ? JOYPAD_E : joy_value;
+         else if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT))
+              && (vice_port < 3 && !mapper_flag[vice_port][JOYPAD_E]))
+            joy_value &= ~JOYPAD_E;
 
          /* Fire button */
          int fire_button = RETRO_DEVICE_ID_JOYPAD_B;
@@ -1270,10 +1311,12 @@ void retro_poll_event()
                   (vice_port == cur_port && input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0, RETROK_KP5))
                )
             )
+         || (vice_port < 3 && mapper_flag[vice_port][JOYPAD_FIRE])
          )
-            joy_value |= (!retro_vkbd) ? 0x10 : joy_value;
-         else
-            joy_value &= ~0x10;
+            joy_value |= (!retro_vkbd) ? JOYPAD_FIRE : joy_value;
+         else if (!(joypad_bits[retro_port] & (1 << fire_button))
+              && (vice_port < 3 && !mapper_flag[vice_port][JOYPAD_FIRE]))
+            joy_value &= ~JOYPAD_FIRE;
 
          /* Jump button */
          int jump_button = -1;
@@ -1295,8 +1338,8 @@ void retro_poll_event()
 
          if (jump_button > -1 && (joypad_bits[retro_port] & (1 << jump_button)))
          {
-            joy_value |= (!retro_vkbd) ? 0x01 : joy_value;
-            joy_value &= ~0x02;
+            joy_value |= (!retro_vkbd) ? JOYPAD_N : joy_value;
+            joy_value &= ~JOYPAD_S;
          }
          else if (!(joypad_bits[retro_port] & (1 << RETRO_DEVICE_ID_JOYPAD_UP))
          && (opt_keyrah_keypad && vice_port < 3
@@ -1311,7 +1354,18 @@ void retro_poll_event()
                )
             )
          )
-            joy_value &= ~0x01;
+            joy_value &= ~JOYPAD_N;
+
+         /* Extra fire buttons */
+         if (vice_port < 3 && mapper_flag[vice_port][JOYPAD_FIRE2])
+            joy_value |= (!retro_vkbd) ? JOYPAD_FIRE2 : joy_value;
+         else if (vice_port < 3 && !mapper_flag[vice_port][JOYPAD_FIRE2])
+            joy_value &= ~JOYPAD_FIRE2;
+
+         if (vice_port < 3 && mapper_flag[vice_port][JOYPAD_FIRE3])
+            joy_value |= (!retro_vkbd) ? JOYPAD_FIRE3 : joy_value;
+         else if (vice_port < 3 && !mapper_flag[vice_port][JOYPAD_FIRE3])
+            joy_value &= ~JOYPAD_FIRE3;
 
          /* Turbo fire */
          if (retro_devices[retro_port] == RETRO_DEVICE_JOYPAD
@@ -1328,20 +1382,28 @@ void retro_poll_event()
                      turbo_toggle[vice_port]++;
 
                   if (turbo_toggle[vice_port] > (turbo_pulse / 2))
-                     joy_value &= ~0x10;
+                  {
+                     joy_value &= ~JOYPAD_FIRE;
+                     mapper_flag[vice_port][JOYPAD_FIRE] = 0;
+                  }
                   else
-                     joy_value |= (!retro_vkbd) ? 0x10 : joy_value;
+                  {
+                     joy_value |= (!retro_vkbd) ? JOYPAD_FIRE : joy_value;
+                     mapper_flag[vice_port][JOYPAD_FIRE] = 1;
+                  }
                }
                else
                {
                   turbo_state[vice_port] = 1;
-                  joy_value |= (!retro_vkbd) ? 0x10 : joy_value;
+                  joy_value |= (!retro_vkbd) ? JOYPAD_FIRE : joy_value;
+                  mapper_flag[vice_port][JOYPAD_FIRE] = 1;
                }
             }
             else
             {
                turbo_state[vice_port] = 0;
                turbo_toggle[vice_port] = 0;
+               mapper_flag[vice_port][JOYPAD_FIRE] = 0;
             }
          }
 
@@ -1561,64 +1623,64 @@ void retro_poll_event()
          if (retro_mouse_l[j] && !vice_mouse_l[j])
          {
             mouse_button(0, 1);
-            mouse_value[retro_j] |= 0x10;
+            mouse_value[retro_j] |= JOYPAD_FIRE;
             vice_mouse_l[j] = 1;
          }
          else if (!retro_mouse_l[j] && vice_mouse_l[j])
          {
             mouse_button(0, 0);
-            mouse_value[retro_j] &= ~0x10;
+            mouse_value[retro_j] &= ~JOYPAD_FIRE;
             vice_mouse_l[j] = 0;
          }
 
          if (retro_mouse_r[j] && !vice_mouse_r[j])
          {
             mouse_button(1, 1);
-            mouse_value[retro_j] |= 0x20;
+            mouse_value[retro_j] |= JOYPAD_FIRE2;
             vice_mouse_r[j] = 1;            
          }
          else if (!retro_mouse_r[j] && vice_mouse_r[j])
          {
             mouse_button(1, 0);
-            mouse_value[retro_j] &= ~0x20;
+            mouse_value[retro_j] &= ~JOYPAD_FIRE2;
             vice_mouse_r[j] = 0;            
          }
 
          if (retro_mouse_m[j] && !vice_mouse_m[j])
          {
             mouse_button(2, 1);
-            mouse_value[retro_j] |= 0x40;
+            mouse_value[retro_j] |= JOYPAD_FIRE3;
             vice_mouse_m[j] = 1;
          }
          else if (!retro_mouse_m[j] && vice_mouse_m[j])
          {
             mouse_button(2, 0);
-            mouse_value[retro_j] &= ~0x40;
+            mouse_value[retro_j] &= ~JOYPAD_FIRE3;
             vice_mouse_m[j] = 0;
          }
 
          /* Movement */
          if (retro_mouse_x[j] || retro_mouse_y[j])
          {
-            if (retro_mouse_y[j] < 0 && !(mouse_value[retro_j] & 0x01))
-               mouse_value[retro_j] |= 0x01;
-            if (retro_mouse_y[j] > -1 && mouse_value[retro_j] & 0x01)
-               mouse_value[retro_j] &= ~0x01;
+            if (retro_mouse_y[j] < 0 && !(mouse_value[retro_j] & JOYPAD_N))
+               mouse_value[retro_j] |= JOYPAD_N;
+            if (retro_mouse_y[j] > -1 && mouse_value[retro_j] & JOYPAD_N)
+               mouse_value[retro_j] &= ~JOYPAD_N;
 
-            if (retro_mouse_y[j] > 0 && !(mouse_value[retro_j] & 0x02))
-               mouse_value[retro_j] |= 0x02;
-            if (retro_mouse_y[j] < -1 && mouse_value[retro_j] & 0x02)
-               mouse_value[retro_j] &= ~0x02;
+            if (retro_mouse_y[j] > 0 && !(mouse_value[retro_j] & JOYPAD_S))
+               mouse_value[retro_j] |= JOYPAD_S;
+            if (retro_mouse_y[j] < -1 && mouse_value[retro_j] & JOYPAD_S)
+               mouse_value[retro_j] &= ~JOYPAD_S;
 
-            if (retro_mouse_x[j] < 0 && !(mouse_value[retro_j] & 0x04))
-               mouse_value[retro_j] |= 0x04;
-            if (retro_mouse_x[j] > -1 && mouse_value[retro_j] & 0x04)
-               mouse_value[retro_j] &= ~0x04;
+            if (retro_mouse_x[j] < 0 && !(mouse_value[retro_j] & JOYPAD_W))
+               mouse_value[retro_j] |= JOYPAD_W;
+            if (retro_mouse_x[j] > -1 && mouse_value[retro_j] & JOYPAD_W)
+               mouse_value[retro_j] &= ~JOYPAD_W;
 
-            if (retro_mouse_x[j] > 0 && !(mouse_value[retro_j] & 0x08))
-               mouse_value[retro_j] |= 0x08;
-            if (retro_mouse_x[j] < -1 && mouse_value[retro_j] & 0x08)
-               mouse_value[retro_j] &= ~0x08;
+            if (retro_mouse_x[j] > 0 && !(mouse_value[retro_j] & JOYPAD_E))
+               mouse_value[retro_j] |= JOYPAD_E;
+            if (retro_mouse_x[j] < -1 && mouse_value[retro_j] & JOYPAD_E)
+               mouse_value[retro_j] &= ~JOYPAD_E;
 
             retro_mouse_move(retro_mouse_x[j], retro_mouse_y[j]);
          }

--- a/libretro/libretro-mapper.h
+++ b/libretro/libretro-mapper.h
@@ -39,6 +39,22 @@
 #define SWITCH_JOYPORT                  -13
 #define MOUSE_SLOWER                    -5
 #define MOUSE_FASTER                    -6
+#define JOYSTICK_FIRE                   -7
+#define JOYSTICK_FIRE2                  -8
+#define JOYSTICK_FIRE3                  -9
+#define OTHERJOY_FIRE                   -21
+#define OTHERJOY_UP                     -22
+#define OTHERJOY_DOWN                   -23
+#define OTHERJOY_LEFT                   -24
+#define OTHERJOY_RIGHT                  -25
+
+#define JOYPAD_N                        0x01
+#define JOYPAD_S                        0x02
+#define JOYPAD_W                        0x04
+#define JOYPAD_E                        0x08
+#define JOYPAD_FIRE                     0x10
+#define JOYPAD_FIRE2                    0x20
+#define JOYPAD_FIRE3                    0x40
 
 extern int mapper_keys[RETRO_MAPPER_LAST];
 extern void retro_poll_event();
@@ -57,6 +73,14 @@ static retro_keymap retro_keys[RETROK_LAST] =
    {TOGGLE_VKBD,        "TOGGLE_VKBD",         "Toggle Virtual Keyboard"},
    {TOGGLE_STATUSBAR,   "TOGGLE_STATUSBAR",    "Toggle Statusbar"},
    {SWITCH_JOYPORT,     "SWITCH_JOYPORT",      "Switch Joyport"},
+   {JOYSTICK_FIRE,      "JOYSTICK_FIRE",       "Joystick Fire"},
+   {JOYSTICK_FIRE2,     "JOYSTICK_FIRE2",      "Joystick Fire 2"},
+   {JOYSTICK_FIRE3,     "JOYSTICK_FIRE3",      "Joystick Fire 3"},
+   {OTHERJOY_FIRE,      "OTHERJOY_FIRE",       "Other Joyport Fire"},
+   {OTHERJOY_UP,        "OTHERJOY_UP",         "Other Joyport Up"},
+   {OTHERJOY_DOWN,      "OTHERJOY_DOWN",       "Other Joyport Down"},
+   {OTHERJOY_LEFT,      "OTHERJOY_LEFT",       "Other Joyport Left"},
+   {OTHERJOY_RIGHT,     "OTHERJOY_RIGHT",      "Other Joyport Right"},
    {MOUSE_SLOWER,       "MOUSE_SLOWER",        "Mouse Slower"},
    {MOUSE_FASTER,       "MOUSE_FASTER",        "Mouse Faster"},
    {RETROK_BACKSPACE,   "RETROK_BACKSPACE",    "Keyboard Backspace"},


### PR DESCRIPTION
Inputs:
- New mapping options for joystick fire 1/2/3
   - For those rare games that read them
- New mapping options for other joyport fire and directions
  - For simple twinstick use
- New core option for overriding non-joysticks to none/left/right/both analog sticks, defaults to current behavior (left stick). None means both sticks work if the stick remaps are empty, and overrides replace remaps
  - For being able to aim with right stick in Portal

Bonus:
- Fixed earlier hack for cart startup restart, which broke savestate autoload with carts only