### PR TITLE
Autostart backport + Autoloadwarp fix

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1843,6 +1843,31 @@ void reload_restart(void)
       if (dc_get_image_type(content_path) == DC_IMAGE_TYPE_TAPE ||
           dc_get_image_type(content_path) == DC_IMAGE_TYPE_MEM)
          sound_drive_mute = true;
+
+#if defined(__XVIC__)
+      /* M3U has to be inspected */
+      if (strcasestr(content_path, ".m3u"))
+      {
+         FILE *fd;
+         char buf[RETRO_PATH_MAX] = {0};
+         char basepath[RETRO_PATH_MAX] = {0};
+         char fullpath[RETRO_PATH_MAX] = {0};
+         snprintf(basepath, sizeof(basepath), "%s", content_path);
+         path_basedir(basepath);
+
+         fd = fopen(content_path, MODE_READ);
+         if (fgets(buf, sizeof(buf), fd) != NULL)
+         {
+            buf[strcspn(buf, "\r\n")] = 0;
+            snprintf(fullpath, sizeof(fullpath), "%s%s", basepath, buf);
+         }
+         fclose(fd);
+
+         if (dc_get_image_type(fullpath) == DC_IMAGE_TYPE_TAPE ||
+             dc_get_image_type(fullpath) == DC_IMAGE_TYPE_MEM)
+            sound_drive_mute = true;
+      }
+#endif
    }
 
    /* Reset file path tag model force */

--- a/retrodep/uistatusbar.c
+++ b/retrodep/uistatusbar.c
@@ -56,23 +56,19 @@ extern float retro_refresh;
 extern int runstate;
 extern dc_storage *dc;
 
-/* ----------------------------------------------------------------- */
-/* static functions/variables */
-
-#ifndef MIN
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#endif
-
 #if defined(__XVIC__)
 extern int vic20mem_forced;
 #endif
+
+/* ----------------------------------------------------------------- */
+/* static functions/variables */
 
 #define STATUSBAR_RESOLUTION_POS    28
 #define STATUSBAR_MODEL_POS         45
 
 #define STATUSBAR_JOY_POS           0
-#define STATUSBAR_TAPE_POS          56
-#define STATUSBAR_DRIVE_POS         57
+#define STATUSBAR_TAPE_POS          55
+#define STATUSBAR_DRIVE_POS         59
 #define STATUSBAR_DRIVE8_TRACK_POS  59
 #define STATUSBAR_DRIVE9_TRACK_POS  59
 #define STATUSBAR_DRIVE10_TRACK_POS 59
@@ -82,10 +78,10 @@ extern int vic20mem_forced;
 #define MAX_STATUSBAR_LEN           64
 
 unsigned char statusbar_text[RETRO_PATH_MAX] = {0};
-unsigned char statusbar_chars[MAX_STATUSBAR_LEN] = {0};
-unsigned char statusbar_resolution[10] = {0};
-unsigned char statusbar_model[10] = {0};
-unsigned char statusbar_memory[10] = {0};
+static unsigned char statusbar_chars[MAX_STATUSBAR_LEN] = {0};
+static unsigned char statusbar_resolution[10] = {0};
+static unsigned char statusbar_model[10] = {0};
+static unsigned char statusbar_memory[10] = {0};
 
 static unsigned char* joystick_value_human(char val, int vice_device)
 {
@@ -120,178 +116,6 @@ static unsigned char* joystick_value_human(char val, int vice_device)
     return str;
 }
 
