### PR TITLE
Audio cleanup + pacing

### DIFF
--- a/retrodep/soundretro.c
+++ b/retrodep/soundretro.c
@@ -7,7 +7,7 @@
 #include "sound.h"
 
 #include "libretro-core.h"
-extern void retro_audio_render(const int16_t *data, size_t frames);
+extern void retro_audio_queue(const int16_t *data, int32_t samples);
 
 static int retro_sound_init(const char *param, int *speed, int *fragsize, int *fragnr, int *channels)
 {
@@ -23,7 +23,7 @@ static int retro_sound_write(SWORD *pbuf, size_t nr)
 #if 0
     printf("pbuf:%d nr:%d\n", *pbuf, nr);
 #endif
-    retro_audio_render(pbuf, nr);
+    retro_audio_queue(pbuf, nr);
     return 0;
 }
 

--- a/retrodep/soundretro.c
+++ b/retrodep/soundretro.c
@@ -3,8 +3,6 @@
  *
  */
 
-#ifdef __LIBRETRO__
-
 #include "vice.h"
 #include "sound.h"
 
@@ -20,7 +18,7 @@ static int retro_sound_init(const char *param, int *speed, int *fragsize, int *f
     return 0;
 }
 
-static int retro_write(SWORD *pbuf, size_t nr)
+static int retro_sound_write(SWORD *pbuf, size_t nr)
 {
 #if 0
     printf("pbuf:%d nr:%d\n", *pbuf, nr);
@@ -29,24 +27,20 @@ static int retro_write(SWORD *pbuf, size_t nr)
     return 0;
 }
 
-static int retro_flush(char *state)
-{
-    return 0;
-}
-
 static sound_device_t retro_device =
 {
-    "retro",
-    retro_sound_init,
-    retro_write,
-    NULL,
-    NULL,/*retro_flush,*/
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    0,
-    2
+    "retro",            /* name */
+    retro_sound_init,   /* init */
+    retro_sound_write,  /* write */
+    NULL,               /* dump */
+    NULL,               /* flush */
+    NULL,               /* bufferspace */
+    NULL,               /* close */
+    NULL,               /* suspend */
+    NULL,               /* resume */
+    0,                  /* need_attenuation */
+    2,                  /* max_channels */
+    true                /* is_timing_source */
 };
 
 int sound_init_retro_device(void)
@@ -54,4 +48,3 @@ int sound_init_retro_device(void)
     return sound_register_device(&retro_device);
 }
 
-#endif

--- a/vice/src/vsync.c
+++ b/vice/src/vsync.c
@@ -540,12 +540,11 @@ void vsync_do_end_of_line(void)
              */
 
             sync_target_tick += sync_emulated_ticks;
-#ifndef __LIBRETRO__
+
             /* Some tricky wrap around cases to deal with */
             if (sync_target_tick - tick_now > 0 && sync_target_tick - tick_now < tick_per_second()) {
                 tick_sleep(sync_target_tick - tick_now);
             }
-#endif
         }
         
         last_sync_tick = tick_now;


### PR DESCRIPTION
- Set retro audio as "timing source", which allows the removal of a hack which made fast-forwarding possible
- Audio pacing fix copied from https://github.com/libretro/libretro-uae/pull/499
