### PR TITLE
Use bash as make's SHELL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ SOURCES_C   :=
 SOURCES_CC  :=
 SOURCES_CXX :=
 OBJECTS     :=
+# bash is required by SILENT's usage of [[
+SHELL       := /bin/bash
 SILENT      := 0
 
 ifeq ($(platform),)


### PR DESCRIPTION
[[ is not (always) valid in a plain /bin/sh.