### PR TITLE
AutoLoadWarp + tape improvements

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -6469,6 +6469,7 @@ bool retro_disk_set_eject_state(bool ejected)
                break;
             case 1:
                tape_image_attach(unit, dc->files[dc->index]);
+               datasette_control(DATASETTE_CONTROL_START);
                break;
             default:
                file_system_attach_disk(unit, 0, dc->files[dc->index]);

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2466,7 +2466,7 @@ static void retro_set_core_options()
          "vice_vkbd_theme",
          "Video > Virtual KBD Theme",
          "Virtual KBD Theme",
-         "By default, the keyboard comes up with RetroPad Select.",
+         "The keyboard comes up with RetroPad Select by default.",
          NULL,
          "video",
          {
@@ -2865,7 +2865,7 @@ static void retro_set_core_options()
          "Audio > TED Audio Leak Emulation",
          "TED Audio Leak Emulation",
 #endif
-         "",
+         "Graphic chip to audio leak emulation.",
          NULL,
          "audio",
          {
@@ -2973,7 +2973,7 @@ static void retro_set_core_options()
          "vice_resid_passband",
          "Audio > ReSID Filter Passband",
          "ReSID Filter Passband",
-         "",
+         "Resampling filter passband in percentage of the total bandwidth.",
          NULL,
          "audio",
          {
@@ -2995,7 +2995,7 @@ static void retro_set_core_options()
          "vice_resid_gain",
          "Audio > ReSID Filter Gain",
          "ReSID Filter Gain",
-         "",
+         "Gain in percent.",
          NULL,
          "audio",
          {
@@ -3018,7 +3018,7 @@ static void retro_set_core_options()
          "vice_resid_filterbias",
          "Audio > ReSID Filter 6581 Bias",
          "ReSID Filter 6581 Bias",
-         "",
+         "Filter bias for 6581, which can be used to adjust DAC bias in millivolts.",
          NULL,
          "audio",
          {
@@ -3051,7 +3051,7 @@ static void retro_set_core_options()
          "vice_resid_8580filterbias",
          "Audio > ReSID Filter 8580 Bias",
          "ReSID Filter 8580 Bias",
-         "",
+         "Filter bias for 8580, which can be used to adjust DAC bias in millivolts.",
          NULL,
          "audio",
          {
@@ -3086,13 +3086,13 @@ static void retro_set_core_options()
          "vice_sfx_sound_expander",
          "Audio > SFX Sound Expander",
          "SFX Sound Expander",
-         "",
+         "Sound synthesizer cartridge with 9 voices.",
          NULL,
          "audio",
          {
             { "disabled", NULL },
-            { "3526", "YM3526" },
-            { "3812", "YM3812" },
+            { "3526", "Yamaha YM3526" },
+            { "3812", "Yamaha YM3812" },
             { NULL, NULL },
          },
          "disabled"
@@ -3102,7 +3102,7 @@ static void retro_set_core_options()
          "vice_sound_sample_rate",
          "Audio > Sample Rate",
          "Sample Rate",
-         "Slightly higher quality or higher performance.",
+         "Sound sample rate in Hz.",
          NULL,
          "audio",
          {
@@ -3135,7 +3135,7 @@ static void retro_set_core_options()
          "vice_analogmouse_deadzone",
          "Input > Analog Stick Mouse Deadzone",
          "Analog Stick Mouse Deadzone",
-         "",
+         "Required distance from stick center to register input.",
          NULL,
          "input",
          {
@@ -3158,7 +3158,7 @@ static void retro_set_core_options()
          "vice_analogmouse_speed",
          "Input > Analog Stick Mouse Speed",
          "Analog Stick Mouse Speed",
-         "",
+         "Mouse movement speed multiplier for analog stick.",
          NULL,
          "input",
          {
@@ -3200,7 +3200,7 @@ static void retro_set_core_options()
          "vice_dpadmouse_speed",
          "Input > D-Pad Mouse Speed",
          "D-Pad Mouse Speed",
-         "",
+         "Mouse movement speed multiplier for directional pad.",
          NULL,
          "input",
          {
@@ -3230,7 +3230,7 @@ static void retro_set_core_options()
          "vice_mouse_speed",
          "Input > Mouse Speed",
          "Mouse Speed",
-         "Affects mouse speed globally.",
+         "Global mouse speed.",
          NULL,
          "input",
          {
@@ -3600,7 +3600,7 @@ static void retro_set_core_options()
          "vice_mapper_select",
          "RetroPad > Select",
          "Select",
-         "",
+         "VKBD comes up with RetroPad Select by default.",
          NULL,
          "retropad",
          {{ NULL, NULL }},

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -124,6 +124,7 @@ extern unsigned short int pix_bytes;
 /* Autoloadwarp */
 #define AUTOLOADWARP_DISK 0x01
 #define AUTOLOADWARP_TAPE 0x02
+#define AUTOLOADWARP_MUTE 0x04
 
 /* Variables */
 extern unsigned int retro_renderloop;

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -144,6 +144,10 @@ extern unsigned int cur_port;
 extern unsigned int retro_region;
 extern int request_model_set;
 
+extern unsigned int retro_warpmode;
+extern int retro_warp_mode_enabled(void);
+extern bool audio_playing(void);
+
 extern bool retro_message;
 extern char retro_message_msg[1024];
 

--- a/retrodep/uistatusbar.c
+++ b/retrodep/uistatusbar.c
@@ -51,6 +51,7 @@ extern unsigned int opt_autoloadwarp;
 extern unsigned int retro_warpmode;
 extern int retro_warp_mode_enabled();
 extern int RGBc(int r, int g, int b);
+extern bool audio_playing(void);
 
 /* ----------------------------------------------------------------- */
 /* static functions/variables */
@@ -506,14 +507,16 @@ static void display_tape(void)
 
     if (tape_enabled && (opt_autoloadwarp & AUTOLOADWARP_TAPE || retro_warp_mode_enabled()) && !retro_warpmode)
     {
-        if (tape_control == 1 && tape_motor && !retro_warp_mode_enabled())
+        bool audio = !(opt_autoloadwarp & AUTOLOADWARP_MUTE) && opt_autoloadwarp & AUTOLOADWARP_TAPE ? audio_playing() : false;
+
+        if (tape_control == 1 && tape_motor && !audio && !retro_warp_mode_enabled())
         {
             resources_set_int("WarpMode", 1);
 #if 0
             printf("Tape Warp ON\n");
 #endif
         }
-        else if ((tape_control != 1 || !tape_motor) && retro_warp_mode_enabled() || !(opt_autoloadwarp & AUTOLOADWARP_TAPE))
+        else if ((tape_control != 1 || !tape_motor || audio) && retro_warp_mode_enabled() || !(opt_autoloadwarp & AUTOLOADWARP_TAPE))
         {
             resources_set_int("WarpMode", 0);
 #if 0

--- a/retrodep/uistatusbar.c
+++ b/retrodep/uistatusbar.c
@@ -509,7 +509,7 @@ static void display_tape(void)
     {
         bool audio = !(opt_autoloadwarp & AUTOLOADWARP_MUTE) && opt_autoloadwarp & AUTOLOADWARP_TAPE ? audio_playing() : false;
 
-        if (tape_control == 1 && tape_motor && !audio && !retro_warp_mode_enabled())
+        if (tape_control == 1 && tape_motor == 2 && !audio && !retro_warp_mode_enabled())
         {
             resources_set_int("WarpMode", 1);
 #if 0
@@ -560,6 +560,9 @@ void ui_display_tape_counter(int counter)
 {
     if (tape_counter != counter) {
         display_tape();
+
+        if (tape_motor)
+           tape_motor = 2;
     }
 
     tape_counter = counter;

--- a/retrodep/uistatusbar.c
+++ b/retrodep/uistatusbar.c
@@ -48,10 +48,7 @@ extern unsigned int mouse_value[2 + 1];
 extern unsigned int vice_led_state[3];
 extern unsigned int opt_joyport_type;
 extern unsigned int opt_autoloadwarp;
-extern unsigned int retro_warpmode;
-extern int retro_warp_mode_enabled();
 extern int RGBc(int r, int g, int b);
-extern bool audio_playing(void);
 
 /* ----------------------------------------------------------------- */
 /* static functions/variables */

--- a/vice/src/drive/drive.c
+++ b/vice/src/drive/drive.c
@@ -77,14 +77,11 @@
 #include <stdbool.h>
 #include "libretro-core.h"
 extern unsigned int opt_autoloadwarp;
-extern unsigned int retro_warpmode;
-extern int retro_warp_mode_enabled(void);
-extern bool retro_disk_get_eject_state(void);
 extern unsigned int vice_led_state[3];
+extern bool retro_disk_get_eject_state(void);
 static int warpmode_counter_ledon = 0;
 static int warpmode_counter_ledoff = 0;
 static int drive_half_track_prev = 0;
-extern bool audio_playing(void);
 #endif
 
 static int drive_init_was_called = 0;

--- a/vice/src/sound.c
+++ b/vice/src/sound.c
@@ -64,6 +64,7 @@
 #include "sid.h"
 #include "libretro-core.h"
 extern void sound_volume_counter_reset(void);
+extern int16_t *audio_buffer;
 #endif
 
 static log_t sound_log = LOG_ERR;
@@ -1237,7 +1238,9 @@ static int sound_run_sound(void)
 
     snddata.bufptr += nr;
     snddata.lastclk = maincpu_clk;
-
+#ifdef __LIBRETRO__
+    audio_buffer = snddata.buffer;
+#endif
     return 0;
 }
 


### PR DESCRIPTION
- AutoLoadWarp now detects audio, and the old behavior is available via `Ignore audio` options
  Closes #422 

- Tape index change presses play automatically
- Core option sublabel adjustments
