### PR TITLE
Misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ External ROM files required in `system/vice`:
 | Filename                         | Size   | MD5                              |
 |----------------------------------|-------:|----------------------------------|
 | **JiffyDOS_C64.bin**             |  8 192 | be09394f0576cf81fa8bacf634daf9a2 |
+| **JiffyDOS_SX-64.bin**           |  8 192 | f0d3aa7c5a81d1e1d3e8eeda84e9dbbe |
 | **JiffyDOS_C128.bin**            | 16 384 | cbbd1bbcb5e4fd8046b6030ab71fc021 |
 | **JiffyDOS_1541-II.bin**         | 16 384 | 1b1e985ea5325a1f46eb7fd9681707bf |
 | **JiffyDOS_1571_repl310654.bin** | 32 768 | 41c6cc528e9515ffd0ed9b180f8467c0 |

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -176,6 +176,7 @@ unsigned int opt_work_disk_unit = 8;
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
 static unsigned int opt_jiffydos_allow = 1;
 unsigned int opt_jiffydos = 0;
+unsigned int opt_jiffydos_kernal_skip = 0;
 #endif
 #if defined(__XSCPU64__)
 unsigned int opt_supercpu_kernal = 0;
@@ -6828,7 +6829,7 @@ static void update_variables(void)
          opt_jiffydos = 0;
 
       if (retro_ui_finalized)
-         request_reload_restart = (opt_jiffydos != opt_jiffydos_prev) ? true : request_reload_restart;
+         request_reload_restart = (opt_jiffydos != opt_jiffydos_prev || request_restart) ? true : request_reload_restart;
    }
 #endif
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -739,12 +739,12 @@ static int process_cmdline(const char* argv)
       }
 
       /* ZIP */
-      if (strendswith(argv, "zip") || strendswith(argv, "7z"))
+      if (strendswith(argv, ".zip") || strendswith(argv, ".7z"))
       {
          path_mkdir(retro_temp_directory);
-         if (strendswith(argv, "zip"))
+         if (strendswith(argv, ".zip"))
             zip_uncompress(full_path, retro_temp_directory, NULL);
-         else if (strendswith(argv, "7z"))
+         else if (strendswith(argv, ".7z"))
             sevenzip_uncompress(full_path, retro_temp_directory, NULL);
 
          /* Default to directory mode */

--- a/libretro/libretro-dc.c
+++ b/libretro/libretro-dc.c
@@ -445,12 +445,12 @@ bool dc_replace_file(dc_storage* dc, int index, const char* filename)
       }
 
       /* ZIP */
-      if (strendswith(full_path_replace, "zip") || strendswith(full_path_replace, "7z"))
+      if (strendswith(full_path_replace, ".zip") || strendswith(full_path_replace, ".7z"))
       {
          path_mkdir(retro_temp_directory);
-         if (strendswith(full_path_replace, "zip"))
+         if (strendswith(full_path_replace, ".zip"))
             zip_uncompress(full_path_replace, retro_temp_directory, NULL);
-         else if (strendswith(full_path_replace, "7z"))
+         else if (strendswith(full_path_replace, ".7z"))
             sevenzip_uncompress(full_path_replace, retro_temp_directory, NULL);
 
          /* Default to directory mode */
@@ -952,14 +952,14 @@ void dc_parse_list(dc_storage* dc, const char* list_file, bool is_vfl, const cha
          }
 
          /* ZIP */
-         if (strendswith(file_path, "zip") || strendswith(file_path, "7z"))
+         if (strendswith(file_path, ".zip") || strendswith(file_path, ".7z"))
          {
             char lastfile[RETRO_PATH_MAX] = {0};
 
             path_mkdir(retro_temp_directory);
-            if (strendswith(file_path, "zip"))
+            if (strendswith(file_path, ".zip"))
                zip_uncompress(file_path, retro_temp_directory, lastfile);
-            else if (strendswith(file_path, "7z"))
+            else if (strendswith(file_path, ".7z"))
                sevenzip_uncompress(file_path, retro_temp_directory, lastfile);
 
             /* Convert all NIBs to G64 */

--- a/vice/src/c64/c64-resources.c
+++ b/vice/src/c64/c64-resources.c
@@ -86,6 +86,12 @@ static int set_chargen_rom_name(const char *val, void *param)
     return c64rom_load_chargen(chargen_rom_name);
 }
 
+#ifdef __LIBRETRO__
+#if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
+extern unsigned int opt_jiffydos_kernal_skip;
+#endif
+#endif
+
 static int set_kernal_rom_name(const char *val, void *param)
 {
     int ret, changed = 1;
@@ -93,6 +99,10 @@ static int set_kernal_rom_name(const char *val, void *param)
     if ((val != NULL) && (kernal_rom_name != NULL)) {
         changed = (strcmp(val, kernal_rom_name) != 0);
     }
+#ifdef __LIBRETRO__
+    if (opt_jiffydos_kernal_skip)
+        return 0;
+#endif
     if (util_string_set(&kernal_rom_name, val)) {
         return 0;
     }


### PR DESCRIPTION
- Add extension dots to archive handling for not getting confused with `.d7z` and `.7z`
   Closes #480 

- Add annoying hack for allowing JiffyDOS to work with SX-64 model
   Closes #479 

