### PR TITLE
Separate paddles type to 'split' and 'raw'

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -208,6 +208,7 @@ bool opt_keyboard_pass_through = false;
 unsigned int opt_keyboard_keymap = KBD_INDEX_POS;
 unsigned int opt_retropad_options = RETROPAD_OPTIONS_DISABLED;
 unsigned int opt_joyport_type = 0;
+bool opt_joyport_paddles_split = true;
 int opt_joyport_pointer_color = -1;
 unsigned int opt_dpadmouse_speed = 6;
 unsigned int opt_mouse_speed = 100;
@@ -4721,12 +4722,13 @@ static void retro_set_core_options()
          "vice_joyport_type",
          "RetroPad > Joystick Port Type",
          "Joystick Port Type",
-         "Non-joysticks are plugged in current port only and are controlled with left analog stick or mouse. Paddles are split to 1st and 2nd RetroPort.",
+         "Non-joysticks are plugged in current port only and are controlled with left analog stick or mouse.",
          NULL,
          "input",
          {
             { "1", "Joystick" },
-            { "2", "Paddles" },
+            { "2", "Paddles (Split)" },
+            { "2R", "Paddles (Raw)" },
             { "3", "Mouse (1351)" },
             { "4", "Mouse (NEOS)" },
             { "5", "Mouse (Amiga)" },
@@ -7003,6 +7005,10 @@ static void update_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       opt_joyport_type = atoi(var.value);
+
+      opt_joyport_paddles_split = true;
+      if (!strcmp(var.value, "2R"))
+         opt_joyport_paddles_split = false;
 
       /* Light guns/pens only possible in port 1 */
       if (opt_joyport_type > 10)

--- a/libretro/libretro-mapper.c
+++ b/libretro/libretro-mapper.c
@@ -88,6 +88,7 @@ int mem_cartridge_type = CARTRIDGE_NONE;
 /* Core options */
 extern unsigned int opt_joyport_type;
 static int opt_joyport_type_prev = -1;
+extern bool opt_joyport_paddles_split;
 extern int opt_joyport_pointer_color;
 extern unsigned int opt_dpadmouse_speed;
 extern unsigned int opt_analogmouse;
@@ -1403,7 +1404,7 @@ void retro_poll_event()
        * Therefore treat RetroPort0 vertical axis as RetroPort1 horizontal axis, and second fire as RetroPort1 fire.
        * Bypassed VICE limitation of one mouse when using paddles for maximum 4 paddles. */
       unsigned retro_j_max = 2;
-      if (opt_joyport_type == 2)
+      if (opt_joyport_type == 2 && opt_joyport_paddles_split)
          retro_j_max = 4;
 
       /* Joypad and mouse control only when VKBD is closed */
@@ -1485,7 +1486,7 @@ void retro_poll_event()
             else if (joypad_bits[retro_j] & (1 << RETRO_DEVICE_ID_JOYPAD_LEFT))
                retro_mouse_x[retro_j] -= dpadmouse_speed[retro_j];
 
-            if (opt_joyport_type != 2)
+            if (opt_joyport_type != 2 || !opt_joyport_paddles_split)
             {
                if (joypad_bits[retro_j] & (1 << RETRO_DEVICE_ID_JOYPAD_DOWN))
                   retro_mouse_y[retro_j] += dpadmouse_speed[retro_j];
@@ -1587,7 +1588,7 @@ void retro_poll_event()
          vice_j = j + 1;
          vice_j = (vice_j > 2) ? 0 : vice_j;
 
-         if (opt_joyport_type == 2)
+         if (opt_joyport_type == 2 && opt_joyport_paddles_split)
          {
             if (retro_j == 0)
             {


### PR DESCRIPTION
Added the possibility to use paddles "raw" per hardware joyport instead of forced splitting to RetroPorts.

Closes #540