-static void display_joyport(void)
-{
-    unsigned char tmpstr[25] = {0};
-
-#if !defined(__XPET__) && !defined(__XCBM2__) && !defined(__XVIC__)
-    unsigned char joy1[2];
-    unsigned char joy2[2];
-    snprintf(joy1, sizeof(joy1), "%s", "1");
-    snprintf(joy2, sizeof(joy2), "%s", "2");
-
-    /* Lightpen/gun */
-    if (opt_joyport_type > 10 && cur_port == 1)
-        snprintf(tmpstr, sizeof(tmpstr), "L%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
-    /* Mouse */
-    else if (opt_joyport_type > 2 && cur_port == 1)
-        snprintf(tmpstr, sizeof(tmpstr), "M%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
-    /* Paddles */
-    else if (opt_joyport_type == 2)
-        snprintf(tmpstr, sizeof(tmpstr), "P%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
-    /* Joystick */
-    else
-        snprintf(tmpstr, sizeof(tmpstr), "J%s%3s ", joy1, joystick_value_human(joystick_value[1], 0));
-
-    /* Lightpen/gun */
-    if (opt_joyport_type > 10 && cur_port == 2)
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "L%s%3s ", joy2, joystick_value_human(mouse_value[2], 1));
-    /* Mouse */
-    else if (opt_joyport_type > 2 && cur_port == 2)
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "M%s%3s ", joy2, joystick_value_human(mouse_value[2], 1));
-    /* Paddles */
-    else if (opt_joyport_type == 2)
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "P%s%3s ", joy2, joystick_value_human(mouse_value[2], 1));
-    /* Joystick */
-    else
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%s%3s ", joy2, joystick_value_human(joystick_value[2], 0));
-#elif defined(__XVIC__)
-    char joy1[2];
-    snprintf(joy1, sizeof(joy1), "%s", "1");
-
-    /* Lightpen/gun */
-    if (opt_joyport_type > 10)
-        snprintf(tmpstr, sizeof(tmpstr), "L%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
-    /* Mouse */
-    else if (opt_joyport_type > 2)
-       snprintf(tmpstr, sizeof(tmpstr), "M%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
-    /* Paddles */
-    else if (opt_joyport_type == 2)
-       snprintf(tmpstr, sizeof(tmpstr), "P%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
-    /* Joystick */
-    else
-       snprintf(tmpstr, sizeof(tmpstr), "J%s%3s ", joy1, joystick_value_human(joystick_value[1], 0));
-#endif
-
-#if !defined(__XPET__) && !defined(__XCBM2__) && !defined(__XVIC__)
-    if (vice_opt.UserportJoyType != -1)
-    {
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 3, joystick_value_human(joystick_value[3], 0));
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 4, joystick_value_human(joystick_value[4], 0));
-    }
-    else
-    {
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
-    }
-#elif defined(__XVIC__)
-    if (vice_opt.UserportJoyType != -1)
-    {
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 2, joystick_value_human(joystick_value[2], 0));
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 3, joystick_value_human(joystick_value[3], 0));
-    }
-    else
-    {
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
-    }
-#elif defined(__XPET__) || defined(__XCBM2__)
-    if (vice_opt.UserportJoyType != -1)
-    {
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 1, joystick_value_human(joystick_value[1], 0));
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 2, joystick_value_human(joystick_value[2], 0));
-    }
-    else
-    {
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
-        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
-    }
-#endif
-
-    if (opt_statusbar & STATUSBAR_BASIC)
-        snprintf(tmpstr, sizeof(tmpstr), "%24s", "");
-
-    snprintf(&statusbar_chars[STATUSBAR_JOY_POS], sizeof(statusbar_chars), "%-55s", tmpstr);
-
-    if (opt_statusbar & STATUSBAR_BASIC)
-        return;
-
-    snprintf(statusbar_resolution, sizeof(statusbar_resolution), "%dx%d", retrow_crop, retroh_crop);
-
-#if defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__)
-    /* Model */
-    unsigned model = vice_opt.Model;
-    if (request_model_set > -1 && request_model_set != model)
-        model = request_model_set;
-
-    tmpstr[0] = '\0';
-    switch (model)
-    {
-        case C64MODEL_C64_PAL:
-        case C64MODEL_C64_PAL_N:
-        case C64MODEL_C64_OLD_PAL:
-        case C64MODEL_C64_NTSC:
-        case C64MODEL_C64_OLD_NTSC:
-            strcpy(tmpstr, "  C64"); break;
-        case C64MODEL_C64C_PAL:
-        case C64MODEL_C64C_NTSC:
-            strcpy(tmpstr, " C64C"); break;
-        case C64MODEL_C64SX_PAL:
-        case C64MODEL_C64SX_NTSC:
-            strcpy(tmpstr, "SX-64"); break;
-        case C64MODEL_PET64_PAL:
-        case C64MODEL_PET64_NTSC:
-            strcpy(tmpstr, "PET64"); break;
-        case C64MODEL_C64_GS:
-            strcpy(tmpstr, "C64GS"); break;
-        case C64MODEL_C64_JAP:
-            strcpy(tmpstr, "C64JP"); break;
-        case C64MODEL_ULTIMAX:
-            strcpy(tmpstr, "  MAX"); break;
-    }
-
-    /* Memory */
-    unsigned memory = 0;
-#if defined(__XSCPU64__)
-    memory = vice_opt.SIMMSize * 1024;
-#else
-    memory = vice_opt.REUsize;
-#endif
-
-    snprintf(statusbar_memory, sizeof(statusbar_memory), "%5dkB", memory);
-    snprintf(statusbar_model, sizeof(statusbar_model), "%-5s", tmpstr);
-#elif defined(__XVIC__)
-    /* Model */
-    unsigned model = vice_opt.Model;
-    if (request_model_set > -1 && request_model_set != model)
-        model = request_model_set;
-
-    tmpstr[0] = '\0';
-    switch (model)
-    {
-        case VIC20MODEL_VIC20_PAL:
-        case VIC20MODEL_VIC20_NTSC:
-            strcpy(tmpstr, "VIC20"); break;
-        case VIC20MODEL_VIC21:
-            strcpy(tmpstr, "VIC21"); break;
-    }
-
-    /* Memory */
-    unsigned memory = 0;
-    memory = (vic20mem_forced > -1) ? vic20mem_forced : vice_opt.VIC20Memory;
-    if (!memory && vice_opt.Model == VIC20MODEL_VIC21)
-        memory = 3;
-
-    int vic20mems[6]  = {0, 3, 8, 16, 24, 35};
-
-    snprintf(statusbar_memory, sizeof(statusbar_memory), "%5dkB", vic20mems[memory]);
-    snprintf(statusbar_model, sizeof(statusbar_model), "%-5s", tmpstr);
-#endif
-
-    if (uistatusbar_state & UISTATUSBAR_ACTIVE) {
-        uistatusbar_state |= UISTATUSBAR_REPAINT;
-    }
-}
 
 static int per = 0;
 static int fps = 0;
