### PR TITLE
Fix Plus/4 disk drive issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,6 @@ xvic -memory 20 "/path/to/rom/some-8k-game.d64"
 
 ## Build instructions
 
-Remember to run `make clean EMUTYPE=x` when building different EMUTYPEs.
-
 Currently working EMUTYPEs:
 
 - `x64`
@@ -229,22 +227,20 @@ Currently working EMUTYPEs:
 - `xscpu64`
 - `xvic`
 
-### Linux
+Remember to run `make clean EMUTYPE=x` or `make objectclean EMUTYPE=x` first before `make EMUTYPE=x` when building different EMUTYPEs.
+
+`x64` is the default when `EMUTYPE` is not defined.
+
+### Linux & Windows
 
 ```
-CC=gcc make -j4
-```
-
-### Windows
-
-```
-make -j4
+make
 ```
 
 ### Win64 (crossbuild)
 
 ```
-make platform=wincross64 -j4
+make platform=wincross64
 ```
 
 ### Android standalone toolchain Build
@@ -254,7 +250,7 @@ export path to your standalone toolchain like
 
 export PATH=$PATH:/opt/standtc/bin
 
-make platform=androidstc -j4
+make platform=androidstc
 ```
 
 ### Android ndk Build

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1579,6 +1579,16 @@ void update_from_vice()
                file_system_attach_disk(dc->unit, 0, attachedImage);
             }
          }
+#if defined(__XPLUS4__)
+         /* Band-aid for disk drive issues:
+          * - D64s fail to read
+          * - D81s fail to stop drive sound emulation */
+         if (dc_get_image_type(dc->files[dc->index]) == DC_IMAGE_TYPE_FLOPPY)
+         {
+            log_resources_set_int("Drive8Type", 0);
+            autodetect_drivetype(dc->unit);
+         }
+#endif
       }
       else if (dc->unit == 0)
       {

--- a/vice/src/log.c
+++ b/vice/src/log.c
@@ -497,7 +497,7 @@ int log_debug(const char *format, ...)
     int rc;
 
     va_start(ap, format);
-#if 1
+#if 0
     vprintf(format, ap);
     printf("\n");
 #else


### PR DESCRIPTION
Band-aid for Plus/4 disk drive issues:
- D64s fail to read
- D81s fail to stop drive sound emulation

Closes #455 