### PR TITLE
Crop + automatic model + misc improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,6 @@ COMMONFLAGS += -DCORE_NAME=\"$(EMUTYPE)\"
 include Makefile.common
 
 OBJECTS     += $(patsubst %.cpp,%.o,$(SOURCES_CXX:.cc=.o)) $(SOURCES_C:.c=.o)
-OBJECT_DEPS  = $(OBJECTS:.o=.d)
 PLATFLAGS   := $(CFLAGS)
 CXXFLAGS    += $(fpic) $(INCFLAGS) $(COMMONFLAGS)
 CFLAGS      += $(fpic) $(INCFLAGS) $(COMMONFLAGS)
@@ -424,7 +423,6 @@ LDFLAGS     += -lm $(fpic)
 
 OBJDIR      := build
 OBJECTS     := $(addprefix $(OBJDIR)/,$(OBJECTS))
-OBJECT_DEPS := $(addprefix $(OBJDIR)/,$(OBJECT_DEPS))
 
 # Ensure only a language version supported by all compilers is used
 # Do not enforce C99 as some gcc-versions appear to not handle system-headers
@@ -446,10 +444,13 @@ default:
 	$(MAKE) $(TARGET)
 
 all: $(TARGET)
+
+-include $(OBJECTS:.o=.d))
+
 $(TARGET): $(OBJECTS)
 ifeq ($(platform), emscripten)
 	$(CXX) -r $(SHARED) -o $@ $(OBJECTS) $(LDFLAGS)
-else  ifeq ($(STATIC_LINKING), 1)
+else ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 #STATIC_LINKING=1 and additional Makefile.common sources are incompatible for PS3 environment
 else ifeq ($(platform), ps3)
@@ -478,8 +479,6 @@ $(OBJDIR)/%.o: %.cc
 		$(if $@, $(shell echo echo CXX $<),);\
 	fi
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
-
--include $(OBJECT_DEPS)
 
 clean:
 	rm -rf $(OBJDIR)

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -4093,26 +4093,6 @@ static void retro_set_core_options()
          {{ NULL, NULL }},
          "---"
       },
-      {
-         "vice_mapper_reset",
-         "Hotkey > Reset",
-         "Reset",
-         "Press the mapped key to trigger the selected 'Reset Type'.",
-         NULL,
-         "hotkey",
-         {{ NULL, NULL }},
-         "RETROK_END"
-      },
-      {
-         "vice_mapper_warp_mode",
-         "Hotkey > Hold Warp Mode",
-         "Hold Warp Mode",
-         "Hold the mapped key for warp mode.",
-         NULL,
-         "hotkey",
-         {{ NULL, NULL }},
-         ""
-      },
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__) || defined(__XVIC__) || defined(__XPLUS4__)
       {
          "vice_mapper_aspect_ratio_toggle",
@@ -4208,6 +4188,26 @@ static void retro_set_core_options()
          "---"
       },
 #endif
+      {
+         "vice_mapper_reset",
+         "Hotkey > Reset",
+         "Reset",
+         "Press the mapped key to trigger the selected 'Reset Type'.",
+         NULL,
+         "hotkey",
+         {{ NULL, NULL }},
+         "RETROK_END"
+      },
+      {
+         "vice_mapper_warp_mode",
+         "Hotkey > Hold Warp Mode",
+         "Hold Warp Mode",
+         "Hold the mapped key for warp mode.",
+         NULL,
+         "hotkey",
+         {{ NULL, NULL }},
+         ""
+      },
       /* Button mappings */
       {
          "vice_mapper_up",

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -811,6 +811,13 @@ static int process_cmdline(const char* argv)
       if (!path_is_valid(argv))
          argv = "";
 
+      /* Disable floppy drive with tapes */
+      if (dc_get_image_type(argv) == DC_IMAGE_TYPE_TAPE)
+      {
+         Add_Option("-drive8type");
+         Add_Option("0");
+      }
+
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
       /* Do not allow JiffyDOS with non-floppies */
       if (dc_get_image_type(argv) == DC_IMAGE_TYPE_TAPE
@@ -1097,6 +1104,14 @@ static int process_cmdline(const char* argv)
          /* Parse the m3u file */
          dc_parse_m3u(dc, argv);
          is_fliplist = true;
+
+         /* Disable floppy drive with tapes */
+         if (dc_get_image_type(dc->files[0]) == DC_IMAGE_TYPE_TAPE)
+         {
+            Add_Option("-drive8type");
+            Add_Option("0");
+         }
+
 #if defined(__X64__) || defined(__X64SC__) || defined(__X128__) || defined(__XSCPU64__)
          /* Do not allow JiffyDOS with non-floppies */
          if (!string_is_empty(dc->files[0]))

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -3144,7 +3144,7 @@ static void retro_set_core_options()
             { "vice", "VICE" },
             { NULL, NULL },
          },
-         "colodore_vic"
+         "default"
       },
 #elif defined(__XPLUS4__)
       {
@@ -3161,7 +3161,7 @@ static void retro_set_core_options()
             { "yape-ntsc", "Yape (NTSC)" },
             { NULL, NULL },
          },
