### PR TITLE
Fix core options not set in retro_set_environment()

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -5227,6 +5227,8 @@ void retro_set_environment(retro_environment_t cb)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
       filestream_vfs_init(&vfs_iface_info);
 #endif
+
+   retro_set_core_options();
 }
 
 int log_resources_set_int(const char *name, int value)


### PR DESCRIPTION
## Description

This PR fixes core variables for frontends that require the variables to be set inside retro_set_environment().

The documentation of `RETRO_ENVIRONMENT_SET_VARIABLES` states:

> This should be called the first time as early as possible (ideally in retro_set_environment).
>
> Afterward it may be called again for the core to communicate updated options to the frontend, but the number of core options must not change from the number in the initial call.

By calling `retro_set_core_options()` both inside retro_set_environment and when loading a game, we satisfy the libretro documentation.

## How has this been tested?

Used to generate Kodi settings for the following cores:

* vice_x128
* vice_x64
* vice_x64dtv
* vice_x64sc
* vice_xcbm2
* vice_xcbm5x0
* vice_xpet
* vice_xplus4
* vice_xscpu64
* vice_xvic
