### PR TITLE
Directory FileSystem

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -278,8 +278,14 @@ static const char* xargv_cmd[64];
 static int PARAMCOUNT = 0;
 
 /* Display message on next retro_run */
-bool retro_message = false;
-char retro_message_msg[1024] = {0};
+static bool retro_message = false;
+static char retro_message_msg[1024] = {0};
+void display_retro_message(const char *message)
+{
+   snprintf(retro_message_msg, sizeof(retro_message_msg), "%s", message);
+   retro_message = true;
+}
+
 extern void display_current_image(const char *image, bool inserted);
 
 extern int skel_main(int argc, char *argv[]);
@@ -7720,7 +7726,6 @@ size_t retro_serialize_size(void)
          else
          {
             log_cb(RETRO_LOG_INFO, "Failed to calculate snapshot size\n");
-            snapshot_display_error();
          }
          snapshot_fclose(snapshot_stream);
          snapshot_stream = NULL;
@@ -7763,7 +7768,6 @@ bool retro_serialize(void *data_, size_t size)
          return true;
       }
       log_cb(RETRO_LOG_INFO, "Failed to serialize snapshot\n");
-      snapshot_display_error();
    }
    return false;
 }
@@ -7789,7 +7793,6 @@ bool retro_unserialize(const void *data_, size_t size)
          return true;
       }
       log_cb(RETRO_LOG_INFO, "Failed to unserialize snapshot\n");
-      snapshot_display_error();
    }
    return false;
 }

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -13,6 +13,7 @@
 #include "drive.h"
 #include "tape.h"
 #include "diskimage.h"
+#include "fsdevice.h"
 #include "vdrive.h"
 #include "vdrive-internal.h"
 #include "charset.h"
@@ -180,6 +181,8 @@ extern bool retro_turbo_fire;
 extern bool turbo_fire_locked;
 extern unsigned int turbo_fire_button;
 extern unsigned int turbo_pulse;
+
+extern char *fsdevice_get_path(unsigned int unit);
 
 #if defined(__XVIC__)
 void cartridge_trigger_freeze(void) {}
@@ -1039,6 +1042,13 @@ static int process_cmdline(const char* argv)
          dc_parse_vfl(dc, argv);
          is_fliplist = true;
       }