-         "colodore_ted"
+         "default"
       },
 #elif defined(__XPET__)
       {
@@ -3207,30 +3207,30 @@ static void retro_set_core_options()
          "video",
          {
             { "default", "Internal" },
-            { "colodore", "Colodore" },
-            { "pepto-pal", "Pepto (PAL)" },
-#if 0
-            { "pepto-palold", "Pepto (old PAL)" },
-#endif
-            { "pepto-ntsc", "Pepto (NTSC)" },
-            { "pepto-ntsc-sony", "Pepto (NTSC, Sony)" },
             { "cjam", "ChristopherJam" },
             { "c64hq", "C64HQ" },
             { "c64s", "C64S" },
             { "ccs64", "CCS64" },
+            { "colodore", "Colodore" },
             { "community-colors", "Community Colors" },
             { "deekay", "Deekay" },
             { "frodo", "Frodo" },
             { "godot", "Godot" },
             { "palette", "PALette" },
             { "pc64", "PC64" },
+            { "pepto-pal", "Pepto (PAL)" },
+#if 0
+            { "pepto-palold", "Pepto (old PAL)" },
+#endif
+            { "pepto-ntsc", "Pepto (NTSC)" },
+            { "pepto-ntsc-sony", "Pepto (NTSC, Sony)" },
             { "pixcen", "Pixcen" },
             { "ptoing", "Ptoing" },
             { "rgb", "RGB" },
             { "vice", "VICE" },
             { NULL, NULL },
          },
-         "colodore"
+         "default"
       },
 #endif
 #if defined(__X64__) || defined(__X64SC__) || defined(__X64DTV__) || defined(__X128__) || defined(__XSCPU64__) || defined(__XCBM5x0__) || defined(__XVIC__) || defined(__XPLUS4__)

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2641,6 +2641,20 @@ static void retro_set_core_options()
       },
 #endif
       {
+         "vice_printer",
+         "System > Printer",
+         "Printer",
+         "Output is written to 'saves/" ARCHDEP_PRINTER_DEFAULT_DEV1 "'.",
+         NULL,
+         "system",
+         {
+            { "disabled", NULL },
+            { "enabled", NULL },
+            { NULL, NULL },
+         },
+         "disabled"
+      },
+      {
          "vice_read_vicerc",
          "System > Read 'vicerc'",
          "Read 'vicerc'",
@@ -7072,6 +7086,14 @@ static void update_variables(void)
          request_reload_restart = (opt_jiffydos != opt_jiffydos_prev || request_restart) ? true : request_reload_restart;
    }
 #endif
+
+   var.key = "vice_printer";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "disabled")) vice_opt.Printer = 0;
+      else                                vice_opt.Printer = 1;
+   }
 
    /* Mapper */
    /* RetroPad */

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -272,6 +272,7 @@ struct vice_core_options
    int AutostartWarp;
    int AttachDevice8Readonly;
    int EasyFlashWriteCRT;
+   int Printer;
    int VirtualDevices;
    int DriveTrueEmulation;
    int DriveSoundEmulation;

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -53,7 +53,7 @@ typedef uint8_t uint8;
 #define WINDOW_HEIGHT 288
 #elif defined(__XCBM2__)
 #define WINDOW_WIDTH  704
-#define WINDOW_HEIGHT 366
+#define WINDOW_HEIGHT 266
 #elif defined(__XVIC__)
 #define WINDOW_WIDTH  448
 #define WINDOW_HEIGHT 288
@@ -147,7 +147,7 @@ extern int request_model_set;
 
 extern unsigned int retro_warpmode;
 extern bool audio_playing(void);
-extern unsigned int crop_id;
+extern int crop_id;
 extern int crop_id_prev;
 
 #define CROP_NONE            0
@@ -182,15 +182,28 @@ extern int crop_id_prev;
 #endif
 #elif defined(__XVIC__)
 /* PAL: 448x284, NTSC: 400x234, VIC: 352x184 */
+#include "victypes.h"
+#include "vic-timing.h"
 #define CROP_WIDTH_MAX   352
 #define CROP_HEIGHT_MAX  184
-#define CROP_TOP_BORDER  48
-#define CROP_LEFT_BORDER 48
-#else /*#elif defined(__XPLUS4__)*/
+#define CROP_TOP_BORDER_PAL  VIC_PAL_NO_BORDER_FIRST_DISPLAYED_LINE  - vic.first_displayed_line
+#define CROP_TOP_BORDER_NTSC VIC_NTSC_NO_BORDER_FIRST_DISPLAYED_LINE - vic.first_displayed_line
+#define CROP_TOP_BORDER  CROP_TOP_BORDER_PAL
+#define CROP_LEFT_BORDER vic.screen_leftborderwidth
+#elif defined(__XPLUS4__)
 /* PAL: 384x288, NTSC: 384x242, TED: 320x200 */
