### PR TITLE
VKBD enhancements

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -7839,7 +7839,7 @@ void retro_run(void)
       statusbar_message_timer--;
 
    /* Forced statusbar messages */
-   if (!retro_statusbar && opt_statusbar & STATUSBAR_MESSAGES && statusbar_message_timer)
+   if ((!retro_statusbar && opt_statusbar & STATUSBAR_MESSAGES && statusbar_message_timer) || retro_statusbar)
       uistatusbar_draw();
 
    /* Set volume back to maximum after starting with mute, due to ReSID 6581 init pop */

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -167,6 +167,12 @@ extern int zoom_mode_id_prev;
 #define ZOOM_HEIGHT_MAX  200
 #define ZOOM_TOP_BORDER  VICII_NO_BORDER_FIRST_DISPLAYED_LINE - vicii.first_displayed_line
 #define ZOOM_LEFT_BORDER vicii.screen_leftborderwidth
+#if defined(__X128__)
+#define ZOOM_VDC_WIDTH_MAX   640
+#define ZOOM_VDC_HEIGHT_MAX  200
+#define ZOOM_VDC_TOP_BORDER  44
+#define ZOOM_VDC_LEFT_BORDER 108
+#endif
 #elif defined(__XVIC__)
 /* PAL: 448x284, NTSC: 400x234, VIC: 352x184 */
 #define ZOOM_WIDTH_MAX   352
@@ -275,6 +281,7 @@ struct vice_core_options
    int REUsize;
 #endif
 #if defined(__X128__)
+   int VDC64KB;
    int C128ColumnKey;
    int Go64Mode;
 #elif defined(__XSCPU64__)

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -1128,7 +1128,8 @@ enum dc_image_type dc_get_image_type(const char* filename)
 
    /* Tape image */
    if (strendswith(filename, "tap") ||
-       strendswith(filename, "t64"))
+       strendswith(filename, "t64") ||
+       strendswith(filename, "tcrt"))
       return DC_IMAGE_TYPE_TAPE;
 
    /* Memory image */

--- a/libretro/libretro-graph.c
+++ b/libretro/libretro-graph.c
@@ -7,6 +7,8 @@
 #include "libretro-graph.h"
 #include "libretro-font.i"
 
+unsigned short int graphed[RETRO_BMP_SIZE];
+
 static uint16_t *linesurf16 = NULL;
 static int linesurf16_w     = 0;
 static int linesurf16_h     = 0;
@@ -186,53 +188,379 @@ void draw_fbox_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t co
 }
 
 
-void draw_box(int x, int y, int dx, int dy, uint32_t color)
+void draw_box(int x, int y, int dx, int dy, int width, int height, uint32_t color, libretro_graph_alpha_t alpha)
 {
    if (pix_bytes == 4)
-      draw_box_bmp32((uint32_t *)retro_bmp, x, y, dx, dy, color);
+      draw_box_bmp32((uint32_t *)retro_bmp, x, y, dx, dy, width, height, color, alpha);
    else
-      draw_box_bmp16((uint16_t *)retro_bmp, x, y, dx, dy, color);
+      draw_box_bmp16((uint16_t *)retro_bmp, x, y, dx, dy, width, height, color, alpha);
 }
 