+      else if (path_is_directory(argv))
+      {
+         Add_Option("-iecdevice8");
+         Add_Option("-device8");
+         Add_Option("1");
+         Add_Option("-fs8");
+      }
 
       if (!is_fliplist)
       {
@@ -1239,50 +1249,74 @@ static void autodetect_drivetype(int unit)
 
 void update_work_disk()
 {
-   request_update_work_disk = false;
+   request_update_work_disk   = false;
    const char* attached_image = NULL;
+   unsigned work_disk_type    = opt_work_disk_type;
+   unsigned work_disk_unit    = opt_work_disk_unit;
+
+   /* Path vars */
+   char work_disk_basename[10]             = "vice_work";
+   char work_disk_filename[RETRO_PATH_MAX] = {0};
+   char work_disk_filepath[RETRO_PATH_MAX] = {0};
+   char work_disk_extension[4]             = {0};
+   switch (work_disk_type)
+   {
+      default:
+      case DISK_IMAGE_TYPE_D64:
+         snprintf(work_disk_extension, sizeof(work_disk_extension), "%s", "d64");
+         break;
+      case DISK_IMAGE_TYPE_D71:
+         snprintf(work_disk_extension, sizeof(work_disk_extension), "%s", "d71");
+         break;
+      case DISK_IMAGE_TYPE_D81:
+         snprintf(work_disk_extension, sizeof(work_disk_extension), "%s", "d81");
+         break;
+      case DISK_IMAGE_TYPE_FS:
+         snprintf(work_disk_extension, sizeof(work_disk_extension), "%s", "");
+         break;
+   }
+
+   if (strcmp(work_disk_extension, ""))
+      snprintf(work_disk_filename, sizeof(work_disk_filename), "%s.%s", work_disk_basename, work_disk_extension);
+   else
+      snprintf(work_disk_filename, sizeof(work_disk_filename), work_disk_basename);
+
+   path_join((char*)&work_disk_filepath, retro_save_directory, work_disk_filename);
 
    /* Skip if device unit collides with autostart */
-   if (!string_is_empty(full_path) && opt_work_disk_unit == 8)
-      opt_work_disk_type = 0;
-   if (opt_work_disk_type)
+   if (!string_is_empty(full_path) && work_disk_unit == 8)
+      work_disk_type = 0;
+   if (work_disk_type)
    {
-      /* Path vars */
-      char opt_work_disk_filename[RETRO_PATH_MAX] = {0};
-      char opt_work_disk_filepath[RETRO_PATH_MAX] = {0};
-      char opt_work_disk_extension[4] = {0};
-      switch (opt_work_disk_type)
-      {
-         default:
-         case DISK_IMAGE_TYPE_D64:
-            snprintf(opt_work_disk_extension, sizeof(opt_work_disk_extension), "%s", "d64");
-            break;
-         case DISK_IMAGE_TYPE_D71:
-            snprintf(opt_work_disk_extension, sizeof(opt_work_disk_extension), "%s", "d71");
-            break;
-         case DISK_IMAGE_TYPE_D81:
-            snprintf(opt_work_disk_extension, sizeof(opt_work_disk_extension), "%s", "d81");
-            break;
-      }
-      snprintf(opt_work_disk_filename, sizeof(opt_work_disk_filename), "vice_work.%s", opt_work_disk_extension);
-      path_join((char*)&opt_work_disk_filepath, retro_save_directory, opt_work_disk_filename);
-
       /* Create disk */
-      if (!path_is_valid(opt_work_disk_filepath))
+      if (!path_is_valid(work_disk_filepath))
       {
-         /* Label format */
-         char format_name[28];
-         snprintf(format_name, sizeof(format_name), "%s-%s", "work", opt_work_disk_extension);
-         charset_petconvstring((uint8_t *)format_name, 0);
+         switch (work_disk_type)
+         {
+            default:
+               {
+                  /* Label format */
+                  char format_name[28];
+                  snprintf(format_name, sizeof(format_name), "%s-%s", "work", work_disk_extension);
+                  charset_petconvstring((uint8_t *)format_name, 0);
 
-         if (vdrive_internal_create_format_disk_image(opt_work_disk_filepath, format_name, opt_work_disk_type))
-            log_cb(RETRO_LOG_INFO, "Work disk creation failed: '%s'\n", opt_work_disk_filepath);
-         else
-            log_cb(RETRO_LOG_INFO, "Work disk created: '%s'\n", opt_work_disk_filepath);
+                  if (vdrive_internal_create_format_disk_image(work_disk_filepath, format_name, work_disk_type))
+                     log_cb(RETRO_LOG_INFO, "Work disk creation failed: '%s'\n", work_disk_filepath);
+                  else
+                     log_cb(RETRO_LOG_INFO, "Work disk created: '%s'\n", work_disk_filepath);
+               }
+               break;
+            case DISK_IMAGE_TYPE_FS:
+               if (path_mkdir(work_disk_filepath))
+                  log_cb(RETRO_LOG_INFO, "Work directory creation failed: '%s'\n", work_disk_filepath);
+               else
+                  log_cb(RETRO_LOG_INFO, "Work directory created: '%s'\n", work_disk_filepath);
+               break;
+         }
       }
 
       /* Attach disk */
-      if (path_is_valid(opt_work_disk_filepath))
+      if (path_is_valid(work_disk_filepath))
       {
          /* Detach previous disks */
          if ((attached_image = file_system_get_disk_name(8, 0)) != NULL)
@@ -1294,33 +1328,92 @@ void update_work_disk()
             log_resources_set_int("Drive9Type", DRIVE_TYPE_NONE);
          }
 
-         if (opt_work_disk_unit == 9)
-            log_resources_set_int("Drive9Type", opt_work_disk_type);
-         file_system_attach_disk(opt_work_disk_unit, 0, opt_work_disk_filepath);
-         autodetect_drivetype(opt_work_disk_unit);
-         log_cb(RETRO_LOG_INFO, "Work disk '%s' attached in drive #%d\n", opt_work_disk_filepath, opt_work_disk_unit);
-         display_current_image(opt_work_disk_filename, true);
+         if ((attached_image = fsdevice_get_path(8)) != NULL)
+         {
+            log_resources_set_int("IECDevice8", 0);
+            log_resources_set_int("FileSystemDevice8", 0);
+            log_resources_set_string("FSDevice8Dir", "");
+         }
+
+         if ((attached_image = fsdevice_get_path(9)) != NULL)
+         {
+            log_resources_set_int("IECDevice9", 0);
+            log_resources_set_int("FileSystemDevice9", 0);
+            log_resources_set_string("FSDevice9Dir", "");
+         }
+
+         drive_reset();
+
+         switch (work_disk_type)
+         {
+            default:
+               if (work_disk_unit == 9)
+                  log_resources_set_int("Drive9Type", work_disk_type);
+               file_system_attach_disk(work_disk_unit, 0, work_disk_filepath);
+               autodetect_drivetype(work_disk_unit);
+               log_cb(RETRO_LOG_INFO, "Work disk '%s' attached to drive #%d\n", work_disk_filepath, work_disk_unit);
+               break;
+            case DISK_IMAGE_TYPE_FS:
+               switch (work_disk_unit)
+               {
+                  default:
+                  case 8:
+                     log_resources_set_int("IECDevice8", 1);
+                     log_resources_set_int("FileSystemDevice8", 1);
+                     log_resources_set_string("FSDevice8Dir", work_disk_filepath);
+                     break;
+                  case 9:
+                     log_resources_set_int("IECDevice9", 1);
+                     log_resources_set_int("FileSystemDevice9", 1);
+                     log_resources_set_string("FSDevice9Dir", work_disk_filepath);
+                     break;
+               }
+               log_cb(RETRO_LOG_INFO, "Work directory '%s' attached to drive #%d\n", work_disk_filepath, work_disk_unit);
+               break;
+         }
+
+         display_current_image(work_disk_filename, true);
       }
    }
    else
    {
       /* Detach work disk if disabled while running */
-      if ((attached_image = file_system_get_disk_name(8, 0)) != NULL && strstr(attached_image, "vice_work"))
+      if ((attached_image = file_system_get_disk_name(8, 0)) != NULL && strstr(attached_image, work_disk_basename))
       {
-         if (string_is_empty(full_path) || (!string_is_empty(full_path) && !strstr(full_path, "vice_work")))
+         if (string_is_empty(full_path) || (!string_is_empty(full_path) && !strstr(full_path, work_disk_filename)))
          {
             log_cb(RETRO_LOG_INFO, "Work disk '%s' detached from drive #%d\n", attached_image, 8);
             file_system_detach_disk(8, 0);
             log_resources_set_int("Drive8Type", DRIVE_TYPE_DEFAULT);
-            display_current_image(attached_image, false);
+            display_current_image("", false);
          }
       }
 
-      if ((attached_image = file_system_get_disk_name(9, 0)) != NULL && strstr(attached_image, "vice_work"))
+      if ((attached_image = fsdevice_get_path(8)) != NULL && strstr(attached_image, work_disk_basename))
+      {
+         if (string_is_empty(full_path) || (!string_is_empty(full_path) && !strstr(full_path, work_disk_filename)))
+         {
+            log_cb(RETRO_LOG_INFO, "Work directory '%s' detached from drive #%d\n", attached_image, 8);
+            log_resources_set_int("IECDevice8", 0);
+            log_resources_set_int("FileSystemDevice8", 0);
+            display_current_image("", false);
+         }
+      }
+
+      if ((attached_image = file_system_get_disk_name(9, 0)) != NULL && strstr(attached_image, work_disk_basename))
       {
          log_cb(RETRO_LOG_INFO, "Work disk '%s' detached from drive #%d\n", attached_image, 9);
          file_system_detach_disk(9, 0);
          log_resources_set_int("Drive9Type", DRIVE_TYPE_NONE);
+         display_current_image("", false);
+      }
+
+      if ((attached_image = fsdevice_get_path(9)) != NULL && strstr(attached_image, work_disk_basename))
+      {
+         log_cb(RETRO_LOG_INFO, "Work directory '%s' detached from drive #%d\n", attached_image, 9);
+         log_resources_set_int("IECDevice9", 0);
+         log_resources_set_int("FileSystemDevice9", 0);
+         display_current_image("", false);
       }
    }
 }
