### PR TITLE
Autoloadwarp + misc

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2249,7 +2249,7 @@ static void retro_set_core_options()
          "vice_autoloadwarp",
          "Media > Automatic Load Warp",
          "Automatic Load Warp",
-         "Toggle warp mode during disk and/or tape access if there is no audio output. Mutes 'Drive Sound Emulation'.\n'True Drive Emulation' required!",
+         "Toggle warp mode during disk and/or tape access if there is no audio output. Mutes 'Drive Sound Emulation' and 'Datasette Sound'.\n'True Drive Emulation' required!",
          NULL,
          "media",
          {
@@ -4467,10 +4467,17 @@ static void update_variables(void)
       if      (strstr(var.value, "mute"))      opt_autoloadwarp |= AUTOLOADWARP_MUTE;
       else if (!strcmp(var.value, "disabled")) opt_autoloadwarp = 0;
 
-      /* Silently restore sounds when autoloadwarp is disabled and DSE is enabled */
+      /* Silently restore drive sounds when autoloadwarp is disabled and DSE is enabled */
       if (retro_ui_finalized && vice_opt.DriveSoundEmulation && vice_opt.DriveTrueEmulation &&
           !(opt_autoloadwarp & AUTOLOADWARP_DISK))
          resources_set_int("DriveSoundEmulationVolume", vice_opt.DriveSoundEmulation);
+
+#if !defined(__XSCPU64__) && !defined(__X64DTV__)
+      /* Silently restore tape sounds when autoloadwarp is disabled */
+      if (retro_ui_finalized && vice_opt.DatasetteSound &&
+          !(opt_autoloadwarp & AUTOLOADWARP_TAPE))
+         resources_set_int("DatasetteSound", vice_opt.DatasetteSound);
+#endif
    }
 
    var.key = "vice_floppy_write_protection";
@@ -4619,6 +4626,10 @@ static void update_variables(void)
       }
 
       vice_opt.DatasetteSound = val;
+
+      /* Silently mute sounds with autoloadwarping */
+      if (retro_ui_finalized && vice_opt.DatasetteSound && opt_autoloadwarp & AUTOLOADWARP_TAPE)
+         resources_set_int("DatasetteSound", 0);
    }
 #endif
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -7546,7 +7546,8 @@ static void load_trap(uint16_t addr, void *success)
 static void retro_unserialize_post(void)
 {
    /* Disable warp */
-   resources_set_int("WarpMode", 0);
+   if (retro_warp_mode_enabled())
+      resources_set_int("WarpMode", 0);
    /* Dismiss possible restart request */
    request_restart = false;
    /* Sync Disc Control index for D64 multidisks */

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -7329,7 +7329,7 @@ void retro_run(void)
       if (perf_cb.get_time_usec && frame_max > 1)
          frame_max = 1000000 / (retro_refresh / 5) / (retro_ticks() - frame_time);
 
-      if (frame_count > 0 && (!retro_warp_mode_enabled() || is_audio_playing_while_autoloadwarping()))
+      if (frame_max > 1 && (!retro_warp_mode_enabled() || is_audio_playing_while_autoloadwarping()))
          frame_max = 1;
    }
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1728,14 +1728,15 @@ void retro_fastforwarding(bool enabled)
 
 bool audio_playing(void)
 {
-   if (audio_buffer && audio_buffer[0])
+   if (audio_buffer)
    {
       for (unsigned i = 2; i < 20; i++)
       {
          int target = (i % 2 == 0) ? 0 : 1;
          if (audio_buffer[i] != audio_buffer[target] &&
-             audio_buffer[i] != 0 &&
-             audio_buffer[target] != 0)
+             abs(audio_buffer[i] - audio_buffer[target]) > 2 &&
+             abs(audio_buffer[i] - audio_buffer[target]) < 30000 &&
+             !(audio_buffer[i] == 0 || audio_buffer[target] == 0))
          {
             audio_is_playing = true;
             return true;

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -234,6 +234,14 @@ struct vice_core_options
 
 extern struct vice_core_options vice_opt;
 
+#if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__)
+#define AUDIOLEAK_RESOURCE "VICIIAudioLeak"
+#elif defined(__XVIC__)
+#define AUDIOLEAK_RESOURCE "VICAudioLeak"
+#elif defined(__XPLUS4__)
+#define AUDIOLEAK_RESOURCE "TEDAudioLeak"
+#endif
+
 /* Dynamic cartridge core option info */
 struct vice_cart_info
 {

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -540,6 +540,16 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
          image_label[0] = '\0';
          fill_short_pathname_representation(image_label, full_path_replace, sizeof(image_label));
 
+         /* Dupecheck */
+         for (unsigned i = 0; i < dc->count - 1; i++)
+         {
+            if (!strcmp(dc->files[i], full_path_replace))
+            {
+               dc_remove_file(dc, index);
+               return true;
+            }
+         }
+
          dc->files[index]       = strdup(full_path_replace);
          dc->labels[index]      = strdup(image_label);
          dc->disk_labels[index] = get_label(full_path_replace);

--- a/libretro/libretro-graph.c
+++ b/libretro/libretro-graph.c
@@ -255,6 +255,8 @@ void draw_hline_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t c
    for (i=x; i<x+dx; i++)
    {
       idx = i+y*retrow;
+      if (idx < 0)
+         continue;
       buffer[idx] = color;
    }
 }
@@ -268,6 +270,8 @@ void draw_hline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t c
    for (i=x; i<x+dx; i++)
    {
       idx = i+y*retrow;
+      if (idx < 0)
+         continue;
       buffer[idx] = color;
    }
 }
@@ -289,6 +293,8 @@ void draw_vline_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t c
    for (j=y; j<y+dy; j++)
    {
       idx = x+j*retrow;
+      if (idx < 0)
+         continue;
       buffer[idx] = color;
    }
 }
@@ -302,6 +308,8 @@ void draw_vline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t c
    for (j=y; j<y+dy; j++)
    {
       idx = x+j*retrow;
+      if (idx < 0)
+         continue;
       buffer[idx] = color;
    }
 }