-void draw_box_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t color)
+void draw_box_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, int width, int height, uint16_t color, libretro_graph_alpha_t alpha)
 {
-   int i, j, idx;
+   int i, j, k, idx;
+   uint16_t *buf_ptr;
 
-   for (i = x; i < x + dx; i++)
+   switch (alpha)
    {
-      idx = i + (y * retrow);
-      buffer[idx] = color;
-      idx = i + ((y + dy) * retrow);
-      buffer[idx] = color;
-   }
+      case GRAPH_ALPHA_0:
+         /* Do nothing - buffer is already the
+          * correct colour */
+         break;
+      case GRAPH_ALPHA_25:
+         for (i = x; i < x + dx + width; i++)
+         {
+            for (k = 0; k < height; k++)
+            {
+               idx = i + (y * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA25(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = i + ((y + dy) * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA25(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
 
-   for (j = y; j < y + dy; j++)
-   {
-      idx = x + (j * retrow);
-      buffer[idx] = color;
-      idx = (x + dx) + (j * retrow);
-      buffer[idx] = color;
+         for (j = y + height; j < y + dy; j++)
+         {
+            for (k = 0; k < width; k++)
+            {
+               idx = x + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA25(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = (x + dx) + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA25(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
+         break;
+      case GRAPH_ALPHA_50:
+         for (i = x; i < x + dx + width; i++)
+         {
+            for (k = 0; k < height; k++)
+            {
+               idx = i + (y * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA50(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = i + ((y + dy) * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA50(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
+
+         for (j = y + height; j < y + dy; j++)
+         {
+            for (k = 0; k < width; k++)
+            {
+               idx = x + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA50(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = (x + dx) + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA50(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
+         break;
+      case GRAPH_ALPHA_75:
+         for (i = x; i < x + dx + width; i++)
+         {
+            for (k = 0; k < height; k++)
+            {
+               idx = i + (y * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA75(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = i + ((y + dy) * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA75(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
+
+         for (j = y + height; j < y + dy; j++)
+         {
+            for (k = 0; k < width; k++)
+            {
+               idx = x + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA75(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = (x + dx) + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND_ALPHA75(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
+         break;
+      case GRAPH_ALPHA_100:
+      default:
+         for (i = x; i <= x + dx; i++)
+         {
+            for (k = 0; k < height; k++)
+            {
+               idx = + i + (y * retrow) + (k * retrow);
+               if (!graphed[idx])
+               {
+                  buffer[idx] = color;
+                  graphed[idx] = 1;
+               }
+               idx = i + ((y + dy) * retrow) + (k * retrow);
+               if (!graphed[idx])
+               {
+                  buffer[idx] = color;
+                  graphed[idx] = 1;
+               }
+            }
+         }
+
+         for (j = y; j <= y + dy; j++)
+         {
+            for (k = 0; k < width; k++)
+            {
+               idx = x + (j * retrow) + k;
+               if (!graphed[idx])
+               {
+                  buffer[idx] = color;
+                  graphed[idx] = 1;
+               }
+               idx = (x + dx) + (j * retrow) + k;
+               if (!graphed[idx])
+               {
+                  buffer[idx] = color;
+                  graphed[idx] = 1;
+               }
+            }
+         }
+         break;
    }
 }
 
-void draw_box_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color)
+void draw_box_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, int width, int height, uint32_t color, libretro_graph_alpha_t alpha)
 {
-   int i, j, idx;
+   int i, j, k, idx;
+   uint32_t *buf_ptr;
 
-   for (i = x; i < x + dx; i++)
-   {
-      idx = i + (y * retrow);
-      buffer[idx] = color;
-      idx = i + ((y + dy) * retrow);
-      buffer[idx] = color;
-   }
+   color = color & 0xFFFFFF;
 
-   for (j = y; j < y + dy; j++)
+   switch (alpha)
    {
-      idx = x + (j * retrow);
-      buffer[idx] = color;
-      idx = (x + dx) + (j * retrow);
-      buffer[idx] = color;
+      case GRAPH_ALPHA_0:
+         /* Do nothing - buffer is already the
+          * correct colour */
+         break;
+      case GRAPH_ALPHA_25:
+         for (i = x; i < x + dx + width; i++)
+         {
+            for (k = 0; k < height; k++)
+            {
+               idx = i + (y * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA25(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = i + ((y + dy) * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA25(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
+
+         for (j = y + height; j < y + dy; j++)
+         {
+            for (k = 0; k < width; k++)
+            {
+               idx = x + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA25(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = (x + dx) + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA25(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
+         break;
+      case GRAPH_ALPHA_50:
+         for (i = x; i < x + dx + width; i++)
+         {
+            for (k = 0; k < height; k++)
+            {
+               idx = i + (y * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA50(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = i + ((y + dy) * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA50(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
+
+         for (j = y + height; j < y + dy; j++)
+         {
+            for (k = 0; k < width; k++)
+            {
+               idx = x + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA50(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = (x + dx) + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA50(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
+         break;
+      case GRAPH_ALPHA_75:
+         for (i = x; i < x + dx + width; i++)
+         {
+            for (k = 0; k < height; k++)
+            {
+               idx = i + (y * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA75(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = i + ((y + dy) * retrow) + (k * retrow);
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA75(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
+
+         for (j = y + height; j < y + dy; j++)
+         {
+            for (k = 0; k < width; k++)
+            {
+               idx = x + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA75(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+               idx = (x + dx) + (j * retrow) + k;
+               buf_ptr = &buffer[idx];
+               if (!graphed[idx])
+               {
+                  BLEND32_ALPHA75(color, *buf_ptr, buf_ptr);
+                  graphed[idx] = 1;
+               }
+            }
+         }
+         break;
+      case GRAPH_ALPHA_100:
+      default:
+         for (i = x; i <= x + dx; i++)
+         {
+            for (k = 0; k < height; k++)
+            {
+               idx = + i + (y * retrow) + (k * retrow);
+               if (!graphed[idx])
+               {
+                  buffer[idx] = color;
+                  graphed[idx] = 1;
+               }
+               idx = i + ((y + dy) * retrow) + (k * retrow);
+               if (!graphed[idx])
+               {
+                  buffer[idx] = color;
+                  graphed[idx] = 1;
+               }
+            }
+         }
+
+         for (j = y; j <= y + dy; j++)
+         {
+            for (k = 0; k < width; k++)
+            {
+               idx = x + (j * retrow) + k;
+               if (!graphed[idx])
+               {
+                  buffer[idx] = color;
+                  graphed[idx] = 1;
+               }
+               idx = (x + dx) + (j * retrow) + k;
+               if (!graphed[idx])
+               {
+                  buffer[idx] = color;
+                  graphed[idx] = 1;
+               }
+            }
+         }
+         break;
    }
 }
 
@@ -403,7 +731,8 @@ static void draw_char_1pass32(const char *string, uint16_t strlen,
 static void draw_char_2pass16(uint16_t *surf,
       uint16_t x, uint16_t y,
       uint8_t xscale, uint8_t yscale,
-      uint16_t fg, uint16_t bg, libretro_graph_bg_t draw_bg)
+      uint16_t fg, uint16_t bg,
+      libretro_graph_alpha_t alpha, libretro_graph_bg_t draw_bg)
 {
    short int xrepeat = 0;
    short int yrepeat = 0;
@@ -436,7 +765,26 @@ static void draw_char_2pass16(uint16_t *surf,
                {
                   if (yrepeat > y - yscale && yrepeat < surfh + y - (yscale * 2) &&
                       xrepeat >= x + xscale && xrepeat < surfw + x - xscale)
-                     ; /* no-op */
+                  {
+                     switch (alpha)
+                     {
+                        case GRAPH_ALPHA_0:
+                           *yptr = *surf_ptr;
+                           break;
+                        case GRAPH_ALPHA_25:
+                           BLEND_ALPHA25(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_50:
+                           BLEND_ALPHA50(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_75:
+                           BLEND_ALPHA75(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_100:
+                        default:
+                           break;
+                     }
+                  }
                   else
                      *yptr = 0;
                }
@@ -459,7 +807,26 @@ static void draw_char_2pass16(uint16_t *surf,
                   /* Bottom right */
                   if (pcount >= surfhxscale+xscale &&
                       yptr[-surfhxscale-xscale] == fg)
-                     ; /* no-op */
+                  {
+                     switch (alpha)
+                     {
+                        case GRAPH_ALPHA_0:
+                           *yptr = *surf_ptr;
+                           break;
+                        case GRAPH_ALPHA_25:
+                           BLEND_ALPHA25(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_50:
+                           BLEND_ALPHA50(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_75:
+                           BLEND_ALPHA75(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_100:
+                        default:
+                           break;
+                     }
+                  }
                   else
                      *yptr = 0;
                }
@@ -492,7 +859,26 @@ static void draw_char_2pass16(uint16_t *surf,
                       (pcount >= xscale             && yptr[-xscale] == fg)             ||
                       (pcount >= 0                  && yptr[+xscale] == fg)
                   )
-                     ; /* no-op */
+                  {
+                     switch (alpha)
+                     {
+                        case GRAPH_ALPHA_0:
+                           *yptr = *surf_ptr;
+                           break;
+                        case GRAPH_ALPHA_25:
+                           BLEND_ALPHA25(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_50:
+                           BLEND_ALPHA50(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_75:
+                           BLEND_ALPHA75(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_100:
+                        default:
+                           break;
+                     }
+                  }
                   else
                      *yptr = 0;
                }
@@ -523,7 +909,8 @@ static void draw_char_2pass16(uint16_t *surf,
 static void draw_char_2pass32(uint32_t *surf,
       uint16_t x, uint16_t y,
       uint8_t xscale, uint8_t yscale,
-      uint32_t fg, uint32_t bg, libretro_graph_bg_t draw_bg)
+      uint32_t fg, uint32_t bg,
+      libretro_graph_alpha_t alpha, libretro_graph_bg_t draw_bg)
 {
    short int xrepeat = 0;
    short int yrepeat = 0;
@@ -556,7 +943,26 @@ static void draw_char_2pass32(uint32_t *surf,
                {
                   if (yrepeat > y - yscale && yrepeat < surfh + y - (yscale * 2) &&
                       xrepeat >= x + xscale && xrepeat < surfw + x - xscale)
-                     ; /* no-op */
+                  {
+                     switch (alpha)
+                     {
+                        case GRAPH_ALPHA_0:
+                           *yptr = *surf_ptr;
+                           break;
+                        case GRAPH_ALPHA_25:
+                           BLEND32_ALPHA25(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_50:
+                           BLEND32_ALPHA50(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_75:
+                           BLEND32_ALPHA75(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_100:
+                        default:
+                           break;
+                     }
+                  }
                   else
                      *yptr = 0;
                }
@@ -579,7 +985,26 @@ static void draw_char_2pass32(uint32_t *surf,
                   /* Bottom right */
                   if (pcount >= surfhxscale+xscale &&
                       yptr[-surfhxscale-xscale] == fg)
-                     ; /* no-op */
+                  {
+                     switch (alpha)
+                     {
+                        case GRAPH_ALPHA_0:
+                           *yptr = *surf_ptr;
+                           break;
+                        case GRAPH_ALPHA_25:
+                           BLEND32_ALPHA25(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_50:
+                           BLEND32_ALPHA50(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_75:
+                           BLEND32_ALPHA75(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_100:
+                        default:
+                           break;
+                     }
+                  }
                   else
                      *yptr = 0;
                }
@@ -612,7 +1037,26 @@ static void draw_char_2pass32(uint32_t *surf,
                       (pcount >= xscale             && yptr[-xscale] == fg)             ||
                       (pcount >= 0                  && yptr[+xscale] == fg)
                   )
-                     ; /* no-op */
+                  {
+                     switch (alpha)
+                     {
+                        case GRAPH_ALPHA_0:
+                           *yptr = *surf_ptr;
+                           break;
+                        case GRAPH_ALPHA_25:
+                           BLEND32_ALPHA25(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_50:
+                           BLEND32_ALPHA50(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_75:
+                           BLEND32_ALPHA75(*surf_ptr, bg, yptr);
+                           break;
+                        case GRAPH_ALPHA_100:
+                        default:
+                           break;
+                     }
+                  }
                   else
                      *yptr = 0;
                }
@@ -651,7 +1095,7 @@ void draw_string_bmp16(uint16_t *surf, uint16_t x, uint16_t y,
    unsigned char surfh;
    unsigned char charw = 8;
    unsigned char charh = 8;
-   uint16_t fg_blend = (fg == COLOR_BLACK_16) ? COLOR_GRAY_16 : COLOR_BLACK_16;
+   uint16_t fg_blend = COLOR_BLACK_16;
 
    if (!string)
       return;
@@ -702,7 +1146,7 @@ void draw_string_bmp16(uint16_t *surf, uint16_t x, uint16_t y,
    }
 
    draw_char_1pass16(string, strlen, charw, charh, xscale, yscale, fg, bg);
-   draw_char_2pass16(surf, x, y, xscale, yscale, fg, bg, draw_bg);
+   draw_char_2pass16(surf, x, y, xscale, yscale, fg, bg, alpha, draw_bg);
 }
 
 void draw_string_bmp32(uint32_t *surf, uint16_t x, uint16_t y,
@@ -715,7 +1159,7 @@ void draw_string_bmp32(uint32_t *surf, uint16_t x, uint16_t y,
    unsigned char surfh;
    unsigned char charw = 8;
    unsigned char charh = 8;
-   uint32_t fg_blend = (fg == COLOR_BLACK_32) ? COLOR_GRAY_32 & 0xFFFFFF : COLOR_BLACK_32 & 0xFFFFFF;
+   uint32_t fg_blend = COLOR_BLACK_32 & 0xFFFFFF;
 
    if (!string)
       return;
@@ -769,7 +1213,7 @@ void draw_string_bmp32(uint32_t *surf, uint16_t x, uint16_t y,
    }
 
    draw_char_1pass32(string, strlen, charw, charh, xscale, yscale, fg, bg);
-   draw_char_2pass32(surf, x, y, xscale, yscale, fg, bg, draw_bg);
+   draw_char_2pass32(surf, x, y, xscale, yscale, fg, bg, alpha, draw_bg);
 }
 
 void draw_text(uint16_t x, uint16_t y,

--- a/libretro/libretro-graph.h
+++ b/libretro/libretro-graph.h
@@ -8,11 +8,9 @@
 #define COLOR_RED_16             RGB565(128,   0,   0)
 #define COLOR_RED_32       ARGB888(255, 128,   0,   0)
 
-#define COLOR_BLACK_16           RGB565( 10,  10,  10)
-#define COLOR_GRAY_16            RGB565( 96,  96,  96)
+#define COLOR_BLACK_16           RGB565(  5,   5,   5)
+#define COLOR_BLACK_32     ARGB888(255,   5,   5,   5)
 #define COLOR_WHITE_16           RGB565(255, 255, 255)
-#define COLOR_BLACK_32     ARGB888(255,  10,  10,  10)
-#define COLOR_GRAY_32      ARGB888(255,  96,  96,  96)
 #define COLOR_WHITE_32     ARGB888(255, 255, 255, 255)
 
 #define COLOR_10_16              RGB565( 10,  10,  10)
@@ -53,6 +51,8 @@
 #define COLOR_TAPE_16            RGB565( 89,  79,  78)
 #define COLOR_TAPE_32      ARGB888(255,  89,  79,  78)
 
+extern unsigned short int graphed[RETRO_BMP_SIZE];
+
 typedef enum {
    GRAPH_ALPHA_0 = 0,
    GRAPH_ALPHA_25,
@@ -72,9 +72,9 @@ void draw_fbox(int x, int y, int dx, int dy, uint32_t color, libretro_graph_alph
 void draw_fbox_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t color, libretro_graph_alpha_t alpha);
 void draw_fbox_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color, libretro_graph_alpha_t alpha);
 
-void draw_box(int x, int y, int dx, int dy, uint32_t color);
-void draw_box_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t color);
-void draw_box_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, uint32_t color);
+void draw_box(int x, int y, int dx, int dy, int width, int height, uint32_t color, libretro_graph_alpha_t alpha);
+void draw_box_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, int width, int height, uint16_t color, libretro_graph_alpha_t alpha);
+void draw_box_bmp32(uint32_t *buffer, int x, int y, int dx, int dy, int width, int height, uint32_t color, libretro_graph_alpha_t alpha);
 
 void draw_hline(int x, int y, int dx, int dy, uint32_t color);
 void draw_hline_bmp16(uint16_t *buffer, int x, int y, int dx, int dy, uint16_t color);

--- a/libretro/libretro-graph.h
+++ b/libretro/libretro-graph.h
@@ -5,6 +5,9 @@
 #define RGB888(r, g, b) (((r * 255 / 31) << 16) | ((g * 255 / 31) << 8) | (b * 255 / 31))
 #define ARGB888(a, r, g, b) ((a << 24) | (r << 16) | (g << 8) | b)
 
+#define COLOR_RED_16             RGB565(128,   0,   0)
+#define COLOR_RED_32       ARGB888(255, 128,   0,   0)
+
 #define COLOR_BLACK_16           RGB565( 10,  10,  10)
 #define COLOR_GRAY_16            RGB565( 96,  96,  96)
 #define COLOR_WHITE_16           RGB565(255, 255, 255)

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -136,7 +136,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { "-"  ,"-"  ,RETROK_EQUALS },
    { "@"  ,"@"  ,RETROK_LEFTBRACKET },
    { "*"  ,"*"  ,RETROK_RIGHTBRACKET },
-   { {26} ,{7}  ,RETROK_DELETE }, /* Up arrow / Pi */
+   { {26} ,{6}  ,RETROK_DELETE }, /* Up arrow / Pi */
    { ":"  ,"["  ,RETROK_SEMICOLON },
    { ";"  ,"]"  ,RETROK_QUOTE },
    { "="  ,"="  ,RETROK_BACKSLASH },
@@ -240,7 +240,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { {15,'-'},{15,'-'},RETROK_KP_MINUS },
    { "@"  ,"@"  ,RETROK_LEFTBRACKET },
    { "*"  ,"*"  ,RETROK_RIGHTBRACKET },
-   { {26} ,{7}  ,RETROK_DELETE }, /* Up arrow / Pi */
+   { {26} ,{6}  ,RETROK_DELETE }, /* Up arrow / Pi */
    { ":"  ,"["  ,RETROK_SEMICOLON },
    { ";"  ,"]"  ,RETROK_QUOTE },
    { "="  ,"="  ,RETROK_BACKSLASH },
@@ -357,7 +357,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { "-"  ,"-"  ,RETROK_EQUALS },
    { "@"  ,"@"  ,RETROK_LEFTBRACKET },
    { "*"  ,"*"  ,RETROK_RIGHTBRACKET },
-   { {26} ,{7}  ,RETROK_DELETE }, /* Up arrow / Pi */
+   { {26} ,{6}  ,RETROK_DELETE }, /* Up arrow / Pi */
    { ":"  ,"["  ,RETROK_SEMICOLON },
    { ";"  ,"]"  ,RETROK_QUOTE },
    { "="  ,"="  ,RETROK_BACKSLASH },

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -145,7 +145,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    /* 55 */
    { {24} ,{24} ,RETROK_LCTRL },
    { "R/S","R/S",RETROK_ESCAPE },
-   { "S/L","S/L",VKBD_SHIFTLOCK }, /* ShiftLock */
+   { "S/L","S/L",VKBD_SHIFTLOCK },
    { "LSH","LSH",RETROK_LSHIFT },
    { "RSH","RSH",RETROK_RSHIFT },
    { "RST","RST",RETROK_PAGEUP },
@@ -156,12 +156,12 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { "JOY","ASR",VKBD_JOYPORT_ASPECT }, /* Switch joyport / Toggle aspect ratio */
 
    /* 66 */
-   { {17} ,{17} ,VKBD_RESET },  /* Reset */
-   { {19} ,{19} ,VKBD_DATASETTE_RESET }, /* Datasette RESET */
-   { {20} ,{20} ,VKBD_DATASETTE_START }, /* Datasette START */
-   { {21} ,{21} ,VKBD_DATASETTE_RWD }, /* Datasette RWD */
-   { {22} ,{22} ,VKBD_DATASETTE_FWD }, /* Datasette FWD */
-   { {23} ,{23} ,VKBD_DATASETTE_STOP }, /* Datasette STOP */
+   { {17} ,{17} ,VKBD_RESET },
+   { {19} ,{19} ,VKBD_DATASETTE_RESET },
+   { {20} ,{20} ,VKBD_DATASETTE_START },
+   { {21} ,{21} ,VKBD_DATASETTE_RWD },
+   { {22} ,{22} ,VKBD_DATASETTE_FWD },
+   { {23} ,{23} ,VKBD_DATASETTE_STOP },
    { {18} ,{18} ,RETROK_SPACE },
    { {27} ,{27} ,RETROK_LEFT },
    { {28} ,{28} ,RETROK_DOWN },
@@ -249,7 +249,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    /* 55 */
    { {24} ,{24} ,RETROK_LCTRL },
    { "R/S","R/S",RETROK_ESCAPE },
-   { "S/L","S/L",VKBD_SHIFTLOCK }, /* ShiftLock */
+   { "S/L","S/L",VKBD_SHIFTLOCK },
    { "LSH","LSH",RETROK_LSHIFT },
    { "RSH","RSH",RETROK_RSHIFT },
    { "RST","RST",RETROK_PAGEUP },
@@ -260,12 +260,12 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { "JOY","ASR",VKBD_JOYPORT_ASPECT }, /* Switch joyport / Toggle aspect ratio */
 
    /* 66 */
-   { {17} ,{17} ,VKBD_RESET },  /* Reset */
-   { {19} ,{19} ,VKBD_DATASETTE_RESET }, /* Datasette RESET */
-   { {20} ,{20} ,VKBD_DATASETTE_START }, /* Datasette START */
-   { {21} ,{21} ,VKBD_DATASETTE_RWD }, /* Datasette RWD */
-   { {22} ,{22} ,VKBD_DATASETTE_FWD }, /* Datasette FWD */
-   { {23} ,{23} ,VKBD_DATASETTE_STOP }, /* Datasette STOP */
+   { {17} ,{17} ,VKBD_RESET },
+   { {19} ,{19} ,VKBD_DATASETTE_RESET },
+   { {20} ,{20} ,VKBD_DATASETTE_START },
+   { {21} ,{21} ,VKBD_DATASETTE_RWD },
+   { {22} ,{22} ,VKBD_DATASETTE_FWD },
+   { {23} ,{23} ,VKBD_DATASETTE_STOP },
    { {18} ,{18} ,RETROK_SPACE },
    { {27} ,{27} ,RETROK_LEFT },
    { {28} ,{28} ,RETROK_DOWN },
@@ -366,7 +366,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    /* 55 */
    { {24} ,{24} ,RETROK_LCTRL },
    { "R/S","R/S",RETROK_ESCAPE },
-   { "S/L","S/L",VKBD_SHIFTLOCK }, /* ShiftLock */
+   { "S/L","S/L",VKBD_SHIFTLOCK },
    { "LSH","LSH",RETROK_LSHIFT },
    { "RSH","RSH",RETROK_RSHIFT },
    { "RST","RST",RETROK_PAGEUP },
@@ -377,12 +377,12 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { "JOY","ASR",VKBD_JOYPORT_ASPECT }, /* Switch joyport / Toggle aspect ratio */
 
    /* 66 */
-   { {17} ,{17} ,-2 },  /* Reset */
-   { {19} ,{19} ,-15 }, /* Datasette RESET */
-   { {20} ,{20} ,-12 }, /* Datasette PLAY */
-   { {21} ,{21} ,-14 }, /* Datasette RWD */
-   { {22} ,{22} ,-13 }, /* Datasette FWD */
-   { {23} ,{23} ,-11 }, /* Datasette STOP */
+   { {17} ,{17} ,VKBD_RESET },
+   { {19} ,{19} ,VKBD_DATASETTE_RESET },
+   { {20} ,{20} ,VKBD_DATASETTE_START },
+   { {21} ,{21} ,VKBD_DATASETTE_RWD },
+   { {22} ,{22} ,VKBD_DATASETTE_FWD },
+   { {23} ,{23} ,VKBD_DATASETTE_STOP },
    { {18} ,{18} ,RETROK_SPACE },
    { {27} ,{27} ,RETROK_LEFT },
    { {28} ,{28} ,RETROK_DOWN },
@@ -418,7 +418,7 @@ static int BKG_PADDING(const char* str)
 }
 
 /* Alternate color keys */
-static int vkbd_alt_keys[] =
+static const int vkbd_alt_keys[] =
 {
       RETROK_F1, RETROK_F3, RETROK_F5, RETROK_F7,
 #if defined(__XPLUS4__)
@@ -428,26 +428,27 @@ static int vkbd_alt_keys[] =
       RETROK_F9, RETROK_F10, RETROK_F11, RETROK_F12,
 #endif
 };
-static int vkbd_alt_keys_len = sizeof(vkbd_alt_keys) / sizeof(vkbd_alt_keys[0]);
+static const int vkbd_alt_keys_len = sizeof(vkbd_alt_keys) / sizeof(vkbd_alt_keys[0]);
 
 /* Extra color keys */
-static int vkbd_extra_keys[] =
+static const int vkbd_extra_keys[] =
 {
    VKBD_NUMPAD, VKBD_RESET, VKBD_STATUSBAR_SAVEDISK, VKBD_JOYPORT_ASPECT, VKBD_TURBO_ZOOM
 };
-static int vkbd_extra_keys_len = sizeof(vkbd_extra_keys) / sizeof(vkbd_extra_keys[0]);
+static const int vkbd_extra_keys_len = sizeof(vkbd_extra_keys) / sizeof(vkbd_extra_keys[0]);
 
 /* Datasette color keys */
-static int vkbd_datasette_keys[] =
+static const int vkbd_datasette_keys[] =
 {
    VKBD_DATASETTE_STOP, VKBD_DATASETTE_START, VKBD_DATASETTE_FWD, VKBD_DATASETTE_RWD, VKBD_DATASETTE_RESET
 };
-static int vkbd_datasette_keys_len = sizeof(vkbd_datasette_keys) / sizeof(vkbd_datasette_keys[0]);
+static const int vkbd_datasette_keys_len = sizeof(vkbd_datasette_keys) / sizeof(vkbd_datasette_keys[0]);
 
 void print_vkbd(void)
 {
    libretro_graph_alpha_t ALPHA      = opt_vkbd_alpha;
    libretro_graph_alpha_t BKG_ALPHA  = ALPHA;
+   libretro_graph_alpha_t BRD_ALPHA  = ALPHA;
    long now                          = retro_ticks() / 1000;
    bool shifted                      = false;
    bool text_outline                 = false;
@@ -568,23 +569,27 @@ void print_vkbd(void)
          break;
    }
 
+   memset(graphed, 0, sizeof(graphed));
+
 #if defined(__XVIC__)
-   XOFFSET  = 4;
+   /* VIC */
+   XOFFSET  = 0;
    YOFFSET  = 0;
-   XPADDING = 108;
+   XPADDING = 116;
    YPADDING = 118;
 
    if (retro_region == RETRO_REGION_NTSC)
    {
-      XOFFSET  = 12;
+      XOFFSET  = 8;
       YOFFSET  = -1;
-      XPADDING = 60;
+      XPADDING = 68;
       YPADDING = 68;
    }
 #elif defined(__XPLUS4__)
-   XOFFSET  = 4;
+   /* TED */
+   XOFFSET  = 0;
    YOFFSET  = -2;
-   XPADDING = 66;
+   XPADDING = 74;
    YPADDING = 108;
 
    if (retro_region == RETRO_REGION_NTSC)
@@ -620,12 +625,13 @@ void print_vkbd(void)
    vkbd_y_max = YOFFSET + YBASEKEY + (YSIDE * VKBDY);
 
    /* Opacity */
-   BKG_ALPHA  = (retro_vkbd_transparent) ? ALPHA : GRAPH_ALPHA_100;
+   BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : GRAPH_ALPHA_100;
+   BRD_ALPHA = GRAPH_ALPHA_50;
 
    /* Key label shifted */
    shifted = false;
-   if (retro_capslock || vkey_sticky1 == RETROK_LSHIFT || vkey_sticky2 == RETROK_LSHIFT ||
-                         vkey_sticky1 == RETROK_RSHIFT || vkey_sticky2 == RETROK_RSHIFT)
+   if (retro_capslock || vkey_sticky1 == RETROK_LSHIFT || vkey_sticky2 == RETROK_LSHIFT
+                      || vkey_sticky1 == RETROK_RSHIFT || vkey_sticky2 == RETROK_RSHIFT)
       shifted = true;
    if (vkflag[RETRO_DEVICE_ID_JOYPAD_B] && (vkey_pressed == RETROK_LSHIFT || vkey_pressed == RETROK_RSHIFT))
       shifted = true;
@@ -666,7 +672,6 @@ void print_vkbd(void)
                 if (vkbd_datasette_keys[datasette_key] == vkeys[(y * VKBDX) + x + page].value)
                     BKG_COLOR = BKG_COLOR_TAPE;
          }
-
 
          /* Default font color */
          FONT_COLOR = FONT_COLOR_NORMAL;
@@ -729,14 +734,36 @@ void print_vkbd(void)
          YKEY  = YOFFSET + YBASEKEY + (y * YSIDE);
          YTEXT = YOFFSET + YBASETEXT + BKG_PADDING_Y + (y * YSIDE);
 
-         /* Key background */
-         draw_fbox(XKEY+XKEYSPACING, YKEY+YKEYSPACING, XSIDE-XKEYSPACING, YSIDE-YKEYSPACING,
-                   BKG_COLOR, BKG_ALPHA);
+         /* Empty key */
+         if (vkeys[(y * VKBDX) + x].value == -1)
+         {
+            /* Key background */
+            draw_fbox(XKEY+XKEYSPACING, YKEY+YKEYSPACING,
+                      XSIDE-XKEYSPACING, YSIDE-YKEYSPACING,
+                      0, BRD_ALPHA);
+         }
+         else
+         {
+            int FONT_ALPHA = BKG_ALPHA;
+            FONT_ALPHA = (FONT_ALPHA < GRAPH_ALPHA_25) ? GRAPH_ALPHA_25 : FONT_ALPHA;
+            FONT_ALPHA = (FONT_ALPHA > GRAPH_ALPHA_75) ? GRAPH_ALPHA_75 : FONT_ALPHA;
 
-         /* Key text */
-         draw_text(XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, GRAPH_ALPHA_25,
-                   (text_outline) ? GRAPH_BG_OUTLINE : GRAPH_BG_SHADOW, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
-                   string);
+            /* Key background */
+            draw_fbox(XKEY+XKEYSPACING, YKEY+YKEYSPACING,
+                      XSIDE-XKEYSPACING, YSIDE-YKEYSPACING,
+                      BKG_COLOR, BKG_ALPHA);
+
+            /* Key text */
+            draw_text(XTEXT, YTEXT, FONT_COLOR, BKG_COLOR, FONT_ALPHA,
+                      (text_outline) ? GRAPH_BG_OUTLINE : GRAPH_BG_SHADOW, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
+                      string);
+         }
+
+         /* Key border */
+         draw_box(XKEY+XKEYSPACING-FONT_WIDTH, YKEY+YKEYSPACING-FONT_HEIGHT,
+                  XSIDE-XKEYSPACING+FONT_WIDTH, YSIDE-YKEYSPACING+FONT_HEIGHT,
+                  FONT_WIDTH, FONT_HEIGHT,
+                  0, BRD_ALPHA);
       }
    }
 
@@ -792,13 +819,50 @@ void print_vkbd(void)
    YTEXT = YOFFSET + YBASETEXT + BKG_PADDING_Y + (vkey_pos_y * YSIDE);
 
    /* Selected key background */
-   draw_fbox(XKEY+XKEYSPACING, YKEY+YKEYSPACING, XSIDE-XKEYSPACING, YSIDE-YKEYSPACING,
+   draw_fbox(XKEY+XKEYSPACING, YKEY+YKEYSPACING,
+             XSIDE-XKEYSPACING, YSIDE-YKEYSPACING,
              BKG_COLOR_SEL, BKG_ALPHA);
+
+   /* Selected key border */
+   draw_box(XKEY+XKEYSPACING-FONT_WIDTH, YKEY+YKEYSPACING-FONT_HEIGHT,
+            XSIDE-XKEYSPACING+FONT_WIDTH, YSIDE-YKEYSPACING+FONT_HEIGHT,
+            FONT_WIDTH, FONT_HEIGHT,
+            0, BRD_ALPHA);
 
    /* Selected key text */
    draw_text(XTEXT, YTEXT, FONT_COLOR, 0, GRAPH_ALPHA_100,
              GRAPH_BG_NONE, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
              string);
+
+   /* Corner dimming */
+   {
+      unsigned corner_y_min = 0;
+      unsigned corner_y_max = 0;
+
+      /* Top */
+      corner_y_min = 0;
+      corner_y_max = vkbd_y_min - YKEYSPACING;
+      draw_fbox(0, corner_y_min,
+                retrow, corner_y_max,
+                0, BRD_ALPHA);
+
+      /* Bottom */
+      corner_y_min = vkbd_y_max + YKEYSPACING;
+      corner_y_max = retroh - retroYS_offset - vkbd_y_max - YKEYSPACING;
+      draw_fbox(0, corner_y_min,
+                retrow, corner_y_max,
+                0, BRD_ALPHA);
+
+      /* Left + Right */
+      corner_y_min = vkbd_y_min - YKEYSPACING;
+      corner_y_max = vkbd_y_max - vkbd_y_min + (YKEYSPACING * 2);
+      draw_fbox(0, corner_y_min,
+                vkbd_x_min - XKEYSPACING, corner_y_max,
+                0, BRD_ALPHA);
+      draw_fbox(vkbd_x_max, corner_y_min,
+                retrow - vkbd_x_max , corner_y_max,
+                0, BRD_ALPHA);
+   }
 
 #if POINTER_DEBUG
    draw_hline(pointer_x, pointer_y, 1, 1, RGBc(255, 0, 255));

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -131,7 +131,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
 
    /* 44 */
    { {25} ,{25} ,RETROK_BACKQUOTE }, /* Left arrow */
-   { "CTR","CTR",RETROK_TAB },
+   { "CTRL","CTRL",RETROK_TAB },
    { "+"  ,"+"  ,RETROK_MINUS },
    { "-"  ,"-"  ,RETROK_EQUALS },
    { "@"  ,"@"  ,RETROK_LEFTBRACKET },
@@ -140,20 +140,20 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { ":"  ,"["  ,RETROK_SEMICOLON },
    { ";"  ,"]"  ,RETROK_QUOTE },
    { "="  ,"="  ,RETROK_BACKSLASH },
-   { "STB","SVD",VKBD_STATUSBAR_SAVEDISK }, /* Statusbar / Save disk */
+   { "STBR","SVDS",VKBD_STATUSBAR_SAVEDISK }, /* Statusbar / Save disk */
 
    /* 55 */
    { {24} ,{24} ,RETROK_LCTRL },
-   { "R/S","R/S",RETROK_ESCAPE },
-   { "S/L","S/L",VKBD_SHIFTLOCK },
-   { "LSH","LSH",RETROK_LSHIFT },
-   { "RSH","RSH",RETROK_RSHIFT },
-   { "RST","RST",RETROK_PAGEUP },
-   { "CLR","CLR",RETROK_HOME },
-   { "DEL","DEL",RETROK_BACKSPACE },
+   { "RUN\1STOP","RUN\1STOP",RETROK_ESCAPE },
+   { "SHFT\1LOCK","SHFT\1LOCK",VKBD_SHIFTLOCK },
+   { {27,'\1','S','H','F','T'},{27,'\1','S','H','F','T'},RETROK_LSHIFT },
+   { {' ',' ',' ',29,'\1','S','H','F','T'},{' ',' ',' ',29,'\1','S','H','F','T'},RETROK_RSHIFT },
+   { "RSTR","RSTR",RETROK_PAGEUP },
+   { "CLR\1HOME","CLR\1HOME",RETROK_HOME },
+   { "INST\1DEL","INST\1DEL",RETROK_BACKSPACE },
    { {30} ,{30} ,RETROK_UP },
-   { "RET","RET",RETROK_RETURN },
-   { "JOY","ASR",VKBD_JOYPORT_ASPECT }, /* Switch joyport / Toggle aspect ratio */
+   { {16} ,{16} ,RETROK_RETURN },
+   { "JOYP","ASPR",VKBD_JOYPORT_ASPECT }, /* Switch joyport / Toggle aspect ratio */
 
    /* 66 */
    { {17} ,{17} ,VKBD_RESET },
@@ -166,7 +166,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { {27} ,{27} ,RETROK_LEFT },
    { {28} ,{28} ,RETROK_DOWN },
    { {29} ,{29} ,RETROK_RIGHT },
-   { "TRF","ZOM",VKBD_TURBO_ZOOM }, /* Toggle turbo fire / Toggle zoom mode */
+   { "TRBF","ZOOM",VKBD_TURBO_ZOOM }, /* Toggle turbo fire / Toggle zoom mode */
 
    /* C128 extra */
    { "ESC","ESC",RETROK_F1 },
@@ -235,7 +235,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
 
    /* 44 */
    { {25} ,{25} ,RETROK_BACKQUOTE }, /* Left arrow */
-   { "CTR","CTR",RETROK_TAB },
+   { "CTRL","CTRL",RETROK_TAB },
    { {15,'+'},{15,'+'},RETROK_KP_PLUS },
    { {15,'-'},{15,'-'},RETROK_KP_MINUS },
    { "@"  ,"@"  ,RETROK_LEFTBRACKET },
@@ -244,20 +244,20 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { ":"  ,"["  ,RETROK_SEMICOLON },
    { ";"  ,"]"  ,RETROK_QUOTE },
    { "="  ,"="  ,RETROK_BACKSLASH },
-   { "STB","SVD",VKBD_STATUSBAR_SAVEDISK }, /* Statusbar / Save disk */
+   { "STBR","SVDS",VKBD_STATUSBAR_SAVEDISK }, /* Statusbar / Save disk */
 
    /* 55 */
    { {24} ,{24} ,RETROK_LCTRL },
-   { "R/S","R/S",RETROK_ESCAPE },
-   { "S/L","S/L",VKBD_SHIFTLOCK },
-   { "LSH","LSH",RETROK_LSHIFT },
-   { "RSH","RSH",RETROK_RSHIFT },
-   { "RST","RST",RETROK_PAGEUP },
-   { "CLR","CLR",RETROK_HOME },
-   { "DEL","DEL",RETROK_BACKSPACE },
+   { "RUN\1STOP","RUN\1STOP",RETROK_ESCAPE },
+   { "SHFT\1LOCK","SHFT\1LOCK",VKBD_SHIFTLOCK },
+   { {27,'\1','S','H','F','T'},{27,'\1','S','H','F','T'},RETROK_LSHIFT },
+   { {' ',' ',' ',29,'\1','S','H','F','T'},{' ',' ',' ',29,'\1','S','H','F','T'},RETROK_RSHIFT },
+   { "RSTR","RSTR",RETROK_PAGEUP },
+   { "CLR\1HOME","CLR\1HOME",RETROK_HOME },
+   { "INST\1DEL","INST\1DEL",RETROK_BACKSPACE },
    { {30} ,{30} ,RETROK_UP },
-   { {15,'E','N','T'},{15,'E','N','T'},RETROK_KP_ENTER },
-   { "JOY","ASR",VKBD_JOYPORT_ASPECT }, /* Switch joyport / Toggle aspect ratio */
+   { {15,16},{15,16},RETROK_KP_ENTER },
+   { "JOYP","ASPR",VKBD_JOYPORT_ASPECT }, /* Switch joyport / Toggle aspect ratio */
 
    /* 66 */
    { {17} ,{17} ,VKBD_RESET },
@@ -270,7 +270,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { {27} ,{27} ,RETROK_LEFT },
    { {28} ,{28} ,RETROK_DOWN },
    { {29} ,{29} ,RETROK_RIGHT },
-   { "TRF","ZOM",VKBD_TURBO_ZOOM }, /* Toggle turbo fire / Toggle zoom mode */
+   { "TRBF","ZOOM",VKBD_TURBO_ZOOM }, /* Toggle turbo fire / Toggle zoom mode */
 
 #else
 
@@ -341,7 +341,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { "."  ,">"  ,RETROK_PERIOD },
    { "/"  ,"?"  ,RETROK_SLASH },
 #ifdef __XPLUS4__
-   { "HLP","F7" ,RETROK_F8 },
+   { "HELP","F7" ,RETROK_F8 },
 #else
    { "f7" ,"f8" ,RETROK_F7 },
 #endif
@@ -352,7 +352,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
 #else
    { {25} ,{25} ,RETROK_BACKQUOTE }, /* Left arrow */
 #endif
-   { "CTR","CTR",RETROK_TAB },
+   { "CTRL","CTRL",RETROK_TAB },
    { "+"  ,"+"  ,RETROK_MINUS },
    { "-"  ,"-"  ,RETROK_EQUALS },
    { "@"  ,"@"  ,RETROK_LEFTBRACKET },
@@ -361,20 +361,20 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { ":"  ,"["  ,RETROK_SEMICOLON },
    { ";"  ,"]"  ,RETROK_QUOTE },
    { "="  ,"="  ,RETROK_BACKSLASH },
-   { "STB","SVD",VKBD_STATUSBAR_SAVEDISK }, /* Statusbar / Save disk */
+   { "STBR","SVDS",VKBD_STATUSBAR_SAVEDISK }, /* Statusbar / Save disk */
 
    /* 55 */
    { {24} ,{24} ,RETROK_LCTRL },
-   { "R/S","R/S",RETROK_ESCAPE },
-   { "S/L","S/L",VKBD_SHIFTLOCK },
-   { "LSH","LSH",RETROK_LSHIFT },
-   { "RSH","RSH",RETROK_RSHIFT },
-   { "RST","RST",RETROK_PAGEUP },
-   { "CLR","CLR",RETROK_HOME },
-   { "DEL","DEL",RETROK_BACKSPACE },
+   { "RUN\1STOP","RUN\1STOP",RETROK_ESCAPE },
+   { "SHFT\1LOCK","SHFT\1LOCK",VKBD_SHIFTLOCK },
+   { {27,'\1','S','H','F','T'},{27,'\1','S','H','F','T'},RETROK_LSHIFT },
+   { {' ',' ',' ',29,'\1','S','H','F','T'},{' ',' ',' ',29,'\1','S','H','F','T'},RETROK_RSHIFT },
+   { "RSTR","RSTR",RETROK_PAGEUP },
+   { "CLR\1HOME","CLR\1HOME",RETROK_HOME },
+   { "INST\1DEL","INST\1DEL",RETROK_BACKSPACE },
    { {30} ,{30} ,RETROK_UP },
-   { "RET","RET",RETROK_RETURN },
-   { "JOY","ASR",VKBD_JOYPORT_ASPECT }, /* Switch joyport / Toggle aspect ratio */
+   { {16} ,{16} ,RETROK_RETURN },
+   { "JOYP","ASPR",VKBD_JOYPORT_ASPECT }, /* Switch joyport / Toggle aspect ratio */
 
    /* 66 */
    { {17} ,{17} ,VKBD_RESET },
@@ -387,7 +387,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
    { {27} ,{27} ,RETROK_LEFT },
    { {28} ,{28} ,RETROK_DOWN },
    { {29} ,{29} ,RETROK_RIGHT },
-   { "TRF","ZOM",VKBD_TURBO_ZOOM }, /* Toggle turbo fire / Toggle zoom mode */
+   { "TRBF","ZOOM",VKBD_TURBO_ZOOM }, /* Toggle turbo fire / Toggle zoom mode */
 
 #endif
 };

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -394,7 +394,7 @@ static const retro_vkeys vkeys[VKBDX * VKBDY * 2] =
 
 static int BKG_PADDING(const char* str)
 {
-   unsigned font_width_default = 6;
+   unsigned font_width_default = (retrow > 704) ? 12 : 6;
    unsigned len = strlen(str);
    unsigned padding = 0;
    unsigned i = 0;
@@ -413,6 +413,9 @@ static int BKG_PADDING(const char* str)
 
       padding -= (font_width / 2);
    }
+
+   if (retrow > 704)
+      padding--;
 
    return padding;
 }
@@ -478,6 +481,7 @@ void print_vkbd(void)
    int BKG_COLOR_TAPE                = 0;
    int BKG_COLOR_SEL                 = 0;
    int BKG_COLOR_ACTIVE              = 0;
+   int BRD_COLOR                     = 0;
 
    int FONT_MAX                      = 10;
    int FONT_WIDTH                    = 1;
@@ -569,6 +573,8 @@ void print_vkbd(void)
          break;
    }
 
+   BRD_COLOR = (pix_bytes == 4) ? COLOR_10_32 : COLOR_10_16;
+
    memset(graphed, 0, sizeof(graphed));
 
 #if defined(__XVIC__)
@@ -597,6 +603,7 @@ void print_vkbd(void)
       YPADDING = 64;
    }
 #else
+   /* VIC-II */
    XOFFSET  = 0;
    YOFFSET  = 1;
    XPADDING = 74;
@@ -607,6 +614,17 @@ void print_vkbd(void)
       YOFFSET  = -1;
       YPADDING = 72;
    }
+#if defined(__X128__)
+   /* VDC */
+   if (retrow > 704)
+   {
+      YOFFSET     = -8;
+      YPADDING    = 108;
+      XPADDING    = 120;
+      XPADDING   *= 2;
+      FONT_WIDTH *= 2;
+   }
+#endif
 #endif
 
    int XSIDE = (retrow - XPADDING) / VKBDX;
@@ -649,11 +667,8 @@ void print_vkbd(void)
          BKG_COLOR = BKG_COLOR_NORMAL;
          BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : GRAPH_ALPHA_100;
 
-         /* Empty key */
-         if (vkeys[(y * VKBDX) + x].value == -1)
-            continue;
          /* Reset key color */
-         else if (vkeys[(y * VKBDX) + x].value == VKBD_RESET)
+         if (vkeys[(y * VKBDX) + x].value == VKBD_RESET)
             BKG_COLOR = (pix_bytes == 4) ? COLOR_RED_32 : COLOR_RED_16;
          else
          {

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -636,11 +636,23 @@ void print_vkbd(void)
    int XBASETEXT = XBASEKEY + (XSIDE / 2);
    int YBASETEXT = YBASEKEY + (YSIDE / 2);
 
+   int x_gap = 0;
+   int y_gap = 0;
+
+   int vkbd_x_gap_pad = VKBDX_GAP_PAD * FONT_WIDTH;
+   int vkbd_y_gap_pad = VKBDY_GAP_PAD * FONT_HEIGHT;
+
+   XOFFSET -= (vkbd_x_gap_pad / 2);
+   YOFFSET -= (vkbd_y_gap_pad / 2);
+
    /* Coordinates */
    vkbd_x_min = XOFFSET + XBASEKEY + XKEYSPACING;
    vkbd_x_max = XOFFSET - XBASEKEY - XKEYSPACING + retrow;
    vkbd_y_min = YOFFSET + YBASEKEY + YKEYSPACING;
    vkbd_y_max = YOFFSET + YBASEKEY + (YSIDE * VKBDY);
+
+   vkbd_x_max += vkbd_x_gap_pad;
+   vkbd_y_max += vkbd_y_gap_pad;
 
    /* Opacity */
    BKG_ALPHA = (retro_vkbd_transparent) ? ALPHA : GRAPH_ALPHA_100;
@@ -657,11 +669,15 @@ void print_vkbd(void)
    /* Key layout */
    for (x = 0; x < VKBDX; x++)
    {
+      x_gap = 0;
+      if (VKBDX_GAP_POS && VKBDX_GAP_PAD && x >= VKBDX_GAP_POS)
+         x_gap = vkbd_x_gap_pad;
+
       for (y = 0; y < VKBDY; y++)
       {
-         /* Skip selected key */
-         if (((vkey_pos_y * VKBDX) + vkey_pos_x + page) == ((y * VKBDX) + x + page))
-            continue;
+         y_gap = 0;
+         if (VKBDY_GAP_POS && VKBDY_GAP_PAD && y >= VKBDY_GAP_POS)
+            y_gap = vkbd_y_gap_pad;
 
          /* Default key color */
          BKG_COLOR = BKG_COLOR_NORMAL;
@@ -744,10 +760,10 @@ void print_vkbd(void)
             BKG_PADDING_Y = -6;
 
          /* Key positions */
-         XKEY  = XOFFSET + XBASEKEY + (x * XSIDE);
-         XTEXT = XOFFSET + XBASETEXT + BKG_PADDING_X + (x * XSIDE);
-         YKEY  = YOFFSET + YBASEKEY + (y * YSIDE);
-         YTEXT = YOFFSET + YBASETEXT + BKG_PADDING_Y + (y * YSIDE);
+         XKEY  = x_gap + XOFFSET + XBASEKEY + (x * XSIDE);
+         XTEXT = x_gap + XOFFSET + XBASETEXT + BKG_PADDING_X + (x * XSIDE);
+         YKEY  = y_gap + YOFFSET + YBASEKEY + (y * YSIDE);
+         YTEXT = y_gap + YOFFSET + YBASETEXT + BKG_PADDING_Y + (y * YSIDE);
 
          /* Empty key */
          if (vkeys[(y * VKBDX) + x].value == -1)
@@ -757,7 +773,8 @@ void print_vkbd(void)
                       XSIDE-XKEYSPACING, YSIDE-YKEYSPACING,
                       0, BRD_ALPHA);
          }
-         else
+         /* Not selected key */
+         else if (((vkey_pos_y * VKBDX) + vkey_pos_x + page) != ((y * VKBDX) + x + page))
          {
             int FONT_ALPHA = BKG_ALPHA;
             FONT_ALPHA = (FONT_ALPHA < GRAPH_ALPHA_25) ? GRAPH_ALPHA_25 : FONT_ALPHA;
@@ -827,27 +844,45 @@ void print_vkbd(void)
    if (strchr(string, '\1'))
       BKG_PADDING_Y = -6;
 
+   x_gap = 0;
+   if (VKBDX_GAP_POS && VKBDX_GAP_PAD && vkey_pos_x >= VKBDX_GAP_POS)
+      x_gap = vkbd_x_gap_pad;
+   y_gap = 0;
+   if (VKBDY_GAP_POS && VKBDY_GAP_PAD && vkey_pos_y >= VKBDY_GAP_POS)
+      y_gap = vkbd_y_gap_pad;
+
    /* Selected key position */
-   XKEY  = XOFFSET + XBASEKEY + (vkey_pos_x * XSIDE);
-   XTEXT = XOFFSET + XBASETEXT + BKG_PADDING_X + (vkey_pos_x * XSIDE);
-   YKEY  = YOFFSET + YBASEKEY + (vkey_pos_y * YSIDE);
-   YTEXT = YOFFSET + YBASETEXT + BKG_PADDING_Y + (vkey_pos_y * YSIDE);
+   XKEY  = x_gap + XOFFSET + XBASEKEY + (vkey_pos_x * XSIDE);
+   XTEXT = x_gap + XOFFSET + XBASETEXT + BKG_PADDING_X + (vkey_pos_x * XSIDE);
+   YKEY  = y_gap + YOFFSET + YBASEKEY + (vkey_pos_y * YSIDE);
+   YTEXT = y_gap + YOFFSET + YBASETEXT + BKG_PADDING_Y + (vkey_pos_y * YSIDE);
 
    /* Selected key background */
    draw_fbox(XKEY+XKEYSPACING, YKEY+YKEYSPACING,
              XSIDE-XKEYSPACING, YSIDE-YKEYSPACING,
              BKG_COLOR_SEL, BKG_ALPHA);
 
-   /* Selected key border */
-   draw_box(XKEY+XKEYSPACING-FONT_WIDTH, YKEY+YKEYSPACING-FONT_HEIGHT,
-            XSIDE-XKEYSPACING+FONT_WIDTH, YSIDE-YKEYSPACING+FONT_HEIGHT,
-            FONT_WIDTH, FONT_HEIGHT,
-            0, BRD_ALPHA);
-
    /* Selected key text */
    draw_text(XTEXT, YTEXT, FONT_COLOR, 0, GRAPH_ALPHA_100,
              GRAPH_BG_NONE, FONT_WIDTH, FONT_HEIGHT, FONT_MAX,
              string);
+
+   /* Gap backgrounds */
+   if (VKBDX_GAP_POS)
+         draw_fbox(XOFFSET+XBASEKEY+(VKBDX_GAP_POS * XSIDE)+FONT_WIDTH, vkbd_y_min-FONT_HEIGHT,
+                VKBDX_GAP_PAD-FONT_WIDTH, vkbd_y_max-vkbd_y_min+(FONT_HEIGHT*2),
+                0, BRD_ALPHA);
+
+   if (VKBDY_GAP_POS)
+   {
+      draw_fbox(vkbd_x_min-FONT_WIDTH, YOFFSET+YBASEKEY+(VKBDY_GAP_POS * YSIDE)+FONT_HEIGHT,
+                vkbd_x_max-vkbd_x_min+FONT_WIDTH-XSIDE-VKBDX_GAP_PAD, VKBDY_GAP_PAD-FONT_HEIGHT,
+                0, BRD_ALPHA);
+
+      draw_fbox(XOFFSET+XBASEKEY+(VKBDX_GAP_POS * XSIDE)+VKBDX_GAP_PAD, YOFFSET+YBASEKEY+(VKBDY_GAP_POS * YSIDE)+FONT_HEIGHT,
+                XSIDE+FONT_WIDTH, VKBDY_GAP_PAD-FONT_HEIGHT,
+                0, BRD_ALPHA);
+   }
 
    /* Corner dimming */
    {
@@ -968,11 +1003,15 @@ void input_vkbd(void)
 
       if (px >= vkbd_x_min && px <= vkbd_x_max && py >= vkbd_y_min && py <= vkbd_y_max)
       {
-         float vkey_width = (float)(vkbd_x_max - vkbd_x_min) / VKBDX;
+         float vkey_width = (float)(vkbd_x_max - vkbd_x_min - VKBDX_GAP_PAD) / VKBDX;
          vkey_pos_x = ((px - vkbd_x_min) / vkey_width);
+         if (VKBDX_GAP_POS && vkey_pos_x >= VKBDX_GAP_POS)
+            vkey_pos_x = ((px - vkbd_x_min + VKBDX_GAP_PAD) / vkey_width);
 
-         float vkey_height = (float)(vkbd_y_max - vkbd_y_min) / VKBDY;
+         float vkey_height = (float)(vkbd_y_max - vkbd_y_min - VKBDY_GAP_PAD) / VKBDY;
          vkey_pos_y = ((py - vkbd_y_min) / vkey_height);
+         if (VKBDY_GAP_POS && vkey_pos_y >= VKBDY_GAP_POS)
+            vkey_pos_y = ((py - vkbd_y_min - VKBDY_GAP_PAD) / vkey_height);
 
          vkey_pos_x = (vkey_pos_x < 0) ? 0 : vkey_pos_x;
          vkey_pos_x = (vkey_pos_x > VKBDX - 1) ? VKBDX - 1 : vkey_pos_x;

--- a/libretro/libretro-vkbd.h
+++ b/libretro/libretro-vkbd.h
@@ -22,6 +22,23 @@ extern int tape_counter;
 extern int tape_control;
 
 #define VKBDX 11
+#ifdef __X128__
+#define VKBDY 8
+#else
 #define VKBDY 7
+#endif
+
+#define VKBD_NUMPAD             -2
+#define VKBD_RESET              -3
+#define VKBD_STATUSBAR_SAVEDISK -4
+#define VKBD_JOYPORT_ASPECT     -5
+#define VKBD_TURBO_ZOOM         -6
+#define VKBD_SHIFTLOCK          -10
+
+#define VKBD_DATASETTE_STOP     -11
+#define VKBD_DATASETTE_START    -12
+#define VKBD_DATASETTE_FWD      -13
+#define VKBD_DATASETTE_RWD      -14
+#define VKBD_DATASETTE_RESET    -15
 
 #endif /* LIBRETRO_VKBD_H */

--- a/libretro/libretro-vkbd.h
+++ b/libretro/libretro-vkbd.h
@@ -28,6 +28,11 @@ extern int tape_control;
 #define VKBDY 7
 #endif
 
+#define VKBDX_GAP_POS 10
+#define VKBDY_GAP_POS 0
+#define VKBDX_GAP_PAD 4
+#define VKBDY_GAP_PAD 0
+
 #define VKBD_NUMPAD             -2
 #define VKBD_RESET              -3
 #define VKBD_STATUSBAR_SAVEDISK -4

--- a/retrodep/keymap.c
+++ b/retrodep/keymap.c
@@ -907,11 +907,11 @@ static void libretro_keyboard()
             keyboard_parse_set_pos_row(RETROK_KP7,          8, 6, 8);   /*     Numpad 7 -> Numpad 7     */
             keyboard_parse_set_pos_row(RETROK_KP8,          8, 1, 8);   /*     Numpad 8 -> Numpad 8     */
             keyboard_parse_set_pos_row(RETROK_KP9,          9, 6, 8);   /*     Numpad 9 -> Numpad 9     */
-            keyboard_parse_set_pos_row(RETROK_KP_MINUS,     9, 1, 8);   /*     Numpad - -> Numpad +     */
+            keyboard_parse_set_pos_row(RETROK_KP_MINUS,     9, 2, 8);   /*     Numpad - -> Numpad -     */
             keyboard_parse_set_pos_row(RETROK_KP4,          8, 5, 8);   /*     Numpad 4 -> Numpad 4     */
             keyboard_parse_set_pos_row(RETROK_KP5,          8, 2, 8);   /*     Numpad 5 -> Numpad 5     */
             keyboard_parse_set_pos_row(RETROK_KP6,          9, 5, 8);   /*     Numpad 6 -> Numpad 6     */
-            keyboard_parse_set_pos_row(RETROK_KP_PLUS,      9, 2, 8);   /*     Numpad + -> Numpad -     */
+            keyboard_parse_set_pos_row(RETROK_KP_PLUS,      9, 1, 8);   /*     Numpad + -> Numpad +     */
             keyboard_parse_set_pos_row(RETROK_KP1,          8, 7, 8);   /*     Numpad 1 -> Numpad 1     */
             keyboard_parse_set_pos_row(RETROK_KP2,          8, 4, 8);   /*     Numpad 2 -> Numpad 2     */
             keyboard_parse_set_pos_row(RETROK_KP3,          9, 7, 8);   /*     Numpad 3 -> Numpad 3     */

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -398,7 +398,7 @@ int ui_init_finalize(void)
    else
       log_resources_set_int("DriveSoundEmulation", 0);
 
-   if (opt_autoloadwarp & AUTOLOADWARP_DISK && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
+   if (vice_opt.DriveSoundEmulation && opt_autoloadwarp & AUTOLOADWARP_DISK && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
       log_resources_set_int("DriveSoundEmulationVolume", 0);
 
 #if !defined(__XSCPU64__) && !defined(__X64DTV__)
@@ -407,21 +407,21 @@ int ui_init_finalize(void)
    else
       log_resources_set_int("DatasetteSound", 0);
 
-   if (opt_autoloadwarp & AUTOLOADWARP_TAPE && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
+   if (vice_opt.DatasetteSound && opt_autoloadwarp & AUTOLOADWARP_TAPE && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
       log_resources_set_int("DatasetteSound", 0);
 #endif
 
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__)
    log_resources_set_int("VICIIAudioLeak", vice_opt.AudioLeak);
-   if (opt_autoloadwarp && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
+   if (vice_opt.AudioLeak && opt_autoloadwarp && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
       log_resources_set_int("VICIIAudioLeak", 0);
 #elif defined(__XVIC__)
    log_resources_set_int("VICAudioLeak", vice_opt.AudioLeak);
-   if (opt_autoloadwarp && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
+   if (vice_opt.AudioLeak && opt_autoloadwarp && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
       log_resources_set_int("VICAudioLeak", 0);
 #elif defined(__XPLUS4__)
    log_resources_set_int("TEDAudioLeak", vice_opt.AudioLeak);
-   if (opt_autoloadwarp && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
+   if (vice_opt.AudioLeak && opt_autoloadwarp && !(opt_autoloadwarp & AUTOLOADWARP_MUTE))
       log_resources_set_int("TEDAudioLeak", 0);
 #endif
 

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -477,6 +477,7 @@ int ui_init_finalize(void)
 #if defined(__X128__)
    log_resources_set_int("Go64Mode", vice_opt.Go64Mode);
    log_resources_set_int("C128ColumnKey", vice_opt.C128ColumnKey);
+   log_resources_set_int("VDC64KB", vice_opt.VDC64KB);
 #elif defined(__XVIC__)
    log_resources_set_int("MegaCartNvRAMWriteBack", 1);
    vic20mem_set();

--- a/retrodep/uistatusbar.c
+++ b/retrodep/uistatusbar.c
@@ -668,6 +668,15 @@ void uistatusbar_close(void)
     uistatusbar_state = UISTATUSBAR_REPAINT;
 }
 
+#define COLOR_BLACK   0
+#define COLOR_WHITE   RGBc(255, 255, 255)
+#define COLOR_RED     RGBc(204,   0,   0)
+#define COLOR_GREEN_B RGBc(  0, 204,   0)
+#define COLOR_GREEN   RGBc(  0,  85,   0)
+#define COLOR_GREEN_D RGBc(  0,  34,   0)
+#define COLOR_BROWN   RGBc(143, 140, 129)
+#define COLOR_BROWN_D RGBc( 89,  79,  78)
+
 void uistatusbar_draw(void)
 {
     unsigned int i = 0;
@@ -682,14 +691,15 @@ void uistatusbar_draw(void)
     unsigned int color_black, color_white,
             color_red, color_greenb, color_green, color_greend,
             color_brown, color_brownd;
-    color_black  = 0;
-    color_white  = RGBc(255, 255, 255);
-    color_red    = RGBc(204,   0,   0);
-    color_greenb = RGBc(  0, 204,   0);
-    color_green  = RGBc(  0,  85,   0);
-    color_greend = RGBc(  0,  34,   0);
-    color_brown  = RGBc(143, 140, 129);
-    color_brownd = RGBc( 89,  79,  78);
+
+    color_black  = COLOR_BLACK;
+    color_white  = COLOR_WHITE;
+    color_red    = COLOR_RED;
+    color_greenb = COLOR_GREEN_B;
+    color_green  = COLOR_GREEN;
+    color_greend = COLOR_GREEN_D;
+    color_brown  = COLOR_BROWN;
+    color_brownd = COLOR_BROWN_D;
     color_f      = color_white;
     color_b      = color_black;
 
@@ -705,16 +715,16 @@ void uistatusbar_draw(void)
     int bkg_y = y - 1;
     int max_width = zoomed_width;
     int bkg_width = max_width;
-    int bkg_height = (char_width + 1) + 2;
+    int bkg_height = 9;
 
     /* Right alignment offset */
-    int x_align_offset = 2;
+    int x_align_offset = 3;
 
     /* LED section position */
     int led_width = 0;
     int led_x = 0;
     if (drive_enabled)
-        led_width = (char_width * 5) - x_align_offset + 1;
+        led_width = (char_width * 5) - x_align_offset + 2;
     else if (tape_enabled)
         led_width = (char_width * 8) - x_align_offset - 4;
     else

--- a/retrodep/uistatusbar.c
+++ b/retrodep/uistatusbar.c
@@ -735,7 +735,7 @@ void uistatusbar_draw(void)
         led_width = (char_width * 8) - x_align_offset - 4;
     else
         led_width = (char_width * 3) - x_align_offset - 1;
-    led_x = retroXS_offset + x + max_width - led_width - 10;
+    led_x = retroXS_offset + x + max_width - led_width - 1;
 
     /* Basic mode statusbar background */
     if (opt_statusbar & STATUSBAR_BASIC && !statusbar_message_timer)

--- a/retrodep/uistatusbar.c
+++ b/retrodep/uistatusbar.c
@@ -685,6 +685,7 @@ void uistatusbar_draw(void)
 
     unsigned int char_width = 6;
     unsigned int char_offset = 1;
+    unsigned int char_scale_x = 1;
     int x = 0, y = 0;
 
     unsigned int color_f, color_b;
@@ -703,12 +704,17 @@ void uistatusbar_draw(void)
     color_f      = color_white;
     color_b      = color_black;
 
+    if (retrow > 704)
+       char_scale_x = 2;
+
+    char_width *= char_scale_x;
+
     /* Statusbar position */
     x = 1;
     if (opt_statusbar & STATUSBAR_TOP)
         y = zoomed_YS_offset + 1;
     else
-        y = zoomed_height + zoomed_YS_offset - (char_width + 1) - 1;
+        y = zoomed_height + zoomed_YS_offset - 8;
 
     /* Statusbar background */
     int bkg_x = retroXS_offset + x - 1;
@@ -729,7 +735,7 @@ void uistatusbar_draw(void)
         led_width = (char_width * 8) - x_align_offset - 4;
     else
         led_width = (char_width * 3) - x_align_offset - 1;
-    led_x = retroXS_offset + x + max_width - led_width - 1;
+    led_x = retroXS_offset + x + max_width - led_width - 10;
 
     /* Basic mode statusbar background */
     if (opt_statusbar & STATUSBAR_BASIC && !statusbar_message_timer)
@@ -750,14 +756,14 @@ void uistatusbar_draw(void)
     /* Message */
     if (statusbar_message_timer)
     {
-        draw_text(bkg_x + char_offset, y, color_f, color_b, GRAPH_ALPHA_100, GRAPH_BG_ALL, 1, 1, 100, statusbar_text);
+        draw_text(bkg_x + char_offset, y, color_f, color_b, GRAPH_ALPHA_100, GRAPH_BG_ALL, char_scale_x, 1, 100, statusbar_text);
         draw_fbox(led_x, bkg_y, led_width, bkg_height, 0, GRAPH_ALPHA_100);
     }
     else if (!(opt_statusbar & STATUSBAR_BASIC))
     {
-        draw_text(bkg_x + (max_width / 2) - (20), y, color_f, color_b, GRAPH_ALPHA_100, GRAPH_BG_ALL, 1, 1, 10, statusbar_resolution);
-        draw_text(bkg_x + (max_width / 2) + (30), y, color_f, color_b, GRAPH_ALPHA_100, GRAPH_BG_ALL, 1, 1, 10, statusbar_memory);
-        draw_text(bkg_x + (max_width / 2) + (80), y, color_f, color_b, GRAPH_ALPHA_100, GRAPH_BG_ALL, 1, 1, 10, statusbar_model);
+        draw_text(bkg_x + (max_width / 2) - (20), y, color_f, color_b, GRAPH_ALPHA_100, GRAPH_BG_ALL, char_scale_x, 1, 10, statusbar_resolution);
+        draw_text(bkg_x + (max_width / 2) + (30), y, color_f, color_b, GRAPH_ALPHA_100, GRAPH_BG_ALL, char_scale_x, 1, 10, statusbar_memory);
+        draw_text(bkg_x + (max_width / 2) + (80), y, color_f, color_b, GRAPH_ALPHA_100, GRAPH_BG_ALL, char_scale_x, 1, 10, statusbar_model);
     }
 
     /* Tape indicator + drive & power LEDs */
@@ -826,20 +832,20 @@ void uistatusbar_draw(void)
         if (drive_enabled)
         {
             if (i == STATUSBAR_DRIVE8_TRACK_POS || i == STATUSBAR_DRIVE8_TRACK_POS + 1)
-                x_align -= 2;
+                x_align -= 2 * char_scale_x;
         }
         else if (tape_enabled)
         {
             if (i >= STATUSBAR_TAPE_POS && i < STATUSBAR_SPEED_POS - 4)
-                x_align = x_align - 3 + char_width;
+                x_align = x_align - (3 * char_scale_x) + char_width;
             else if (i >= STATUSBAR_TAPE_POS && i < STATUSBAR_SPEED_POS - 1)
-                x_align = x_align - 2 + char_width;
+                x_align = x_align - (2 * char_scale_x) + char_width;
         }
 
         int x_char = x + char_offset + x_align + (i * char_width);
 
         /* Output */
         snprintf(s, sizeof(s), "%c", c);
-        draw_text(x_char, y, color_f, color_b, GRAPH_ALPHA_100, GRAPH_BG_ALL, 1, 1, 10, s);
+        draw_text(x_char - char_scale_x, y, color_f, color_b, GRAPH_ALPHA_100, GRAPH_BG_ALL, char_scale_x, 1, 10, s);
     }
 }

--- a/retrodep/vsyncarch.c
+++ b/retrodep/vsyncarch.c
@@ -50,10 +50,11 @@ void vsyncarch_init(void)
 
 void vsyncarch_presync(void)
 {
+#if 0
     if (uistatusbar_state & UISTATUSBAR_ACTIVE) {
         uistatusbar_draw();
     }
-
+#endif
     retro_renderloop = 0;
     retro_lightpen_update();
 }

--- a/vice/src/autostart.c
+++ b/vice/src/autostart.c
@@ -1245,8 +1245,8 @@ void autostart_advance(void)
         case AUTOSTART_ERROR:
 #ifndef __LIBRETRO__
             log_message(autostart_log, "Error");
-#endif
             restore_drive_emulation_state(autostart_disk_unit, autostart_disk_drive);
+#endif
             autostartmode = AUTOSTART_DONE;
             break;
 

--- a/vice/src/tapeport/tapeport.c
+++ b/vice/src/tapeport/tapeport.c
@@ -84,7 +84,9 @@ tapeport_device_list_t *tapeport_device_register(tapeport_device_t *device)
                     use_id = tapeport_devices - 1;
                     ++current->device->id;
                 } else {
+#ifndef __LIBRETRO__
                     ui_error("last tapeport device %s does not support passthrough, and %s does not support passthrough either", current->device->name, device->name);
+#endif
                     return NULL;
                 }
             }


### PR DESCRIPTION
VKBD:
- Blended font shadows
- Dimmed surroundings
- Section gap
- Use 4 letters max instead of 3

C128:
- Proper VKBD layout for C128
  Closes #468 
- Fix 40/80 toggle switching

Other:
- TCRT extension to valid list
- Auto-enable TDE with TCRT
- Auto-disable TDE with D2M/D4M