@@ -510,10 +334,8 @@ static int tape_motor = 0;
 
 static void display_tape(void)
 {
-    char tape_chars[5] = {23, 20, 22, 21, 'R'};
-
-    if (drive_enabled)
-        return;
+    const char tape_chars[5] = {23, 20, 22, 21, 'R'};
+    unsigned char tmpstr[5]  = {0};
 
     if (tape_enabled)
         vice_led_state[RETRO_LED_TAPE] = (tape_control == 1 && tape_motor) ? 1 : 0;
@@ -539,9 +361,12 @@ static void display_tape(void)
     }
 
     if (tape_enabled)
-        sprintf(&(statusbar_chars[STATUSBAR_TAPE_POS]), "%c%03d", tape_chars[tape_control], tape_counter);
+        snprintf(tmpstr, sizeof(tmpstr), "%c%03d", tape_chars[tape_control], tape_counter);
     else
-        sprintf(&(statusbar_chars[STATUSBAR_TAPE_POS]), "    ");
+        snprintf(tmpstr, sizeof(tmpstr), "    ");
+
+    /* Skip null terminator */
+    strncpy(&statusbar_chars[STATUSBAR_TAPE_POS], tmpstr, sizeof(tmpstr)-1);
 
     if (uistatusbar_state & UISTATUSBAR_ACTIVE) {
         uistatusbar_state |= UISTATUSBAR_REPAINT;
@@ -658,6 +483,179 @@ int uistatusbar_init_resources(void)
     return resources_register_int(resources_int);
 }
 
