### PR TITLE
use emar for object file archives, not em++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -448,9 +448,7 @@ all: $(TARGET)
 -include $(OBJECTS:.o=.d))
 
 $(TARGET): $(OBJECTS)
-ifeq ($(platform), emscripten)
-	$(CXX) -r $(SHARED) -o $@ $(OBJECTS) $(LDFLAGS)
-else ifeq ($(STATIC_LINKING), 1)
+ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 #STATIC_LINKING=1 and additional Makefile.common sources are incompatible for PS3 environment
 else ifeq ($(platform), ps3)


### PR DESCRIPTION
Per https://github.com/libretro/RetroArch/pull/15688