### PR TITLE
VDC, VKBD + crop corrections

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -6364,7 +6364,7 @@ static void update_variables(void)
          else                                   blur = 500;
       }
 
-      if (retro_ui_finalized && vice_opt.Filter != blur)
+      if (retro_ui_finalized && vice_opt.VDCFilter != blur)
       {
          log_resources_set_int("VDCFilter", filter);
          log_resources_set_int("VDCPALBlur", blur);

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -623,19 +623,27 @@ void print_vkbd(void)
       YPADDING = 72;
    }
 #if defined(__X128__)
+   /* Difference due to VKBD height difference */
+   if (retro_region == RETRO_REGION_NTSC)
+   {
+      YOFFSET  = 2;
+      YPADDING = 64;
+   }
+
    /* VDC */
    if (retrow > 704)
    {
-      YOFFSET     = -8;
-      YPADDING    = 108;
+      XOFFSET     = 2;
+      YOFFSET     = 1;
       XPADDING    = 120;
       XPADDING   *= 2;
+      YPADDING    = 108;
       FONT_WIDTH *= 2;
 
-      if (retro_region == RETRO_REGION_NTSC)
+      if (retro_region == RETRO_REGION_NTSC || retroh == 240)
       {
-         YOFFSET     = 2;
-         YPADDING    = 68;
+         YOFFSET  = 7;
+         YPADDING = 64;
       }
    }
 #endif
@@ -941,7 +949,7 @@ void print_vkbd(void)
 
       /* Bottom */
       corner_y_min = vkbd_y_max + YKEYSPACING;
-      corner_y_max = retroh - retroYS_offset - vkbd_y_max - YKEYSPACING;
+      corner_y_max = retroh - vkbd_y_max - YKEYSPACING;
       draw_fbox(0, corner_y_min,
                 retrow, corner_y_max,
                 0, BRD_ALPHA);

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -590,64 +590,59 @@ void print_vkbd(void)
    XOFFSET  = 0;
    YOFFSET  = 0;
    XPADDING = 116;
-   YPADDING = 118;
 
    if (retro_region == RETRO_REGION_NTSC)
    {
       XOFFSET  = 8;
       YOFFSET  = -1;
       XPADDING = 68;
-      YPADDING = 68;
    }
 #elif defined(__XPLUS4__)
    /* TED */
    XOFFSET  = 0;
-   YOFFSET  = -2;
    XPADDING = 74;
-   YPADDING = 108;
-
-   if (retro_region == RETRO_REGION_NTSC)
-   {
-      YPADDING = 64;
-   }
 #else
    /* VIC-II */
    XOFFSET  = 0;
    YOFFSET  = 1;
    XPADDING = 74;
-   YPADDING = 92;
-
-   if (retro_region == RETRO_REGION_NTSC)
-   {
-      YOFFSET  = -1;
-      YPADDING = 72;
-   }
 #if defined(__X128__)
    /* Difference due to VKBD height difference */
    if (retro_region == RETRO_REGION_NTSC)
-   {
       YOFFSET  = 2;
-      YPADDING = 64;
-   }
 
    /* VDC */
    if (retrow > 704)
    {
       XOFFSET     = 2;
-      YOFFSET     = 1;
       XPADDING    = 120;
       XPADDING   *= 2;
-      YPADDING    = 108;
       FONT_WIDTH *= 2;
 
       if (retro_region == RETRO_REGION_NTSC || retroh == 240)
-      {
          YOFFSET  = 7;
-         YPADDING = 64;
-      }
    }
 #endif
 #endif
+
+   /* Vertical centering calculations */
+   {
+      int crop_top_border = (retroh - CROP_HEIGHT_MAX) / 2;
+#if defined(__X128__)
+      if (c128_vdc)
+         crop_top_border = (retroh - CROP_VDC_HEIGHT_MAX) / 2;
+#endif
+      /* Bonus 10 for statusbar */
+      YPADDING = (crop_top_border + 10) * 2;
+
+      /* Vertical centering offset required if both borders are not used */
+      if (retroYS_offset && retroYS_offset < crop_top_border)
+      {
+         int leftover = retroh - retroh_crop - crop_top_border - retroYS_offset;
+         if (leftover > 0)
+            YOFFSET -= (crop_top_border - retroYS_offset) / 2;
+      }
+   }
 
    int XSIDE     = (retrow - XPADDING) / VKBDX;
    int YSIDE     = (retroh - YPADDING) / VKBDY;


### PR DESCRIPTION
- Fixed VDC filter core option
- Fixed VDC filter itself which was using the wrong render mode, causing wrong colors
- Enforced VDC "toggle" key (40/80 column mode) to change display output at once
- Fixed Automatic cropping with VDC
- Fixed and streamlined Automatic cropping in general
- Fixed Auto-Disable crop with x64sc (current quick method only worked with fast VIC-II)

Closes #492