+/* Joyport bar */
+static void display_joyport(void)
+{
+    unsigned char tmpstr[25] = {0};
+
+#if !defined(__XPET__) && !defined(__XCBM2__) && !defined(__XVIC__)
+    unsigned char joy1[2];
+    unsigned char joy2[2];
+    snprintf(joy1, sizeof(joy1), "%s", "1");
+    snprintf(joy2, sizeof(joy2), "%s", "2");
+
+    /* Lightpen/gun */
+    if (opt_joyport_type > 10 && cur_port == 1)
+        snprintf(tmpstr, sizeof(tmpstr), "L%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
+    /* Mouse */
+    else if (opt_joyport_type > 2 && cur_port == 1)
+        snprintf(tmpstr, sizeof(tmpstr), "M%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
+    /* Paddles */
+    else if (opt_joyport_type == 2)
+        snprintf(tmpstr, sizeof(tmpstr), "P%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
+    /* Joystick */
+    else
+        snprintf(tmpstr, sizeof(tmpstr), "J%s%3s ", joy1, joystick_value_human(joystick_value[1], 0));
+
+    /* Lightpen/gun */
+    if (opt_joyport_type > 10 && cur_port == 2)
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "L%s%3s ", joy2, joystick_value_human(mouse_value[2], 1));
+    /* Mouse */
+    else if (opt_joyport_type > 2 && cur_port == 2)
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "M%s%3s ", joy2, joystick_value_human(mouse_value[2], 1));
+    /* Paddles */
+    else if (opt_joyport_type == 2)
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "P%s%3s ", joy2, joystick_value_human(mouse_value[2], 1));
+    /* Joystick */
+    else
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%s%3s ", joy2, joystick_value_human(joystick_value[2], 0));
+#elif defined(__XVIC__)
+    char joy1[2];
+    snprintf(joy1, sizeof(joy1), "%s", "1");
+
+    /* Lightpen/gun */
+    if (opt_joyport_type > 10)
+        snprintf(tmpstr, sizeof(tmpstr), "L%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
+    /* Mouse */
+    else if (opt_joyport_type > 2)
+       snprintf(tmpstr, sizeof(tmpstr), "M%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
+    /* Paddles */
+    else if (opt_joyport_type == 2)
+       snprintf(tmpstr, sizeof(tmpstr), "P%s%3s ", joy1, joystick_value_human(mouse_value[1], 1));
+    /* Joystick */
+    else
+       snprintf(tmpstr, sizeof(tmpstr), "J%s%3s ", joy1, joystick_value_human(joystick_value[1], 0));
+#endif
+
+#if !defined(__XPET__) && !defined(__XCBM2__) && !defined(__XVIC__)
+    if (vice_opt.UserportJoyType != -1)
+    {
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 3, joystick_value_human(joystick_value[3], 0));
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 4, joystick_value_human(joystick_value[4], 0));
+    }
+    else
+    {
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
+    }
+#elif defined(__XVIC__)
+    if (vice_opt.UserportJoyType != -1)
+    {
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 2, joystick_value_human(joystick_value[2], 0));
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 3, joystick_value_human(joystick_value[3], 0));
+    }
+    else
+    {
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
+    }
+#elif defined(__XPET__) || defined(__XCBM2__)
+    if (vice_opt.UserportJoyType != -1)
+    {
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 1, joystick_value_human(joystick_value[1], 0));
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "J%d%3s ", 2, joystick_value_human(joystick_value[2], 0));
+    }
+    else
+    {
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
+        snprintf(tmpstr + strlen(tmpstr), sizeof(tmpstr), "%5s", "");
+    }
+#endif
+
+    if (opt_statusbar & STATUSBAR_BASIC)
+        snprintf(tmpstr, sizeof(tmpstr), "%24s", "");
+
+    snprintf(&statusbar_chars[STATUSBAR_JOY_POS], sizeof(statusbar_chars), "%-54s", tmpstr);
+
+    if (opt_statusbar & STATUSBAR_BASIC)
+        return;
+
+    snprintf(statusbar_resolution, sizeof(statusbar_resolution), "%dx%d", retrow_crop, retroh_crop);
+
+#if defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__)
+    /* Model */
+    unsigned model = vice_opt.Model;
+    if (request_model_set > -1 && request_model_set != model)
+        model = request_model_set;
+
+    tmpstr[0] = '\0';
+    switch (model)
+    {
+        case C64MODEL_C64_PAL:
+        case C64MODEL_C64_PAL_N:
+        case C64MODEL_C64_OLD_PAL:
+        case C64MODEL_C64_NTSC:
+        case C64MODEL_C64_OLD_NTSC:
+            strcpy(tmpstr, "  C64"); break;
+        case C64MODEL_C64C_PAL:
+        case C64MODEL_C64C_NTSC:
+            strcpy(tmpstr, " C64C"); break;
+        case C64MODEL_C64SX_PAL:
+        case C64MODEL_C64SX_NTSC:
+            strcpy(tmpstr, "SX-64"); break;
+        case C64MODEL_PET64_PAL:
+        case C64MODEL_PET64_NTSC:
+            strcpy(tmpstr, "PET64"); break;
+        case C64MODEL_C64_GS:
+            strcpy(tmpstr, "C64GS"); break;
+        case C64MODEL_C64_JAP:
+            strcpy(tmpstr, "C64JP"); break;
+        case C64MODEL_ULTIMAX:
+            strcpy(tmpstr, "  MAX"); break;
+    }
+
+    /* Memory */
+    unsigned memory = 0;
+#if defined(__XSCPU64__)
+    memory = vice_opt.SIMMSize * 1024;
+#else
+    memory = vice_opt.REUsize;
+#endif
+
+    snprintf(statusbar_memory, sizeof(statusbar_memory), "%5dkB", memory);
+    snprintf(statusbar_model - ((tape_enabled && retrow_crop == CROP_WIDTH_MAX) ? 2 : 0), sizeof(statusbar_model), "%-5s", tmpstr);
+#elif defined(__XVIC__)
+    /* Model */
+    unsigned model = vice_opt.Model;
+    if (request_model_set > -1 && request_model_set != model)
+        model = request_model_set;
+
+    tmpstr[0] = '\0';
+    switch (model)
+    {
+        case VIC20MODEL_VIC20_PAL:
+        case VIC20MODEL_VIC20_NTSC:
+            strcpy(tmpstr, "VIC20"); break;
+        case VIC20MODEL_VIC21:
+            strcpy(tmpstr, "VIC21"); break;
+    }
+
+    /* Memory */
+    unsigned memory = 0;
+    memory = (vic20mem_forced > -1) ? vic20mem_forced : vice_opt.VIC20Memory;
+    if (!memory && vice_opt.Model == VIC20MODEL_VIC21)
+        memory = 3;
+
+    int vic20mems[6]  = {0, 3, 8, 16, 24, 35};
+
+    snprintf(statusbar_memory, sizeof(statusbar_memory), "%5dkB", vic20mems[memory]);
+    snprintf(statusbar_model, sizeof(statusbar_model), "%-5s", tmpstr);
+#endif
+
+    if (uistatusbar_state & UISTATUSBAR_ACTIVE) {
+        uistatusbar_state |= UISTATUSBAR_REPAINT;
+    }
+}
 
 /* ----------------------------------------------------------------- */
 /* uistatusbar.h */
