### PR TITLE
Add REU core option for x128

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2060,6 +2060,27 @@ static void retro_set_core_options()
          "C128 PAL"
       },
       {
+         "vice_c128_ram_expansion_unit",
+         "RAM Expansion Unit",
+         NULL,
+         "Changing while running resets the system!",
+         NULL,
+         NULL,
+         {
+            { "none", "disabled" },
+            { "128kB", "128kB (1700)" },
+            { "256kB", "256kB (1764)" },
+            { "512kB", "512kB (1750)" },
+            { "1024kB", "1024kB" },
+            { "2048kB", "2048kB" },
+            { "4096kB", "4096kB" },
+            { "8192kB", "8192kB" },
+            { "16384kB", "16384kB" },
+            { NULL, NULL },
+         },
+         "none"
+      },
+      {
          "vice_c128_video_output",
          "Video Output",
          NULL,
@@ -4917,6 +4938,30 @@ static void update_variables(void)
       }
 
       vice_opt.Model = model;
+   }
+
+   var.key = "vice_c128_ram_expansion_unit";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      int reusize = 0;
+
+      if (strcmp(var.value, "none"))
+         reusize = atoi(var.value);
+
+      if (retro_ui_finalized && vice_opt.REUsize != reusize)
+      {
+         if (!reusize)
+            log_resources_set_int("REU", 0);
+         else
+         {
+            log_resources_set_int("REUsize", reusize);
+            log_resources_set_int("REU", 1);
+         }
+         request_restart = true;
+      }
+
+      vice_opt.REUsize = reusize;
    }
 
    var.key = "vice_c128_video_output";

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -249,11 +249,12 @@ struct vice_core_options
 #if !defined(__XPET__)
    char CartridgeFile[RETRO_PATH_MAX];
 #endif
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+   int REUsize;
+#endif
 #if defined(__X128__)
    int C128ColumnKey;
    int Go64Mode;
-#elif defined(__X64__) || defined(__X64SC__)
-   int REUsize;
 #elif defined(__XSCPU64__)
    int SIMMSize;
    int SpeedSwitch;

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -456,6 +456,15 @@ int ui_init_finalize(void)
 #endif
 
    /* Misc model specific */
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__)
+   if (vice_opt.REUsize)
+   {
+      log_resources_set_int("REUsize", vice_opt.REUsize);
+      log_resources_set_int("REU", 1);
+   }
+   else
+      log_resources_set_int("REU", 0);
+#endif
 #if defined(__X128__)
    log_resources_set_int("Go64Mode", vice_opt.Go64Mode);
    log_resources_set_int("C128ColumnKey", vice_opt.C128ColumnKey);
@@ -501,14 +510,6 @@ int ui_init_finalize(void)
    log_resources_set_int("RAMBlock2", (vic_blocks & VIC_BLK2) ? 1 : 0);
    log_resources_set_int("RAMBlock3", (vic_blocks & VIC_BLK3) ? 1 : 0);
    log_resources_set_int("RAMBlock5", (vic_blocks & VIC_BLK5) ? 1 : 0);
-#elif defined(__X64__) || defined(__X64SC__)
-   if (vice_opt.REUsize)
-   {
-      log_resources_set_int("REUsize", vice_opt.REUsize);
-      log_resources_set_int("REU", 1);
-   }
-   else
-      log_resources_set_int("REU", 0);
 #elif defined(__XSCPU64__)
    log_resources_set_int("SIMMSize", vice_opt.SIMMSize);
    log_resources_set_int("SpeedSwitch", vice_opt.SpeedSwitch);


### PR DESCRIPTION
921715e66c86aed76afbe6c9a92b20f1b3790640 added core options for RAM Expansion Units to C64-based cores, but C128 got left out of the party. This brings the x128 emutype in-line with the others.

This is particularly useful right now thanks to [mrsid's brand new Sonic the Hedgehog 1 C64 port](https://www.lemon64.com/forum/viewtopic.php?t=78945), which requires an REU of 256KB or greater (with 512KB, you can load the entire game into the REU on start). While the game of course runs on C64, using the C128 reduces the in-game slowdown.