--- a/libretro/libretro-graph.c
+++ b/libretro/libretro-graph.c
@@ -78,10 +78,10 @@ void draw_fbox_bmp16(unsigned short *buffer, int x, int y, int dx, int dy, uint1
           * correct colour */
          break;
       case GRAPH_ALPHA_25:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint16_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND_ALPHA25(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -89,10 +89,10 @@ void draw_fbox_bmp16(unsigned short *buffer, int x, int y, int dx, int dy, uint1
          }
          break;
       case GRAPH_ALPHA_50:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint16_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND_ALPHA50(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -100,10 +100,10 @@ void draw_fbox_bmp16(unsigned short *buffer, int x, int y, int dx, int dy, uint1
          }
          break;
       case GRAPH_ALPHA_75:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint16_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND_ALPHA75(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -112,10 +112,10 @@ void draw_fbox_bmp16(unsigned short *buffer, int x, int y, int dx, int dy, uint1
          break;
       case GRAPH_ALPHA_100:
       default:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint16_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                *buf_ptr = color;
                buf_ptr++;
@@ -138,10 +138,10 @@ void draw_fbox_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t co
           * correct colour */
          break;
       case GRAPH_ALPHA_25:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint32_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND32_ALPHA25(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -149,10 +149,10 @@ void draw_fbox_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t co
          }
          break;
       case GRAPH_ALPHA_50:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint32_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND32_ALPHA50(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -160,10 +160,10 @@ void draw_fbox_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t co
          }
          break;
       case GRAPH_ALPHA_75:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint32_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                BLEND32_ALPHA75(color, *buf_ptr, buf_ptr);
                buf_ptr++;
@@ -172,10 +172,10 @@ void draw_fbox_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t co
          break;
       case GRAPH_ALPHA_100:
       default:
-         for (j=y; j<y+dy; j++)
+         for (j = y; j < y + dy; j++)
          {
             uint32_t *buf_ptr = buffer + (j * retrow) + x;
-            for (i=x; i<x+dx; i++)
+            for (i = x; i < x + dx; i++)
             {
                *buf_ptr = color;
                buf_ptr++;
@@ -198,19 +198,19 @@ void draw_box_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t col
 {
    int i, j, idx;
 
-   for (i=x; i<x+dx; i++)
+   for (i = x; i < x + dx; i++)
    {
-      idx = i+y*retrow;
+      idx = i + (y * retrow);
       buffer[idx] = color;
-      idx = i+(y+dy)*retrow;
+      idx = i + ((y + dy) * retrow);
       buffer[idx] = color;
    }
 
-   for (j=y; j<y+dy; j++)
+   for (j = y; j < y + dy; j++)
    {
-      idx = x+j*retrow;
+      idx = x + (j * retrow);
       buffer[idx] = color;
-      idx = (x+dx)+j*retrow;
+      idx = (x + dx) + (j * retrow);
       buffer[idx] = color;
    }
 }
@@ -219,19 +219,19 @@ void draw_box_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t col
 {
    int i, j, idx;
 
-   for (i=x; i<x+dx; i++)
+   for (i = x; i < x + dx; i++)
    {
-      idx = i+y*retrow;
+      idx = i + (y * retrow);
       buffer[idx] = color;
-      idx = i+(y+dy)*retrow;
+      idx = i + ((y + dy) * retrow);
       buffer[idx] = color;
    }
 
-   for (j=y; j<y+dy; j++)
+   for (j = y; j < y + dy; j++)
    {
-      idx = x+j*retrow;
+      idx = x + (j * retrow);
       buffer[idx] = color;
-      idx = (x+dx)+j*retrow;
+      idx = (x + dx) + (j * retrow);
       buffer[idx] = color;
    }
 }
@@ -252,9 +252,9 @@ void draw_hline_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t c
 
    (void)j;
 
-   for (i=x; i<x+dx; i++)
+   for (i = x; i < x + dx; i++)
    {
-      idx = i+y*retrow;
+      idx = i + (y * retrow);
       if (idx < 0)
          continue;
       buffer[idx] = color;
@@ -267,9 +267,9 @@ void draw_hline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t c
 
    (void)j;
 
-   for (i=x; i<x+dx; i++)
+   for (i = x; i < x + dx; i++)
    {
-      idx = i+y*retrow;
+      idx = i + (y * retrow);
       if (idx < 0)
          continue;
       buffer[idx] = color;
@@ -290,9 +290,9 @@ void draw_vline_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t c
 
    (void)i;
 
-   for (j=y; j<y+dy; j++)
+   for (j = y; j < y + dy; j++)
    {
-      idx = x+j*retrow;
+      idx = x + (j * retrow);
       if (idx < 0)
          continue;
       buffer[idx] = color;
@@ -305,9 +305,9 @@ void draw_vline_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t c
 
    (void)i;
 
-   for (j=y; j<y+dy; j++)
+   for (j = y; j < y + dy; j++)
    {
-      idx = x+j*retrow;
+      idx = x + (j * retrow);
       if (idx < 0)
          continue;
       buffer[idx] = color;

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -600,6 +600,14 @@ void update_input(unsigned disable_keys)
                   mapper_flag[cur_port][JOYPAD_FIRE2] = 1;
                else if (mapper_keys[i] == JOYSTICK_FIRE3)
                   mapper_flag[cur_port][JOYPAD_FIRE3] = 1;
+               else if (mapper_keys[i] == JOYSTICK_UP)
+                  mapper_flag[cur_port][JOYPAD_N] = 1;
+               else if (mapper_keys[i] == JOYSTICK_DOWN)
+                  mapper_flag[cur_port][JOYPAD_S] = 1;
+               else if (mapper_keys[i] == JOYSTICK_LEFT)
+                  mapper_flag[cur_port][JOYPAD_W] = 1;
+               else if (mapper_keys[i] == JOYSTICK_RIGHT)
+                  mapper_flag[cur_port][JOYPAD_E] = 1;
                else if (mapper_keys[i] == OTHERJOY_FIRE)
                   mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_FIRE] = 1;
                else if (mapper_keys[i] == OTHERJOY_UP)
@@ -665,6 +673,14 @@ void update_input(unsigned disable_keys)
                   mapper_flag[cur_port][JOYPAD_FIRE2] = 0;
                else if (mapper_keys[i] == JOYSTICK_FIRE3)
                   mapper_flag[cur_port][JOYPAD_FIRE3] = 0;
+               else if (mapper_keys[i] == JOYSTICK_UP)
+                  mapper_flag[cur_port][JOYPAD_N] = 0;
+               else if (mapper_keys[i] == JOYSTICK_DOWN)
+                  mapper_flag[cur_port][JOYPAD_S] = 0;
+               else if (mapper_keys[i] == JOYSTICK_LEFT)
+                  mapper_flag[cur_port][JOYPAD_W] = 0;
+               else if (mapper_keys[i] == JOYSTICK_RIGHT)
+                  mapper_flag[cur_port][JOYPAD_E] = 0;
                else if (mapper_keys[i] == OTHERJOY_FIRE)
                   mapper_flag[(cur_port == 2) ? 1 : 2][JOYPAD_FIRE] = 0;
                else if (mapper_keys[i] == OTHERJOY_UP)

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -115,6 +115,7 @@ int retro_ui_get_pointer_state(int *px, int *py, unsigned int *pbuttons)
    if (opt_joyport_pointer_color > -1)
    {
       unsigned pointer_color = 0;
+      unsigned pointer_white = RGBc(255, 255, 255);
       switch (opt_joyport_pointer_color)
       {
          case 0: pointer_color = RGBc(  0,   0,   0); break; /* Black */
@@ -127,10 +128,17 @@ int retro_ui_get_pointer_state(int *px, int *py, unsigned int *pbuttons)
          case 7: pointer_color = RGBc(255,   0, 255); break; /* Purple */
       }
 
-      draw_hline(*px - 2, *py, 2, 1, pointer_color);
-      draw_hline(*px + 1, *py, 2, 1, pointer_color);
-      draw_vline(*px, *py - 2, 1, 2, pointer_color);
-      draw_vline(*px, *py + 1, 1, 2, pointer_color);
+      draw_hline(*px - 3, *py, 3, 1, pointer_color);
+      draw_hline(*px - 2, *py, 1, 1, pointer_white);
+
+      draw_hline(*px + 1, *py, 3, 1, pointer_color);
+      draw_hline(*px + 2, *py, 1, 1, pointer_white);
+
+      draw_vline(*px, *py - 3, 1, 3, pointer_color);
+      draw_vline(*px, *py - 2, 1, 1, pointer_white);
+
+      draw_vline(*px, *py + 1, 1, 3, pointer_color);
+      draw_vline(*px, *py + 2, 1, 1, pointer_white);
    }
 
    return 1;

--- a/libretro/libretro-mapper.h
+++ b/libretro/libretro-mapper.h
@@ -36,19 +36,23 @@
 
 #define RETRO_MAPPER_LAST               39
 
-#define TOGGLE_VKBD                     -11
-#define TOGGLE_STATUSBAR                -12
-#define SWITCH_JOYPORT                  -13
+#define TOGGLE_VKBD                     -31
+#define TOGGLE_STATUSBAR                -32
+#define SWITCH_JOYPORT                  -33
 #define MOUSE_SLOWER                    -5
 #define MOUSE_FASTER                    -6
-#define JOYSTICK_FIRE                   -7
-#define JOYSTICK_FIRE2                  -8
-#define JOYSTICK_FIRE3                  -9
-#define OTHERJOY_FIRE                   -21
-#define OTHERJOY_UP                     -22
-#define OTHERJOY_DOWN                   -23
-#define OTHERJOY_LEFT                   -24
-#define OTHERJOY_RIGHT                  -25
+#define JOYSTICK_UP                     -11
+#define JOYSTICK_DOWN                   -12
+#define JOYSTICK_LEFT                   -13
+#define JOYSTICK_RIGHT                  -14
+#define JOYSTICK_FIRE                   -15
+#define JOYSTICK_FIRE2                  -16
+#define JOYSTICK_FIRE3                  -17
+#define OTHERJOY_UP                     -21
+#define OTHERJOY_DOWN                   -22
+#define OTHERJOY_LEFT                   -23
+#define OTHERJOY_RIGHT                  -24
+#define OTHERJOY_FIRE                   -25
 
 #define JOYPAD_N                        0x01
 #define JOYPAD_S                        0x02
@@ -81,14 +85,18 @@ static retro_keymap retro_keys[RETROK_LAST] =
    {TOGGLE_VKBD,        "TOGGLE_VKBD",         "Toggle Virtual Keyboard"},
    {TOGGLE_STATUSBAR,   "TOGGLE_STATUSBAR",    "Toggle Statusbar"},
    {SWITCH_JOYPORT,     "SWITCH_JOYPORT",      "Switch Joyport"},
+   {JOYSTICK_UP,        "JOYSTICK_UP",         "Joystick Up"},
+   {JOYSTICK_DOWN,      "JOYSTICK_DOWN",       "Joystick Down"},
+   {JOYSTICK_LEFT,      "JOYSTICK_LEFT",       "Joystick Left"},
+   {JOYSTICK_RIGHT,     "JOYSTICK_RIGHT",      "Joystick Right"},
    {JOYSTICK_FIRE,      "JOYSTICK_FIRE",       "Joystick Fire"},
    {JOYSTICK_FIRE2,     "JOYSTICK_FIRE2",      "Joystick Fire 2"},
    {JOYSTICK_FIRE3,     "JOYSTICK_FIRE3",      "Joystick Fire 3"},
-   {OTHERJOY_FIRE,      "OTHERJOY_FIRE",       "Other Joyport Fire"},
    {OTHERJOY_UP,        "OTHERJOY_UP",         "Other Joyport Up"},
    {OTHERJOY_DOWN,      "OTHERJOY_DOWN",       "Other Joyport Down"},
    {OTHERJOY_LEFT,      "OTHERJOY_LEFT",       "Other Joyport Left"},
    {OTHERJOY_RIGHT,     "OTHERJOY_RIGHT",      "Other Joyport Right"},
+   {OTHERJOY_FIRE,      "OTHERJOY_FIRE",       "Other Joyport Fire"},
    {MOUSE_SLOWER,       "MOUSE_SLOWER",        "Mouse Slower"},
    {MOUSE_FASTER,       "MOUSE_FASTER",        "Mouse Faster"},
    {RETROK_BACKSPACE,   "RETROK_BACKSPACE",    "Keyboard Backspace"},
@@ -104,10 +112,10 @@ static retro_keymap retro_keys[RETROK_LAST] =
 /* {RETROK_DOLLAR,      "RETROK_DOLLAR",       "Keyboard $"}, */
 /* {RETROK_AMPERSAND,   "RETROK_AMPERSAND",    "Keyboard &"}, */
    {RETROK_QUOTE,       "RETROK_QUOTE",        "Keyboard \'"},
-   {RETROK_LEFTPAREN,   "RETROK_LEFTPAREN",    "Keyboard ("},
-   {RETROK_RIGHTPAREN,  "RETROK_RIGHTPAREN",   "Keyboard )"},
-   {RETROK_ASTERISK,    "RETROK_ASTERISK",     "Keyboard *"},
-   {RETROK_PLUS,        "RETROK_PLUS",         "Keyboard +"},
+/* {RETROK_LEFTPAREN,   "RETROK_LEFTPAREN",    "Keyboard ("}, */
+/* {RETROK_RIGHTPAREN,  "RETROK_RIGHTPAREN",   "Keyboard )"}, */
+/* {RETROK_ASTERISK,    "RETROK_ASTERISK",     "Keyboard *"}, */
+/* {RETROK_PLUS,        "RETROK_PLUS",         "Keyboard +"}, */
    {RETROK_COMMA,       "RETROK_COMMA",        "Keyboard ,"},
    {RETROK_MINUS,       "RETROK_MINUS",        "Keyboard -"},
    {RETROK_PERIOD,      "RETROK_PERIOD",       "Keyboard ."},
@@ -122,18 +130,18 @@ static retro_keymap retro_keys[RETROK_LAST] =
    {RETROK_7,           "RETROK_7",            "Keyboard 7"},
    {RETROK_8,           "RETROK_8",            "Keyboard 8"},
    {RETROK_9,           "RETROK_9",            "Keyboard 9"},
-   {RETROK_COLON,       "RETROK_COLON",        "Keyboard :"},
+/* {RETROK_COLON,       "RETROK_COLON",        "Keyboard :"}, */
    {RETROK_SEMICOLON,   "RETROK_SEMICOLON",    "Keyboard ;"},
-   {RETROK_LESS,        "RETROK_LESS",         "Keyboard <"},
+/* {RETROK_LESS,        "RETROK_LESS",         "Keyboard <"}, */
    {RETROK_EQUALS,      "RETROK_EQUALS",       "Keyboard ="},
-   {RETROK_GREATER,     "RETROK_GREATER",      "Keyboard >"},
+/* {RETROK_GREATER,     "RETROK_GREATER",      "Keyboard >"}, */
 /* {RETROK_QUESTION,    "RETROK_QUESTION",     "Keyboard ?"}, */
 /* {RETROK_AT,          "RETROK_AT",           "Keyboard @"}, */
    {RETROK_LEFTBRACKET, "RETROK_LEFTBRACKET",  "Keyboard ["},
    {RETROK_BACKSLASH,   "RETROK_BACKSLASH",    "Keyboard \\"},
    {RETROK_RIGHTBRACKET,"RETROK_RIGHTBRACKET", "Keyboard ]"},
-   {RETROK_CARET,       "RETROK_CARET",        "Keyboard ^"},
-   {RETROK_UNDERSCORE,  "RETROK_UNDERSCORE",   "Keyboard _"},
+/* {RETROK_CARET,       "RETROK_CARET",        "Keyboard ^"}, */
+/* {RETROK_UNDERSCORE,  "RETROK_UNDERSCORE",   "Keyboard _"}, */
    {RETROK_BACKQUOTE,   "RETROK_BACKQUOTE",    "Keyboard `"},
    {RETROK_a,           "RETROK_a",            "Keyboard A"},
    {RETROK_b,           "RETROK_b",            "Keyboard B"},

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -397,6 +397,9 @@ int ui_init_finalize(void)
       log_resources_set_int("DatasetteSound", 1);
    else
       log_resources_set_int("DatasetteSound", 0);
+
+   if (opt_autoloadwarp & AUTOLOADWARP_TAPE)
+      log_resources_set_int("DatasetteSound", 0);
 #endif
 
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__)

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -389,7 +389,7 @@ int ui_init_finalize(void)
    else
       log_resources_set_int("DriveSoundEmulation", 0);
 
-   if (opt_autoloadwarp & AUTOLOADWARP_DISK)
+   if (opt_autoloadwarp & AUTOLOADWARP_DISK && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
       log_resources_set_int("DriveSoundEmulationVolume", 0);
 
 #if !defined(__XSCPU64__) && !defined(__X64DTV__)
@@ -398,16 +398,22 @@ int ui_init_finalize(void)
    else
       log_resources_set_int("DatasetteSound", 0);
 
-   if (opt_autoloadwarp & AUTOLOADWARP_TAPE)
+   if (opt_autoloadwarp & AUTOLOADWARP_TAPE && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
       log_resources_set_int("DatasetteSound", 0);
 #endif
 
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__)
    log_resources_set_int("VICIIAudioLeak", vice_opt.AudioLeak);
+   if (opt_autoloadwarp && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
+      log_resources_set_int("VICIIAudioLeak", 0);
 #elif defined(__XVIC__)
    log_resources_set_int("VICAudioLeak", vice_opt.AudioLeak);
+   if (opt_autoloadwarp && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
+      log_resources_set_int("VICAudioLeak", 0);
 #elif defined(__XPLUS4__)
    log_resources_set_int("TEDAudioLeak", vice_opt.AudioLeak);
+   if (opt_autoloadwarp && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
+      log_resources_set_int("TEDAudioLeak", 0);
 #endif
 
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__)

--- a/retrodep/uistatusbar.c
+++ b/retrodep/uistatusbar.c
@@ -510,14 +510,14 @@ static void display_tape(void)
         {
             resources_set_int("WarpMode", 1);
 #if 0
-            printf("Tape Warp ON\n");
+            printf("Tape Warp  ON, control:%d motor:%d audio:%d\n", tape_control, tape_motor, audio);
 #endif
         }
         else if ((tape_control != 1 || !tape_motor || audio) && retro_warp_mode_enabled() || !(opt_autoloadwarp & AUTOLOADWARP_TAPE))
         {
             resources_set_int("WarpMode", 0);
 #if 0
-            printf("Tape Warp OFF\n");
+            printf("Tape Warp OFF, control:%d motor:%d audio:%d\n", tape_control, tape_motor, audio);
 #endif
         }
     }

--- a/vice/src/drive/drive.c
+++ b/vice/src/drive/drive.c
@@ -894,9 +894,9 @@ void drive_update_ui_status(void)
                 {
                     resources_set_int("WarpMode", (warp > 1) ? 0 : warp);
 #if 0
-                    printf("Disk Warp:%2d track:%3d prev:%3d led:%d timer:%3d,%3d\n",
+                    printf("Disk Warp:%2d track:%3d prev:%3d led:%d audio:%d timer:%3d,%3d\n",
                             warp, drive_half_track, drive_half_track_prev, drive_led_status,
-                            warpmode_counter_ledoff, warpmode_counter_ledon);
+                            audio, warpmode_counter_ledoff, warpmode_counter_ledon);
 #endif
                 }
                 drive_half_track_prev = drive_half_track;

--- a/vice/src/drive/drive.c
+++ b/vice/src/drive/drive.c
@@ -735,7 +735,7 @@ void drive_gcr_data_writeback_all(void)
     drive_t *drive;
     unsigned int i, j;
 #ifdef __LIBRETRO__
-    if(!diskunit_context[0])
+    if (!diskunit_context[0])
         return;
 #endif
 
@@ -870,7 +870,7 @@ void drive_update_ui_status(void)
                     if (warpmode_counter_ledon > 998)
                         warp = 2;
                 }
-                else if ((drive_half_track == drive_half_track_prev && !drive_led_status) && retro_warp_mode_enabled())
+                else if ((drive_half_track == drive_half_track_prev && !drive_led_status) && retro_warp_mode_enabled() && !audio)
                 {
                     warpmode_counter_ledon = 0;
                     warpmode_counter_ledoff++;

--- a/vice/src/sid/sid.c
+++ b/vice/src/sid/sid.c
@@ -1095,11 +1095,10 @@ int sid_engine_get_max_sids(int engine)
         case SID_ENGINE_FASTSID:
             return SID_ENGINE_FASTSID_NUM_SIDS;
         case SID_ENGINE_RESID:
-            return SID_ENGINE_RESID_NUM_SIDS;
 #ifdef ___LIBRETRO__
         case SID_ENGINE_RESIDFP:
-            return 2;
 #endif
+            return SID_ENGINE_RESID_NUM_SIDS;
        case SID_ENGINE_CATWEASELMKIII:
             return SID_ENGINE_CATWEASELMKIII_NUM_SIDS;
         case SID_ENGINE_HARDSID:

--- a/vice/src/sound.c
+++ b/vice/src/sound.c
@@ -65,6 +65,7 @@
 #include "libretro-core.h"
 extern void sound_volume_counter_reset(void);
 extern int16_t *audio_buffer;
+extern int tape_enabled;
 #endif
 
 static log_t sound_log = LOG_ERR;
@@ -1633,6 +1634,12 @@ void sound_set_warp_mode(int value)
     if (vice_opt.SidEngine != SID_ENGINE_FASTSID)
     {
         resources_set_int("SidEngine", (value) ? SID_ENGINE_FASTSID : vice_opt.SidEngine);
+
+        /* Reset SID when entering warp in disk mode only,
+         * otherwise tape loading music is affected (?!) */
+        if (value && !tape_enabled)
+            sid_reset();
+
         /* 6581 init pop muting */
         if (!value)
             sound_volume_counter_reset();


### PR DESCRIPTION
Audio + warp related:
- Streamlined autoloadwarp behavior so that if mode tries to detect audio, it will disable all "noise" generation (disk/tape/leak) automatically
- Improvements to autoloadwarp audio detection when using floppies
- Rewind no longer mutes audio

Other:
- Added joystick directions to core option RetroPad mapper
- Removed possibility to add the same disk to DC list
- Made light gun cursor more visible