@@ -733,14 +731,19 @@ void uistatusbar_draw(void)
     int x_align_offset = 3;
 
     /* LED section position */
+    int led_x     = 0;
     int led_width = 0;
-    int led_x = 0;
     if (drive_enabled)
+    {
         led_width = (char_width * 5) - x_align_offset + 2;
+        if (tape_enabled)
+            led_width += (char_width * 5) - x_align_offset;
+    }
     else if (tape_enabled)
-        led_width = (char_width * 8) - x_align_offset - 4;
+        led_width = (char_width * 8) - x_align_offset - 3;
     else
-        led_width = (char_width * 3) - x_align_offset - 1;
+        led_width = (char_width * 3) - x_align_offset;
+
     led_x = retroXS_offset + x + max_width - led_width - 1;
 
     /* Basic mode statusbar background */
@@ -839,13 +842,24 @@ void uistatusbar_draw(void)
         {
             if (i == STATUSBAR_DRIVE8_TRACK_POS || i == STATUSBAR_DRIVE8_TRACK_POS + 1)
                 x_align -= 2 * char_scale_x;
+
+            if (tape_enabled)
+            {
+                if (i == STATUSBAR_TAPE_POS)
+                    x_align -= ((char_width + 5) * char_scale_x) - char_width;
+                else if (i >= STATUSBAR_TAPE_POS && i < STATUSBAR_TAPE_POS + 4)
+                    x_align -= ((char_width + 4) * char_scale_x) - char_width;
+            }
         }
         else if (tape_enabled)
         {
-            if (i >= STATUSBAR_TAPE_POS && i < STATUSBAR_SPEED_POS - 4)
-                x_align = x_align - (3 * char_scale_x) + char_width;
-            else if (i >= STATUSBAR_TAPE_POS && i < STATUSBAR_SPEED_POS - 1)
-                x_align = x_align - (2 * char_scale_x) + char_width;
+            if (i == STATUSBAR_TAPE_POS)
+                x_align -= (3 * char_scale_x) - (char_width * 2);
+            else if (i >= STATUSBAR_TAPE_POS && i < STATUSBAR_TAPE_POS + 4)
+                x_align -= (2 * char_scale_x) - (char_width * 2);
+
+            if (i == STATUSBAR_DRIVE8_TRACK_POS || i == STATUSBAR_DRIVE8_TRACK_POS + 1)
+                c = '\0';
         }
 
         int x_char = x + char_offset + x_align + (i * char_width);

--- a/vice/src/autostart-prg.c
+++ b/vice/src/autostart-prg.c
@@ -85,17 +85,15 @@ static autostart_prg_t * load_prg(const char *file_name, fileio_info_t *finfo, l
     }
 
     /* get load addr */
