### PR TITLE
android: fix cx11 compile

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -16,6 +16,7 @@ COREFLAGS := -DCORE_NAME=\"$(EMUTYPE)\" \
   $(INCFLAGS) $(COMMONFLAGS) \
   -DHAVE_INET_ATON \
   -DHAVE_7ZIP -D_7ZIP_ST \
+  -DHAVE_CXX11 \
   -D_INTTYPES_H
 
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -7,4 +7,4 @@ APP_ABI := all
 # This should be investigated more in the future.
 APP_CFLAGS += -Wno-error=format-security -Ofast
 APP_STL := c++_static
-APP_PLATFORM := android-16
+APP_PLATFORM := android-21


### PR DESCRIPTION
Fixes android compile with newer NDKs

```
In file included from /home/cscd98/Developer/vice-libretro/jni/../vice/src/sid/resid-fp.cc:23:
In file included from /home/cscd98/Developer/vice-libretro/jni/../vice/src/residfp/builders/residfp-builder/residfp/SID.h:285:
/home/cscd98/Developer/vice-libretro/jni/../vice/src/residfp/builders/residfp-builder/residfp/Voice.h:49:10: error: no template named 'auto_ptr' in namespace 'std'
   49 |     std::unique_ptr<EnvelopeGenerator> const envelopeGenerator;
      |     ~~~~~^
/home/cscd98/Developer/vice-libretro/jni/../vice/src/residfp/sidcxx11.h:32:22: note: expanded from macro 'unique_ptr'
   32 | #  define unique_ptr auto_ptr

```