@@ -2330,7 +2423,7 @@ static void retro_set_core_options()
          "vice_work_disk",
          "Media > Global Work Disk",
          "Global Work Disk",
-         "Global disk in device 8 is only inserted when core is started without content.",
+         "Global disk in device 8 is only inserted when core is started without content. Files and directories are named 'vice_work'.\n",
          NULL,
          "media",
          {
@@ -2341,6 +2434,8 @@ static void retro_set_core_options()
             { "9_d71", "D71 - 1328 blocks, 340kB - Device 9" },
             { "8_d81", "D81 - 3160 blocks, 800kB - Device 8" },
             { "9_d81", "D81 - 3160 blocks, 800kB - Device 9" },
+            { "8_fs", "FileSystem - Device 8" },
+            { "9_fs", "FileSystem - Device 9" },
             { NULL, NULL },
          },
          "disabled"
@@ -4540,6 +4635,7 @@ static void update_variables(void)
          if      (strstr(var.value, "_d64")) opt_work_disk_type = DISK_IMAGE_TYPE_D64;
          else if (strstr(var.value, "_d71")) opt_work_disk_type = DISK_IMAGE_TYPE_D71;
          else if (strstr(var.value, "_d81")) opt_work_disk_type = DISK_IMAGE_TYPE_D81;