-    if (autostart_basic_load) {
-        mem_get_basic_text(&prg->start_addr, NULL);
-    } else {
-        prg->start_addr = (uint16_t)hi << 8 | (uint16_t)lo;
-    }
+    prg->start_addr = (uint16_t)hi << 8 | (uint16_t)lo;
+
     prg->size -= 2; /* skip load addr */
 
     /* check range */
     end = prg->start_addr + prg->size - 1;
     if (end > 0xffff) {
         log_error(log, "Invalid size of '%s': %" PRIu32, file_name, prg->size);
+        lib_free(prg);
         return NULL;
     }
 
@@ -365,6 +363,13 @@ int autostart_prg_perform_injection(log_t log)
         return -1;
     }
 
+    mem_get_basic_text(&start, &end);
+
+    /* load to basic start if requested */
+    if (autostart_basic_load) {
+        prg->start_addr = start;
+    }
+
     log_message(autostart_log, "Injecting program data at $%04x (size $%04x)",
                 prg->start_addr, (unsigned int)prg->size);
 
@@ -374,7 +379,6 @@ int autostart_prg_perform_injection(log_t log)
     }
 
     /* now simulate a basic load */
-    mem_get_basic_text(&start, &end);
     end = (uint16_t)(prg->start_addr + prg->size);
     mem_set_basic_text(start, end);
 

