### PR TITLE
fix autostart not working on reset

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -8270,7 +8270,7 @@ void retro_run(void)
    if (request_restart && retro_now > 20000)
    {
       request_restart = false;
-      emu_reset(-1);
+      emu_reset(0);
    }
 }
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -8270,7 +8270,7 @@ void retro_run(void)
    if (request_restart && retro_now > 20000)
    {
       request_restart = false;
-      emu_reset(0);
+      emu_reset(-1);
    }
 }
 

--- a/vice/src/autostart.c
+++ b/vice/src/autostart.c
@@ -1716,8 +1716,9 @@ int autostart_disk(int unit, int drive, const char *file_name, const char *progr
     if (name) {
         autostart_disk_cook_name(&name);
 
-        /* detach disk before reattaching */
+#ifdef __LIBRETRO__
         file_system_detach_disk(unit, drive);
+#endif
 
         if (!(file_system_attach_disk(unit, drive, file_name) < 0)) {
 #if 1

--- a/vice/src/autostart.c
+++ b/vice/src/autostart.c
@@ -1715,6 +1715,10 @@ int autostart_disk(int unit, int drive, const char *file_name, const char *progr
 
     if (name) {
         autostart_disk_cook_name(&name);
+
+        /* detach disk before reattaching */
+        file_system_detach_disk(unit, drive);
+
         if (!(file_system_attach_disk(unit, drive, file_name) < 0)) {
 #if 1
             vdrive_t *vdrive;


### PR DESCRIPTION
ensures the disk is detached before trying to reattach it in the autostart code.

also modifies the `emu_reset` call to allow the `vice_reset` config to be processed when resetting.