+         else if (strstr(var.value, "_fs"))  opt_work_disk_type = DISK_IMAGE_TYPE_FS;
 
          if      (strstr(var.value, "8_"))   opt_work_disk_unit = 8;
          else if (strstr(var.value, "9_"))   opt_work_disk_unit = 9;
@@ -7422,7 +7518,7 @@ bool retro_load_game(const struct retro_game_info *info)
       local_path = utf8_to_local_string_alloc(info->path);
       if (local_path)
       {
-         if (path_is_valid(info->path) && !path_is_directory(info->path))
+         if (path_is_valid(info->path))
             process_cmdline(local_path);
          else
             process_cmdline("");

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -341,4 +341,6 @@ struct vice_cart_info
 #include "petmodel.h"
 #endif
 
+#define DISK_IMAGE_TYPE_FS 0xFFFF
+
 #endif /* LIBRETRO_CORE_H */

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -179,9 +179,6 @@ extern int zoom_mode_id_prev;
 #define ZOOM_LEFT_BORDER 32
 #endif
 
-extern bool retro_message;
-extern char retro_message_msg[1024];
-
 enum
 {
    RUNSTATE_FIRST_START = 0,
@@ -194,6 +191,7 @@ extern long retro_ticks(void);
 extern void reload_restart(void);
 extern void emu_reset(int type);
 extern int RGBc(int r, int g, int b);
+extern void display_retro_message(const char *message);
 
 extern void emu_function(int function);
 enum EMU_FUNCTIONS

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -688,6 +688,7 @@ bool dc_save_disk_toggle(dc_storage* dc, bool file_check, bool select)
       unsigned save_disk_index = 0;
       unsigned index = 0;
       char save_disk_label[64] = {0};
+      char message[1024] = {0};
 
       snprintf(save_disk_label, 64, "%s %u",
             M3U_SAVEDISK_LABEL, 0);
@@ -712,10 +713,10 @@ bool dc_save_disk_toggle(dc_storage* dc, bool file_check, bool select)
       retro_disk_set_eject_state(false);
 
       /* Widget notification */
-      snprintf(retro_message_msg, sizeof(retro_message_msg),
+      snprintf(message, sizeof(message),
                "%d/%d - %s",
                dc->index+1, dc->count, path_basename(dc->labels[dc->index]));
-      retro_message = true;
+      display_retro_message(message);
    }
    else
       log_cb(RETRO_LOG_INFO, "Save Disk 0 appended\n");

--- a/libretro/libretro-glue.c
+++ b/libretro/libretro-glue.c
@@ -141,6 +141,25 @@ char *path_remove_program(char *path)
    return path;
 }
 
+char *first_file_in_dir(char *path)
+{
+   DIR *path_dir;
+   struct dirent *path_dirp;
+
+   path_dir = opendir(path);
+   char *path_lastfile = {0};
+   while ((path_dirp = readdir(path_dir)) != NULL && string_is_empty(path_lastfile))
+   {
+      if (path_dirp->d_name[0] == '.')
+         continue;
+
+      path_lastfile = local_to_utf8_string_alloc(path_dirp->d_name);
+   }
+   closedir(path_dir);
+
+   return path_lastfile;
+}
+
 /* zlib */
 void zip_uncompress(char *in, char *out, char *lastfile)
 {

--- a/libretro/libretro-glue.h
+++ b/libretro/libretro-glue.h
@@ -29,6 +29,7 @@ bool strstartswith(const char* str, const char* start);
 bool strendswith(const char* str, const char* end);
 void path_join(char* out, const char* basedir, const char* filename);
 char *path_remove_program(char *path);
+char *first_file_in_dir(char *path);
 
 /* VICE helpers */
 extern int log_resources_set_int(const char *name, int value);

--- a/retrodep/snapshot_stream.c
+++ b/retrodep/snapshot_stream.c
@@ -1128,6 +1128,9 @@ snapshot_t *snapshot_create_from_stream(snapshot_stream_t *f, uint8_t major_vers
     return s;
 
 fail:
+#ifdef __LIBRETRO__
+    snapshot_display_error();
+#endif
     return NULL;
 }
 
@@ -1219,6 +1222,9 @@ snapshot_t *snapshot_open_from_stream(snapshot_stream_t *f, uint8_t *major_versi
     return s;
 
 fail:
+#ifdef __LIBRETRO__
+    snapshot_display_error();
+#endif
     return NULL;
 }
 

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -128,6 +128,7 @@ void ui_error(const char *format, ...)
    vsprintf(text, format, ap);
    va_end(ap);
    log_cb(RETRO_LOG_ERROR, "%s\n", text);
+   display_retro_message(text);
 }
 
 int ui_emulation_is_paused(void)

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -182,6 +182,7 @@ int ui_init_finalize(void)
    log_resources_set_int("Printer4", 1);
    log_resources_set_int("AutostartPrgMode", 1);
    log_resources_set_int("AutostartDelayRandom", 0);
+   log_resources_set_int("FSDeviceLongNames", 1);
 
    /* Machine specific defaults */
 #if defined(__X64DTV__)

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -182,8 +182,6 @@ int ui_init_finalize(void)
    log_resources_set_int("Printer4", 1);
    log_resources_set_int("AutostartPrgMode", 1);
    log_resources_set_int("AutostartDelayRandom", 0);
-   log_resources_set_int("FileSystemDevice8", 0);
-   log_resources_set_int("FSDevice8ConvertP00", 0);
 
    /* Machine specific defaults */
 #if defined(__X64DTV__)

--- a/vice/src/serial/fsdrive.c
+++ b/vice/src/serial/fsdrive.c
@@ -45,7 +45,6 @@
  * kernel traps are in use.
  */
 /* #define FSDRIVE_DEBUG */
-#define FSDRIVE_DEBUG
 #ifdef FSDRIVE_DEBUG
 #define DBG(_x_)        log_debug _x_
 #else


### PR DESCRIPTION
Main:
- FileSystem can be used either via launching a directory or via work disk option
- M3U parsing allows quotes for including empty space endings in prg names
- M3U dupecheck fixed to be able to include the same disk with a different label

Other:
- FSDRIVE debug logging removal
- Snapshot error messages to log and as core message