--- a/vice/src/crt.c
+++ b/vice/src/crt.c
@@ -1,0 +1,297 @@
+/*
+ * crt.c - CRT image handling.
+ *
+ * Written by
+ *  Andreas Boose <viceteam@t-online.de>
+ *  Marco van den Heuvel <blackystardust68@yahoo.com>
+ *
+ * This file is part of VICE, the Versatile Commodore Emulator.
+ * See README for copyright notice.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ *  02111-1307  USA.
+ *
+ */
+
+#include "vice.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "archdep.h"
+#include "cartridge.h"
+#include "crt.h"
+#include "log.h"
+#include "machine.h"
+#include "resources.h"
+#include "types.h"
+#include "c64cart.h"  /* FIXME: for C64CART_IMAGE_LIMIT */
+#include "util.h"
+
+//#define DEBUGCRT
+
+#ifdef DEBUGCRT
+#define DBG(x)  printf x
+#else
+#define DBG(x)
+#endif
+
+/*
+ * CRT image "strings".
+ */
+static const char CRT_HEADER_C64[] = "C64 CARTRIDGE   ";
+static const char CRT_HEADER_VIC20[] = "VIC20 CARTRIDGE ";
+static const char CRT_HEADER_PLUS4[] = "PLUS4 CARTRIDGE ";
+
+static const char CHIP_HEADER[] = "CHIP";
+
+/*
+    Open a crt file and read header, return NULL on fault, fd otherwise
+*/
+FILE *crt_open(const char *filename, crt_header_t *header)
+{
+    uint8_t crt_header[0x40];
+    uint32_t skip;
+    FILE *fd;
+
+    fd = fopen(filename, MODE_READ);
+
+    if (fd == NULL) {
+        return NULL;
+    }
+
+    do {
+        if (fread(crt_header, sizeof(crt_header), 1, fd) < 1) {
+            log_error(LOG_DEFAULT, "could not read CRT header.");
+            break;
+        }
+
+        if (machine_class == VICE_MACHINE_C64 || 
+            machine_class == VICE_MACHINE_C64SC ||
+            machine_class == VICE_MACHINE_C128 ||
+            machine_class == VICE_MACHINE_SCPU64) {
+            if (memcmp(crt_header, CRT_HEADER_C64, 16)) {
+                log_error(LOG_DEFAULT, "CRT header invalid.");
+                break;
+            }
+        }
+
+        if (machine_class == VICE_MACHINE_VIC20) {
+            if (memcmp(crt_header, CRT_HEADER_VIC20, 16)) {
+                log_error(LOG_DEFAULT, "CRT header invalid.");
+                break;
+            }
+        }
+
+        if (machine_class == VICE_MACHINE_PLUS4) {
+            if (memcmp(crt_header, CRT_HEADER_PLUS4, 16)) {
+                log_error(LOG_DEFAULT, "CRT header invalid.");
+                break;
+            }
+        }
+
+        skip = util_be_buf_to_dword(&crt_header[0x10]);
+
+        if (skip < sizeof(crt_header)) {
+            log_error(LOG_DEFAULT, "CRT header size is wrong (is 0x%02x, expected 0x%02x).",
+                (unsigned int)skip, (unsigned int)sizeof(crt_header));
+            break; /* invalid header size */
+        }
+        skip -= sizeof(crt_header); /* without header */
+
+        header->version = util_be_buf_to_word(&crt_header[0x14]);
+        header->type = util_be_buf_to_word(&crt_header[0x16]);
+        header->subtype = crt_header[0x1a];
+        header->exrom = crt_header[0x18];
+        header->game = crt_header[0x19];
+        memset(header->name, 0, sizeof(header->name));
+        strncpy(header->name, (char *)(crt_header + 0x20),
+                sizeof(header->name) - 1);
+
+        fseek(fd, skip, SEEK_CUR); /* skip the rest */
+
+        return fd; /* Ok, exit */
+    } while (0);
+
+    fclose(fd);
+    return NULL; /* Fault */
+}
+/*
+    returns -1 on error, else a positive CRT ID
+*/
+int crt_getid(const char *filename)
+{
+    crt_header_t header;
+    FILE *fd;
+
+    fd = crt_open(filename, &header);
+
+    if (fd == NULL) {
+        return -1;
+    }
+
+    fclose(fd);
+
+    return header.type;
+}
+
+/*
+    Read and parse chip header, return -1 on fault
+*/
+int crt_read_chip_header(crt_chip_header_t *header, FILE *fd)
+{
+    uint8_t chipheader[0x10];
+
+    if (fread(chipheader, sizeof(chipheader), 1, fd) < 1) {
+        return -1; /* couldn't read header */
+    }
+    if (memcmp(chipheader, CHIP_HEADER, 4)) {
+        return -1; /* invalid header signature */
+    }
+
+    /* 1: grab size of chip packet from the file */
+    header->skip = util_be_buf_to_dword(&chipheader[4]);
+
+    if (header->skip < sizeof(chipheader)) {
+        return -1; /* invalid packet size */
+    }
+    /* 2: subtract header size, we now have the payload size */
+    header->skip -= sizeof(chipheader); /* without header */
+
+    header->size = util_be_buf_to_word(&chipheader[14]);
+    if (header->size > header->skip) {
+        return -1; /* rom bigger then total size?! */
+    }
+    /* 3: subtract ROM size, we get the unused portion at the end,
+          which we need to skip */
+    header->skip -= header->size; /* skip size after image */
+
+    header->type = util_be_buf_to_word(&chipheader[8]);
+    header->bank = util_be_buf_to_word(&chipheader[10]);
+    header->start = util_be_buf_to_word(&chipheader[12]);
+
+    if (header->start + header->size > 0x10000) {
+        return -1; /* rom crossing the 64k boundary?! */
+    }
+
+    return 0;
+}
+/*
+    Read chip data, return -1 on error
+*/
+int crt_read_chip(uint8_t *rawcart, int offset, crt_chip_header_t *chip, FILE *fd)
+{
+    if (offset + chip->size > C64CART_IMAGE_LIMIT) {
+        return -1; /* overflow */
+    }
+    if (fread(&rawcart[offset], chip->size, 1, fd) < 1) {
+        return -1; /* eof?! */
+    }
+    fseek(fd, chip->skip, SEEK_CUR); /* skip the rest */
+
+    return 0;
+}
+/*
+    Write chip header and data, return -1 on fault
+*/
+int crt_write_chip(uint8_t *data, crt_chip_header_t *header, FILE *fd)
+{
+    uint8_t chipheader[0x10];
+
+    memcpy(chipheader, CHIP_HEADER, 4);
+    util_dword_to_be_buf(&chipheader[4], header->size + sizeof(chipheader));
+    util_word_to_be_buf(&chipheader[8], header->type);
+    util_word_to_be_buf(&chipheader[10], header->bank);
+    util_word_to_be_buf(&chipheader[12], header->start);
+    util_word_to_be_buf(&chipheader[14], header->size);
+
+    if (fwrite(chipheader, sizeof(chipheader), 1, fd) < 1) {
+        return -1; /* could not write chip header */
+    }
+
+    if (fwrite(data, header->size, 1, fd) < 1) {
+        return -1; /* could not write chip content */
+    }
+
+    return 0;
+}
+/*
+    Create crt file with header, return NULL on fault, fd otherwise
+*/
+FILE *crt_create(const char *filename, int type, int exrom, int game, const char *name)
+{
+    uint8_t crt_header[0x40];
+    FILE *fd;
+
+    if (filename == NULL) {
+        return NULL;
+    }
+
+    fd = fopen(filename, MODE_WRITE);
+
+    if (fd == NULL) {
+        return NULL;
+    }
+
+    memset(&crt_header, 0, sizeof(crt_header));
+    memcpy(crt_header, CRT_HEADER_C64, 16); /* FIXME */
+    util_dword_to_be_buf(&crt_header[0x10], sizeof(crt_header));
+    util_word_to_be_buf(&crt_header[0x14], 0x100); /* version */
+    util_word_to_be_buf(&crt_header[0x16], (uint16_t)type);
+    crt_header[0x18] = exrom ? 1 : 0;
+    crt_header[0x19] = game ? 1 : 0;
+    strncpy((char*)(crt_header + 0x20), name, sizeof(crt_header) - 0x20 - 1);
+
+    if (fwrite(crt_header, sizeof(crt_header), 1, fd) < 1) {
+        fclose(fd);
+        return NULL;
+    }
+
+    return fd;
+}
+
+/* create v1.1 header with sub type */
+FILE *crt_create_v11(const char *filename, int type, int subtype, int exrom, int game, const char *name)
+{
+    uint8_t crt_header[0x40];
+    FILE *fd;
+
+    if (filename == NULL) {
+        return NULL;
+    }
+
+    fd = fopen(filename, MODE_WRITE);
+
+    if (fd == NULL) {
+        return NULL;
+    }
+
+    memset(&crt_header, 0, sizeof(crt_header));
+    memcpy(crt_header, CRT_HEADER_C64, 16); /* FIXME */
+    util_dword_to_be_buf(&crt_header[0x10], sizeof(crt_header));
+    util_word_to_be_buf(&crt_header[0x14], 0x0101); /* version */
+    util_word_to_be_buf(&crt_header[0x16], (uint16_t)type);
+    crt_header[0x18] = exrom ? 1 : 0;
+    crt_header[0x19] = game ? 1 : 0;
+    crt_header[0x1a] = subtype;
+    strncpy((char*)(crt_header + 0x20), name, sizeof(crt_header) - 0x20 - 1);
+
+    if (fwrite(crt_header, sizeof(crt_header), 1, fd) < 1) {
+        fclose(fd);
+        return NULL;
+    }
+
+    return fd;
+}

