### PR TITLE
Fix internal gzip extraction

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2524,8 +2524,8 @@ static void retro_set_core_options()
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__)
             /* Automatic only for VIC-II */
             { "auto", "Automatic" },
-#endif
             { "auto_disable", "Auto-Disable" },
+#endif
             { "manual", "Manual" },
             { NULL, NULL },
          },
@@ -3221,7 +3221,7 @@ static void retro_set_core_options()
          "vice_resid_gain",
          "Audio > ReSID Filter Gain",
          "ReSID Filter Gain",
-         "Gain in percent.",
+         "Filter gain in percent.",
          NULL,
          "audio",
          {

--- a/retrodep/archdep.c
+++ b/retrodep/archdep.c
@@ -79,6 +79,7 @@
 #include "libretro-core.h"
 extern unsigned int opt_read_vicerc;
 extern char full_path[RETRO_PATH_MAX];
+extern char retro_temp_directory[RETRO_PATH_MAX];
 
 static char *argv0 = NULL;
 static char *boot_path = NULL;
@@ -518,7 +519,9 @@ char *archdep_tmpnam(void)
     lib_free(tmpName);
     return lib_strdup(tmpName);
 #elif __LIBRETRO__
-    return NULL;
+    char tmp_name[RETRO_PATH_MAX];
+    snprintf(tmp_name, sizeof(tmp_name), "%s%s%s%d", retro_temp_directory, FSDEV_DIR_SEP_STR, "vice-tmp-", rand());
+    return lib_strdup(tmp_name);
 #else
     return lib_strdup(tmpnam(NULL));
 #endif


### PR DESCRIPTION
- Filter gain sublabel + zoom option correction
- Fix crash when internal temp names are used with gzipped files
Closes #449 