+#include "tedtypes.h"
+#include "ted-timing.h"
 #define CROP_WIDTH_MAX   320
 #define CROP_HEIGHT_MAX  200
-#define CROP_TOP_BORDER  40
+#define CROP_TOP_BORDER_PAL  TED_PAL_NO_BORDER_FIRST_DISPLAYED_LINE  - ted.first_displayed_line
+#define CROP_TOP_BORDER_NTSC TED_NTSC_NO_BORDER_FIRST_DISPLAYED_LINE - ted.first_displayed_line
+#define CROP_TOP_BORDER  CROP_TOP_BORDER_PAL
+#define CROP_LEFT_BORDER ted.screen_leftborderwidth
+#else /* CRTC */
+#define CROP_WIDTH_MAX   320
+#define CROP_HEIGHT_MAX  200
+#define CROP_TOP_BORDER  33
 #define CROP_LEFT_BORDER 32
 #endif
 

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -91,7 +91,6 @@ extern float opt_analogmouse_speed;
 bool datasette_hotkeys = false;
 
 extern unsigned int opt_reset_type;
-extern unsigned int crop_id;
 extern unsigned int opt_crop_id;
 extern bool opt_keyboard_pass_through;
 extern unsigned int opt_aspect_ratio;

--- a/libretro/libretro-vkbd.c
+++ b/libretro/libretro-vkbd.c
@@ -628,10 +628,7 @@ void print_vkbd(void)
    /* Vertical centering calculations */
    {
       int crop_top_border = (retroh - CROP_HEIGHT_MAX) / 2;
-#if defined(__X128__)
-      if (c128_vdc)
-         crop_top_border = (retroh - CROP_VDC_HEIGHT_MAX) / 2;
-#endif
+
       /* Bonus 10 for statusbar */
       YPADDING = (crop_top_border + 10) * 2;
 

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -334,7 +334,6 @@ int ui_init_finalize(void)
    log_resources_set_int("AutostartHandleTrueDriveEmulation", 0);
    log_resources_set_int("FSDeviceLongNames", 1);
    log_resources_set_int("Mouse", 1);
-   log_resources_set_int("Printer4", 1);
 
    /* Machine specific defaults */
 #if defined(__X64DTV__)
@@ -564,6 +563,9 @@ int ui_init_finalize(void)
    if (strcmp(vice_opt.CartridgeFile, ""))
       log_resources_set_string("CartridgeFile", vice_opt.CartridgeFile);
 #endif
+
+   /* Printer */
+   log_resources_set_int("Printer4", vice_opt.Printer);
 
    retro_ui_finalized = true;
    log_resource_set = true;

--- a/retrodep/ui.c
+++ b/retrodep/ui.c
@@ -61,6 +61,11 @@ BYTE c64memrom_kernal64_rom_original[C64_KERNAL_ROM_SIZE] = {0};
 extern unsigned int opt_jiffydos_kernal_skip;
 #endif
 
+#if defined(__X64__) || defined(__X64SC__) || defined(__XSCPU64__) || defined(__XVIC__)
+extern int request_model_auto_set;
+extern bool opt_model_auto;
+#endif
+
 #include "libretro-core.h"
 #if defined(__XVIC__)
 extern void vic20mem_set(void);
@@ -74,6 +79,7 @@ extern unsigned int opt_jiffydos;
 extern unsigned int opt_autoloadwarp;
 extern char full_path[RETRO_PATH_MAX];
 extern char retro_system_data_directory[RETRO_PATH_MAX];
+extern bool log_resource_set;
 extern retro_log_printf_t log_cb;
 
 static const cmdline_option_t cmdline_options[] = {
@@ -283,7 +289,7 @@ int ui_init_finalize(void)
 #elif defined(__XCBM2__) || defined(__XCBM5x0__)
    cbm2model_set(vice_opt.Model);
 #elif defined(__XVIC__)
-   vic20model_set(vice_opt.Model);
+   vic20model_set(opt_model_auto && request_model_auto_set > -1 ? request_model_auto_set : vice_opt.Model);
 #elif defined(__XPLUS4__)
    plus4model_set(vice_opt.Model);
 #elif defined(__X128__)
@@ -291,7 +297,7 @@ int ui_init_finalize(void)
 #elif defined(__X64DTV__)
    dtvmodel_set(vice_opt.Model);
 #else
-   c64model_set(vice_opt.Model);
+   c64model_set(opt_model_auto && request_model_auto_set > -1 ? request_model_auto_set : vice_opt.Model);
 #endif
 
 #if defined(__X64__) || defined(__X64SC__)
@@ -560,6 +566,7 @@ int ui_init_finalize(void)
 #endif
 
    retro_ui_finalized = true;
+   log_resource_set = true;
    return 0;
 }
 


### PR DESCRIPTION
- Added crop functionality for all emutypes
- Added printer core option, defaults to disabled, since it can cause loading issues
- Disabled floppy drives when launching tapes, since it can cause loading issues
- Improved model/region detection+enforcing with automatic models
- Changed default palette to "Internal" for all emutypes