--- a/vice/src/crt.h
+++ b/vice/src/crt.h
@@ -1,0 +1,59 @@
+/*
+ * crt.h - CRT image handling.
+ *
+ * Written by
+ *  Andreas Boose <viceteam@t-online.de>
+ *  Marco van den Heuvel <blackystardust68@yahoo.com>
+ *
+ * This file is part of VICE, the Versatile Commodore Emulator.
+ * See README for copyright notice.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ *  02111-1307  USA.
+ *
+ */
+
+#ifndef VICE_CRT_H
+#define VICE_CRT_H
+
+#include "types.h"
+
+typedef struct crt_header_s {
+    uint16_t version;         /* version */
+    uint16_t type;            /* type of cartridge */
+    uint8_t subtype;          /* subtype/hardware revision of cartridge */
+    int exrom;                /* exrom line status */
+    int game;                 /* game line status */
+    char name[32 + 1];        /* name of cartridge */
+} crt_header_t;
+
+typedef struct crt_chip_header_s {
+    uint32_t skip;               /* bytes to skip after ROM */
+    uint16_t type;                /* chip type */
+    uint16_t bank;                /* bank number */
+    uint16_t start;               /* start address of ROM */
+    uint16_t size;                /* size of ROM in bytes */
+} crt_chip_header_t;
+
+FILE *crt_open(const char *filename, crt_header_t *header);
+extern int crt_getid(const char *filename);
+extern int crt_read_chip_header(crt_chip_header_t *header, FILE *fd);
+extern int crt_read_chip(uint8_t *rawcart, int offset, crt_chip_header_t *chip, FILE *fd);
+extern FILE *crt_create(const char *filename, int type, int exrom, int game, const char *name);
+extern int crt_write_chip(uint8_t *data, crt_chip_header_t *header, FILE *fd);
+/* create v1.1 header with sub type */
+extern FILE *crt_create_v11(const char *filename, int type, int subtype, int exrom, int game, const char *name);
+
+#endif


### PR DESCRIPTION
- Recent change of not disabling disk drive by default caused a clash when tape was enabled, ultimately causing statusbar being broken and autoloadwarp to not work
Closes #475 

- Recent autostart backport aimed at fixing tapecart images broke VIC-20 PRG autostart
Closes #476 